### PR TITLE
Mutable sequencing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ constants_output.csv
 
 .codex
 
+.envrc
+
 *.log
 
 # Temporary test data files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11554,6 +11554,7 @@ dependencies = [
  "sov-address",
  "sov-api-spec",
  "sov-bank",
+ "sov-blob-storage",
  "sov-cli",
  "sov-eth-client",
  "sov-eth-dev-signer",

--- a/crates/full-node/sov-ethereum/Cargo.toml
+++ b/crates/full-node/sov-ethereum/Cargo.toml
@@ -49,10 +49,10 @@ proptest = { workspace = true }
 strum = { workspace = true }
 test-strategy = { workspace = true }
 
-# Enable the `local` feature on this crate for the integration test target so the
-# eth_accounts / eth_sendTransaction handlers are registered and the eth_signer field
-# of EthRpcConfig exists.
-sov-ethereum = { path = ".", features = ["local"] }
+# Enable test-only cfgs on this crate for the integration test target.
+# `local` registers eth_accounts / eth_sendTransaction handlers; `native` lets tests
+# exercise native-only paths explicitly.
+sov-ethereum = { path = ".", features = ["local", "native"] }
 
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-rollup-interface = { workspace = true }
@@ -63,6 +63,7 @@ sov-state = { workspace = true }
 sov-kernels = { workspace = true, features = ["native"] }
 sov-accounts = { workspace = true }
 sov-paymaster = { workspace = true, features = ["native"] }
+sov-blob-storage = { workspace = true }
 sov-test-utils = { workspace = true }
 
 alloy = { workspace = true, features = ["signers", "transport-http"] }
@@ -85,3 +86,4 @@ default = []
 local = [
 	"sov-ethereum/local"
 ]
+native = []

--- a/crates/full-node/sov-ethereum/Cargo.toml
+++ b/crates/full-node/sov-ethereum/Cargo.toml
@@ -86,4 +86,20 @@ default = []
 local = [
 	"sov-ethereum/local"
 ]
-native = []
+native = [
+	"sov-accounts/native",
+	"sov-address/native",
+	"sov-bank/native",
+	"sov-blob-storage/native",
+	"sov-ethereum/native",
+	"sov-evm/native",
+	"sov-kernels/native",
+	"sov-metrics/native",
+	"sov-mock-da/native",
+	"sov-modules-api/native",
+	"sov-modules-stf-blueprint/native",
+	"sov-paymaster/native",
+	"sov-rollup-interface/native",
+	"sov-state/native",
+	"sov-uniqueness/native"
+]

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
@@ -1,0 +1,706 @@
+use std::collections::BTreeMap;
+use std::convert::Infallible;
+use std::marker::PhantomData;
+use std::str::FromStr;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+use alloy_primitives::{Address, Bytes, TxHash, U256};
+use borsh::{BorshDeserialize, BorshSerialize};
+use sov_address::{EthereumAddress, FromVmAddress, MultiAddress};
+use sov_blob_storage::PreferredBatchData;
+use sov_evm::precompiles::{
+    EvmPrecompile, EvmPrecompileEnv, PrecompileError, PrecompileOutput, PrecompileResult,
+};
+use sov_evm::{
+    AccountData, ContractCreationPolicy, Evm, EvmAuthenticatorInput, EvmChainSpec,
+    EvmGenesisConfig, SpecId,
+};
+use sov_evm_test_utils::{PrecompileTester, SolCall};
+use sov_mock_da::BlockProducingConfig;
+use sov_modules_api::capabilities::{
+    AuthorizationData, GasEnforcer, Guard, HasCapabilities, HasKernel, ProofProcessor,
+    SequencerAuthorization, SequencerRemuneration, SequencingDataHandler, TransactionAuthenticator,
+    TransactionAuthorizer,
+};
+use sov_modules_api::sov_universal_wallet::schema::UniversalWallet;
+use sov_modules_api::transaction::{
+    AuthenticatedTransactionData, ProverReward, RemainingFunds, SequencerReward, Transaction,
+};
+use sov_modules_api::{
+    AggregatedProofPublicData, Amount, BlobReaderTrait, Context, DaSpec, ExecutionContext, Gas,
+    GetGasPrice, InfallibleStateAccessor, InvalidProofError, OperatingMode, RawTx, Rewards,
+    SequencerType, SovAttestation, SovStateTransitionPublicData, Spec, StateAccessor, StateReader,
+    StateWriter, Storage, TxState, VersionReader,
+};
+use sov_modules_stf_blueprint::{GenesisParams, Runtime as RuntimeTrait};
+use sov_paymaster::Paymaster;
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::optimistic::{SerializedAttestation, SerializedChallenge};
+use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
+use sov_sequencer::SequencerKindConfig;
+use sov_state::{Kernel, User};
+use sov_stf_runner::processes::RollupProverConfig;
+use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
+use sov_test_utils::runtime::StandardProvenRollupCapabilities;
+use sov_test_utils::test_rollup::{GenesisSource, RollupBuilder, StoragePath, TestRollup};
+use sov_test_utils::{generate_runtime_without_capabilities, RtAgnosticBlueprintWithApis};
+
+use crate::common::{
+    create_simple_storage_client, DEFAULT_EVM_BALANCE, DEFAULT_FUNDED_EVM_ACCOUNTS, EVM_EXTENSION,
+    SENDER_PRIV_KEY,
+};
+use crate::runtime::{EvmAdditionalApis, EvmTestSpec};
+
+const ORACLE_PRECOMPILE_ADDRESS: Address = Address::new([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02, 0x00, 0x01,
+]);
+const ORACLE_PRECOMPILE_GAS: u64 = 100;
+const FINALIZATION_BLOCKS: u32 = 2;
+
+static ORACLE_DATA: LazyLock<Mutex<OracleSequencingData>> =
+    LazyLock::new(|| Mutex::new(OracleSequencingData::default()));
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct OracleSequencingData(BTreeMap<u64, u64>);
+
+impl sov_modules_api::capabilities::SequencingDataTrait for OracleSequencingData {
+    fn get_maybe_timestamp(self) -> Option<sov_modules_api::HDTimestamp> {
+        None
+    }
+}
+
+#[derive(Clone, Default)]
+struct OraclePrecompile<S>(PhantomData<S>);
+
+impl<S: Spec> EvmPrecompile<S> for OraclePrecompile<S> {
+    const ADDRESS: Address = ORACLE_PRECOMPILE_ADDRESS;
+
+    fn execute<ST: TxState<S>>(
+        &self,
+        input: &[u8],
+        gas_limit: u64,
+        env: &mut EvmPrecompileEnv<'_, S, ST>,
+    ) -> PrecompileResult {
+        if ORACLE_PRECOMPILE_GAS > gas_limit {
+            return Err(PrecompileError::OutOfGas);
+        }
+        if input.len() != 32 {
+            return Err(PrecompileError::InvalidInput(format!(
+                "expected 32-byte key, got {} bytes",
+                input.len()
+            )));
+        }
+
+        let raw_key = U256::from_be_slice(input);
+        if raw_key > U256::from(u64::MAX) {
+            return Err(PrecompileError::InvalidInput(
+                "key does not fit in u64".to_string(),
+            ));
+        }
+        let key = raw_key.to::<u64>();
+
+        let sequencing_data = env
+            .sov_context
+            .and_then(|ctx| ctx.sequencing_data().as_ref())
+            .ok_or_else(|| PrecompileError::State("missing sequencing data".to_string()))?;
+        let sequencing_data =
+            OracleSequencingData::try_from_slice(sequencing_data).map_err(|err| {
+                PrecompileError::State(format!("failed to deserialize sequencing data: {err}"))
+            })?;
+        let value = sequencing_data
+            .0
+            .get(&key)
+            .ok_or_else(|| PrecompileError::InvalidInput(format!("missing oracle key {key}")))?;
+
+        #[cfg(feature = "native")]
+        env.sov_context
+            .expect("sov context was checked above")
+            .sequencing_scratchpad()
+            .set(
+                borsh::to_vec(&key)
+                    .expect("u64 serialization is infallible")
+                    .into(),
+            );
+
+        Ok(PrecompileOutput {
+            gas_used: ORACLE_PRECOMPILE_GAS,
+            bytes: u256_word(*value),
+        })
+    }
+}
+
+sov_evm::generate_precompile_set! {
+    pub struct OraclePrecompiles<S> {
+        oracle: OraclePrecompile<S>,
+    }
+}
+
+generate_runtime_without_capabilities! {
+    name: PruningRuntime,
+    modules: [evm: Evm<S, OraclePrecompiles<S>>, paymaster: Paymaster<S>],
+    operating_mode: sov_modules_api::runtime::OperatingMode::Optimistic,
+    minimal_genesis_config_type: sov_test_utils::runtime::genesis::optimistic::MinimalOptimisticGenesisConfig<S>,
+    runtime_trait_impl_bounds: [S::Address: FromVmAddress<EthereumAddress>],
+    kernel_type: sov_kernels::soft_confirmations::SoftConfirmationsKernel<'a, S>,
+    auth_type: sov_evm::EvmAuthenticator<S, Self>,
+    auth_call_wrapper: |call| match call {
+        EvmAuthenticatorInput::Evm(call) => PruningRuntimeCall::Evm(call),
+        EvmAuthenticatorInput::Standard(call) => call,
+    },
+}
+
+impl<S: Spec> sov_evm::EthereumAuthenticator<S> for PruningRuntime<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+    Transaction<Self, S>: UniversalWallet,
+{
+    fn add_ethereum_auth(tx: RawTx) -> <Self::Auth as TransactionAuthenticator<S>>::Input {
+        EvmAuthenticatorInput::Evm(tx)
+    }
+}
+
+type S = EvmTestSpec;
+type RT = PruningRuntime<S>;
+type PruningBlueprint = RtAgnosticBlueprintWithApis<S, RT, EvmAdditionalApis>;
+type StandardCapabilities<'a, S> = StandardProvenRollupCapabilities<'a, S, &'a mut Paymaster<S>>;
+
+pub struct PruningCapabilities<'a, S: Spec> {
+    standard: StandardCapabilities<'a, S>,
+}
+
+impl<S: Spec> SequencingDataHandler<S> for PruningCapabilities<'_, S> {
+    type SequencingData = OracleSequencingData;
+
+    fn handle_sequencing_data(
+        &mut self,
+        _data: Self::SequencingData,
+        _context: &Context<S>,
+        _state: &mut impl TxState<S>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn create_sequencing_data(&self) -> Self::SequencingData {
+        ORACLE_DATA
+            .lock()
+            .expect("oracle data mutex was poisoned")
+            .clone()
+    }
+
+    fn finalize_sequencing_data(
+        &mut self,
+        mut data: Self::SequencingData,
+        scratchpad: Option<sov_rollup_interface::Bytes>,
+    ) -> Self::SequencingData {
+        let Some(scratchpad) = scratchpad else {
+            return data;
+        };
+        let Ok(used_key) = u64::try_from_slice(&scratchpad) else {
+            return data;
+        };
+        data.0.retain(|key, _| *key == used_key);
+        data
+    }
+}
+
+impl<S: Spec> GasEnforcer<S> for PruningCapabilities<'_, S> {
+    fn try_reserve_gas(
+        &mut self,
+        tx: &AuthenticatedTransactionData<S>,
+        gas_price: <S::Gas as Gas>::Price,
+        ctx: &mut Context<S>,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<()> {
+        self.standard.try_reserve_gas(tx, gas_price, ctx, state)
+    }
+
+    fn try_reserve_gas_for_proof(
+        &mut self,
+        tx: &AuthenticatedTransactionData<S>,
+        gas_price: <S::Gas as Gas>::Price,
+        sender: &S::Address,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<()> {
+        self.standard
+            .try_reserve_gas_for_proof(tx, gas_price, sender, state)
+    }
+
+    fn reward_prover(
+        &mut self,
+        prover_rewards: &ProverReward,
+        operating_mode: OperatingMode,
+        state: &mut impl InfallibleStateAccessor,
+    ) {
+        self.standard
+            .reward_prover(prover_rewards, operating_mode, state);
+    }
+
+    fn refund_remaining_gas(
+        &mut self,
+        recipient: &S::Address,
+        remaining_funds: &RemainingFunds,
+        state: &mut impl InfallibleStateAccessor,
+    ) {
+        self.standard
+            .refund_remaining_gas(recipient, remaining_funds, state);
+    }
+
+    fn reward_prover_from_sequencer_balance(
+        &mut self,
+        amount: Amount,
+        sequencer: &S::Address,
+        operating_mode: OperatingMode,
+        state: &mut impl InfallibleStateAccessor,
+    ) -> anyhow::Result<()> {
+        self.standard
+            .reward_prover_from_sequencer_balance(amount, sequencer, operating_mode, state)
+    }
+
+    fn return_escrowed_funds_to_sequencer<
+        Accessor: StateReader<Kernel, Error = Infallible>
+            + StateWriter<Kernel, Error = Infallible>
+            + StateWriter<User, Error = Infallible>
+            + StateReader<User, Error = Infallible>
+            + VersionReader,
+    >(
+        &mut self,
+        bond_amount: Amount,
+        reward: Rewards,
+        sequencer: &<S::Da as DaSpec>::Address,
+        state: &mut Accessor,
+    ) {
+        self.standard
+            .return_escrowed_funds_to_sequencer(bond_amount, reward, sequencer, state);
+    }
+}
+
+impl<S: Spec> SequencerAuthorization<S> for PruningCapabilities<'_, S> {
+    fn is_preferred_sequencer(
+        &self,
+        sequencer: &<S::Da as DaSpec>::Address,
+        state: &mut impl InfallibleStateAccessor,
+    ) -> bool {
+        self.standard.is_preferred_sequencer(sequencer, state)
+    }
+}
+
+impl<S: Spec> TransactionAuthorizer<S> for PruningCapabilities<'_, S> {
+    fn resolve_context(
+        &mut self,
+        auth_data: &AuthorizationData<S>,
+        sequencer: &<S::Da as DaSpec>::Address,
+        sequencer_rollup_address: S::Address,
+        state: &mut impl StateAccessor,
+        sequencing_data: Option<sov_rollup_interface::Bytes>,
+        execution_context: ExecutionContext,
+        sequencer_type: SequencerType,
+    ) -> anyhow::Result<Context<S>> {
+        self.standard.resolve_context(
+            auth_data,
+            sequencer,
+            sequencer_rollup_address,
+            state,
+            sequencing_data,
+            execution_context,
+            sequencer_type,
+        )
+    }
+
+    fn resolve_unregistered_context(
+        &mut self,
+        auth_data: &AuthorizationData<S>,
+        sequencer: &<S::Da as DaSpec>::Address,
+        state: &mut impl StateAccessor,
+        execution_context: ExecutionContext,
+    ) -> anyhow::Result<Context<S>> {
+        self.standard
+            .resolve_unregistered_context(auth_data, sequencer, state, execution_context)
+    }
+
+    fn check_uniqueness(
+        &self,
+        auth_data: &AuthorizationData<S>,
+        context: &Context<S>,
+        execution_context: &ExecutionContext,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<()> {
+        self.standard
+            .check_uniqueness(auth_data, context, execution_context, state)
+    }
+
+    fn mark_tx_attempted(
+        &mut self,
+        auth_data: &AuthorizationData<S>,
+        sequencer: &<S::Da as DaSpec>::Address,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<()> {
+        self.standard.mark_tx_attempted(auth_data, sequencer, state)
+    }
+}
+
+impl<'a, S: Spec> ProofProcessor<S> for PruningCapabilities<'a, S> {
+    type BondingProofService<K: HasKernel<S>> =
+        <StandardCapabilities<'a, S> as ProofProcessor<S>>::BondingProofService<K>;
+
+    fn create_bonding_proof_service<K: HasKernel<S>>(
+        &self,
+        attester_address: S::Address,
+        storage_receiver: tokio::sync::watch::Receiver<S::Storage>,
+    ) -> Self::BondingProofService<K> {
+        self.standard
+            .create_bonding_proof_service::<K>(attester_address, storage_receiver)
+    }
+
+    fn process_aggregated_proof<ST: TxState<S> + GetGasPrice<Spec = S>>(
+        &mut self,
+        proof: SerializedAggregatedProof,
+        prover_address: &S::Address,
+        execution_context: ExecutionContext,
+        state: &mut ST,
+    ) -> Result<
+        (
+            AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+            SerializedAggregatedProof,
+        ),
+        InvalidProofError,
+    > {
+        self.standard
+            .process_aggregated_proof(proof, prover_address, execution_context, state)
+    }
+
+    fn process_attestation<ST: TxState<S> + GetGasPrice<Spec = S>>(
+        &mut self,
+        proof: SerializedAttestation,
+        prover_address: &S::Address,
+        state: &mut ST,
+    ) -> Result<SovAttestation<S>, InvalidProofError> {
+        self.standard
+            .process_attestation(proof, prover_address, state)
+    }
+
+    fn process_challenge<ST: TxState<S> + GetGasPrice<Spec = S>>(
+        &mut self,
+        proof: SerializedChallenge,
+        rollup_height: SlotNumber,
+        prover_address: &S::Address,
+        state: &mut ST,
+    ) -> Result<SovStateTransitionPublicData<S>, InvalidProofError> {
+        self.standard
+            .process_challenge(proof, rollup_height, prover_address, state)
+    }
+}
+
+impl<S: Spec> SequencerRemuneration<S> for PruningCapabilities<'_, S> {
+    fn reward_sequencer_or_refund<
+        Accessor: StateReader<Kernel, Error = Infallible>
+            + StateWriter<Kernel, Error = Infallible>
+            + StateWriter<User, Error = Infallible>
+            + StateReader<User, Error = Infallible>,
+    >(
+        &mut self,
+        sequencer: &<S::Da as DaSpec>::Address,
+        sequencer_rollup_address: &S::Address,
+        reward: SequencerReward,
+        state: &mut Accessor,
+    ) {
+        self.standard.reward_sequencer_or_refund(
+            sequencer,
+            sequencer_rollup_address,
+            reward,
+            state,
+        );
+    }
+
+    fn preferred_sequencer(
+        &self,
+        state: &mut impl InfallibleStateAccessor,
+    ) -> Option<<S::Da as DaSpec>::Address> {
+        self.standard.preferred_sequencer(state)
+    }
+}
+
+impl<S: Spec> HasCapabilities<S> for PruningRuntime<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    type Capabilities<'a>
+        = PruningCapabilities<'a, S>
+    where
+        Self: 'a;
+    type SequencingData = OracleSequencingData;
+
+    fn capabilities(&mut self) -> Guard<Self::Capabilities<'_>> {
+        Guard::new(PruningCapabilities {
+            standard: StandardProvenRollupCapabilities {
+                bank: &mut self.bank,
+                gas_payer: &mut self.paymaster,
+                sequencer_registry: &mut self.sequencer_registry,
+                accounts: &mut self.accounts,
+                uniqueness: &mut self.uniqueness,
+                chain_state: &mut self.chain_state,
+                operator_incentives: &mut self.operator_incentives,
+                prover_incentives: &mut self.prover_incentives,
+                attester_incentives: &mut self.attester_incentives,
+            },
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_precompile_can_prune_sequencing_data_and_replay_from_da() -> anyhow::Result<()> {
+    let test_rollup = setup_pruning_rollup().await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await?;
+
+    let evm_client = create_simple_storage_client(test_rollup.http_addr, SENDER_PRIV_KEY).await;
+    let tester_address = deploy_precompile_tester(&evm_client).await?;
+
+    let oracle_entries = BTreeMap::from([(11, 1_100), (22, 2_200), (33, 3_300)]);
+    set_oracle_data(oracle_entries.clone());
+
+    let mut expected_by_hash = BTreeMap::new();
+    for (&key, &value) in &oracle_entries {
+        let tx_hash = assert_precompile_value(&evm_client, tester_address, key, value).await?;
+        expected_by_hash.insert(tx_hash_bytes(tx_hash), key);
+    }
+
+    let last_checked_height = test_rollup.da_service.get_head_block_header().await?.height;
+    test_rollup.force_close_batch().await?;
+
+    wait_for_pruned_txs_on_da(
+        &test_rollup,
+        &expected_by_hash,
+        &oracle_entries,
+        last_checked_height,
+    )
+    .await?;
+
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_node_synced().await?;
+
+    for tx_hash in expected_by_hash.keys() {
+        let receipt = evm_client
+            .wait_for_finalized_receipt(TxHash::from(*tx_hash))
+            .await;
+        assert!(receipt.status(), "oracle assertion tx should be finalized");
+    }
+
+    let (resynced_rollup, _keep_da_storage_alive) =
+        restart_from_scratch_on_same_da(test_rollup).await?;
+    let resynced_client =
+        create_simple_storage_client(resynced_rollup.http_addr, SENDER_PRIV_KEY).await;
+    resynced_rollup.wait_for_node_synced().await?;
+
+    for tx_hash in expected_by_hash.keys() {
+        let receipt = resynced_client
+            .wait_for_finalized_receipt(TxHash::from(*tx_hash))
+            .await;
+        assert!(
+            receipt.status(),
+            "oracle assertion tx should replay on resync"
+        );
+    }
+
+    resynced_rollup.shutdown().await?;
+    Ok(())
+}
+
+async fn setup_pruning_rollup() -> TestRollup<PruningBlueprint> {
+    let (genesis, seq_da_address) = pruning_genesis();
+    let storage = StoragePath::Tmp(Arc::new(tempfile::tempdir().expect("create tempdir")));
+
+    let mut builder = RollupBuilder::<PruningBlueprint>::new_with_storage_path(
+        GenesisSource::CustomParams(GenesisParams { runtime: genesis }),
+        BlockProducingConfig::Periodic {
+            block_time_ms: 1_000,
+        },
+        FINALIZATION_BLOCKS,
+        storage,
+        false,
+    );
+
+    builder = builder
+        .set_config(|c| {
+            c.max_concurrent_batch_blobs = 65536;
+            c.rollup_prover_config = RollupProverConfig::Disabled;
+            c.aggregated_proof_block_jump = 5;
+            c.max_infos_in_db = 30;
+            c.max_channel_size = 20;
+            c.extension = Some(EVM_EXTENSION);
+            if let SequencerKindConfig::Preferred(ref mut seq) = c.sequencer_config {
+                seq.ideal_lag_behind_finalized_slot = 3;
+            }
+        })
+        .set_da_config(|c| {
+            c.sender_address = seq_da_address;
+        });
+
+    builder.start().await.expect("start pruning test rollup")
+}
+
+fn pruning_genesis() -> (
+    GenesisConfig<S>,
+    <<S as Spec>::Da as sov_rollup_interface::da::DaSpec>::Address,
+) {
+    let hl_genesis = HighLevelOptimisticGenesisConfig::<S>::generate();
+    let seq_da_address = hl_genesis.initial_sequencer.da_address;
+    let admin = hl_genesis.initial_sequencer.user_info.address();
+
+    let evm_chain_spec = EvmChainSpec {
+        block_gas_limit: 100_000_000_000,
+        tx_gas_limit: Some(30_000_000),
+        hardforks: vec![(0, SpecId::CANCUN)],
+        ..EvmChainSpec::default()
+    };
+
+    let evm_config = EvmGenesisConfig::<S> {
+        accounts: DEFAULT_FUNDED_EVM_ACCOUNTS
+            .iter()
+            .map(|addr| AccountData::empty_with_address(Address::from_str(addr).unwrap()))
+            .collect(),
+        initial_base_fee: 10,
+        genesis_timestamp: 0,
+        chain_spec: evm_chain_spec,
+        contract_creation_policy: ContractCreationPolicy::Everyone,
+        admin,
+    };
+
+    let mut genesis = GenesisConfig::from_minimal_config(
+        hl_genesis.into(),
+        evm_config,
+        sov_paymaster::PaymasterConfig::default(),
+    );
+    if let Some(token_cfg) = genesis.bank.gas_token_config.as_mut() {
+        for addr in DEFAULT_FUNDED_EVM_ACCOUNTS {
+            token_cfg.address_and_balances.push((
+                MultiAddress::Vm(EthereumAddress::from(Address::from_str(addr).unwrap())),
+                Amount::new(DEFAULT_EVM_BALANCE),
+            ));
+        }
+    }
+
+    (genesis, seq_da_address)
+}
+
+async fn deploy_precompile_tester(
+    client: &sov_eth_client::SimpleStorageClient,
+) -> anyhow::Result<Address> {
+    set_oracle_data(BTreeMap::new());
+    let tx = client.make_tx(None, Some(Bytes::from(PrecompileTester::BYTECODE.to_vec())));
+    let receipt = client
+        .send_tx_and_wait(tx)
+        .await
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+    assert!(
+        receipt.status(),
+        "precompile tester deployment should succeed"
+    );
+    Ok(receipt
+        .contract_address
+        .expect("deployment receipt should include contract address"))
+}
+
+async fn assert_precompile_value(
+    client: &sov_eth_client::SimpleStorageClient,
+    tester_address: Address,
+    key: u64,
+    value: u64,
+) -> anyhow::Result<TxHash> {
+    let call = PrecompileTester::assertPrecompileResultCall {
+        precompile: ORACLE_PRECOMPILE_ADDRESS,
+        input: u256_word(key),
+        expectedOutput: u256_word(value),
+    };
+    let tx = client.make_tx(Some(tester_address), Some(Bytes::from(call.abi_encode())));
+    let tx_hash = client
+        .send_tx(tx)
+        .await
+        .map_err(|err| anyhow::anyhow!("{err}"))?;
+    let receipt = client.wait_for_receipt(tx_hash).await;
+    assert!(
+        receipt.status(),
+        "precompile assertion tx for key {key} should succeed"
+    );
+    Ok(tx_hash)
+}
+
+async fn wait_for_pruned_txs_on_da(
+    test_rollup: &TestRollup<PruningBlueprint>,
+    expected_by_hash: &BTreeMap<[u8; 32], u64>,
+    oracle_entries: &BTreeMap<u64, u64>,
+    mut last_checked_height: u64,
+) -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_secs(20), async {
+        let mut found = BTreeMap::new();
+        loop {
+            test_rollup.da_service.produce_block_now().await?;
+            let head_height = test_rollup.da_service.get_head_block_header().await?.height;
+            for height in last_checked_height + 1..=head_height {
+                let mut block = test_rollup.da_service.get_block_at(height).await?;
+                for blob in block.batch_blobs.iter_mut() {
+                    let batch = PreferredBatchData::try_from_slice(blob.full_data())?;
+                    for tx in batch.data.iter() {
+                        let tx_hash = <RT as RuntimeTrait<S>>::Auth::compute_tx_hash(tx)?;
+                        let tx_hash = <[u8; 32]>::from(tx_hash);
+                        let Some(expected_key) = expected_by_hash.get(&tx_hash) else {
+                            continue;
+                        };
+                        let sequencing_data = tx
+                            .sequencing_data
+                            .as_ref()
+                            .expect("oracle tx should include sequencing data");
+                        let sequencing_data =
+                            OracleSequencingData::try_from_slice(sequencing_data)?;
+                        assert_eq!(
+                            sequencing_data.0.len(),
+                            1,
+                            "published tx should retain only the used oracle key"
+                        );
+                        assert_eq!(
+                            sequencing_data.0.get(expected_key),
+                            oracle_entries.get(expected_key),
+                            "published tx should retain the used oracle value"
+                        );
+                        found.insert(tx_hash, *expected_key);
+                    }
+                }
+            }
+            if found.len() == expected_by_hash.len() {
+                return anyhow::Ok(());
+            }
+            last_checked_height = head_height;
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for oracle txs to be published")
+}
+
+async fn restart_from_scratch_on_same_da(
+    test_rollup: TestRollup<PruningBlueprint>,
+) -> anyhow::Result<(TestRollup<PruningBlueprint>, StoragePath)> {
+    let builder = test_rollup.shutdown().await?;
+    let keep_da_storage_alive = builder.storage_path();
+    let fresh_storage = StoragePath::Tmp(Arc::new(tempfile::tempdir()?));
+    let rollup = builder
+        .set_config(|c| c.storage = fresh_storage)
+        .start()
+        .await?;
+    Ok((rollup, keep_da_storage_alive))
+}
+
+fn set_oracle_data(data: BTreeMap<u64, u64>) {
+    *ORACLE_DATA.lock().expect("oracle data mutex was poisoned") = OracleSequencingData(data);
+}
+
+fn u256_word(value: u64) -> Bytes {
+    Bytes::copy_from_slice(&U256::from(value).to_be_bytes::<32>())
+}
+
+fn tx_hash_bytes(tx_hash: TxHash) -> [u8; 32] {
+    let mut bytes = [0; 32];
+    bytes.copy_from_slice(tx_hash.as_slice());
+    bytes
+}

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::str::FromStr;
@@ -83,52 +83,81 @@ impl<S: Spec> EvmPrecompile<S> for OraclePrecompile<S> {
         gas_limit: u64,
         env: &mut EvmPrecompileEnv<'_, S, ST>,
     ) -> PrecompileResult {
-        if ORACLE_PRECOMPILE_GAS > gas_limit {
-            return Err(PrecompileError::OutOfGas);
-        }
-        if input.len() != 32 {
+        if input.is_empty() || input.len() % 32 != 0 {
             return Err(PrecompileError::InvalidInput(format!(
-                "expected 32-byte key, got {} bytes",
+                "expected one or more 32-byte keys, got {} bytes",
                 input.len()
             )));
         }
 
-        let raw_key = U256::from_be_slice(input);
-        if raw_key > U256::from(u64::MAX) {
-            return Err(PrecompileError::InvalidInput(
-                "key does not fit in u64".to_string(),
-            ));
+        let key_count = u64::try_from(input.len() / 32)
+            .map_err(|_| PrecompileError::InvalidInput("too many oracle keys".to_string()))?;
+        let gas_used = ORACLE_PRECOMPILE_GAS
+            .checked_mul(key_count)
+            .ok_or(PrecompileError::OutOfGas)?;
+        if gas_used > gas_limit {
+            return Err(PrecompileError::OutOfGas);
         }
-        let key = raw_key.to::<u64>();
 
-        let sequencing_data = env
-            .sov_context
-            .and_then(|ctx| ctx.sequencing_data().as_ref())
-            .ok_or_else(|| PrecompileError::State("missing sequencing data".to_string()))?;
-        let sequencing_data =
+        let sequencing_data = {
+            let sequencing_data = env
+                .sov_context
+                .and_then(|ctx| ctx.sequencing_data().as_ref())
+                .ok_or_else(|| PrecompileError::State("missing sequencing data".to_string()))?;
             OracleSequencingData::try_from_slice(sequencing_data).map_err(|err| {
                 PrecompileError::State(format!("failed to deserialize sequencing data: {err}"))
-            })?;
-        let value = sequencing_data
-            .0
-            .get(&key)
-            .ok_or_else(|| PrecompileError::InvalidInput(format!("missing oracle key {key}")))?;
+            })?
+        };
 
-        #[cfg(feature = "native")]
-        env.sov_context
-            .expect("sov context was checked above")
-            .sequencing_scratchpad()
-            .set(
-                borsh::to_vec(&key)
-                    .expect("u64 serialization is infallible")
-                    .into(),
-            );
+        let mut output = Vec::with_capacity(input.len());
+        for raw_key in input.chunks_exact(32) {
+            let raw_key = U256::from_be_slice(raw_key);
+            if raw_key > U256::from(u64::MAX) {
+                return Err(PrecompileError::InvalidInput(
+                    "key does not fit in u64".to_string(),
+                ));
+            }
+            let key = raw_key.to::<u64>();
+            let value = *sequencing_data.0.get(&key).ok_or_else(|| {
+                PrecompileError::InvalidInput(format!("missing oracle key {key}"))
+            })?;
+
+            #[cfg(feature = "native")]
+            record_used_oracle_key(env, key)?;
+
+            output.extend_from_slice(&U256::from(value).to_be_bytes::<32>());
+        }
 
         Ok(PrecompileOutput {
-            gas_used: ORACLE_PRECOMPILE_GAS,
-            bytes: u256_word(*value),
+            gas_used,
+            bytes: output.into(),
         })
     }
+}
+
+#[cfg(feature = "native")]
+fn record_used_oracle_key<S: Spec, ST: TxState<S>>(
+    env: &EvmPrecompileEnv<'_, S, ST>,
+    key: u64,
+) -> Result<(), PrecompileError> {
+    env.sov_context
+        .expect("sov context was checked above")
+        .sequencing_scratchpad()
+        .with_value(|scratchpad| {
+            let mut used_keys = match scratchpad.as_deref() {
+                Some(bytes) => Vec::<u64>::try_from_slice(bytes).map_err(|err| {
+                    PrecompileError::State(format!("failed to deserialize used oracle keys: {err}"))
+                })?,
+                None => Vec::new(),
+            };
+            used_keys.push(key);
+            *scratchpad = Some(
+                borsh::to_vec(&used_keys)
+                    .expect("u64 vector serialization is infallible")
+                    .into(),
+            );
+            Ok(())
+        })
 }
 
 sov_evm::generate_precompile_set! {
@@ -197,10 +226,11 @@ impl<S: Spec> SequencingDataHandler<S> for PruningCapabilities<'_, S> {
         let Some(scratchpad) = scratchpad else {
             return data;
         };
-        let Ok(used_key) = u64::try_from_slice(&scratchpad) else {
+        let Ok(used_keys) = Vec::<u64>::try_from_slice(&scratchpad) else {
             return data;
         };
-        data.0.retain(|key, _| *key == used_key);
+        let used_keys = used_keys.into_iter().collect::<BTreeSet<_>>();
+        data.0.retain(|key, _| used_keys.contains(key));
         data
     }
 }
@@ -460,10 +490,17 @@ async fn evm_precompile_can_prune_sequencing_data_and_replay_from_da() -> anyhow
     let oracle_entries = BTreeMap::from([(11, 1_100), (22, 2_200), (33, 3_300)]);
     set_oracle_data(oracle_entries.clone());
 
-    let mut expected_by_hash = BTreeMap::new();
-    for (&key, &value) in &oracle_entries {
-        let tx_hash = assert_precompile_value(&evm_client, tester_address, key, value).await?;
-        expected_by_hash.insert(tx_hash_bytes(tx_hash), key);
+    let mut expected_by_hash: BTreeMap<[u8; 32], BTreeSet<u64>> = BTreeMap::new();
+    for &key in oracle_entries.keys() {
+        let keys = [key];
+        let tx_hash =
+            assert_precompile_values(&evm_client, tester_address, &keys, &oracle_entries).await?;
+        expected_by_hash.insert(tx_hash_bytes(tx_hash), keys.into_iter().collect());
+    }
+    for keys in [vec![11, 22], vec![33, 11, 22]] {
+        let tx_hash =
+            assert_precompile_values(&evm_client, tester_address, &keys, &oracle_entries).await?;
+        expected_by_hash.insert(tx_hash_bytes(tx_hash), keys.into_iter().collect());
     }
 
     let last_checked_height = test_rollup.da_service.get_head_block_header().await?.height;
@@ -602,16 +639,22 @@ async fn deploy_precompile_tester(
         .expect("deployment receipt should include contract address"))
 }
 
-async fn assert_precompile_value(
+async fn assert_precompile_values(
     client: &sov_eth_client::SimpleStorageClient,
     tester_address: Address,
-    key: u64,
-    value: u64,
+    keys: &[u64],
+    oracle_entries: &BTreeMap<u64, u64>,
 ) -> anyhow::Result<TxHash> {
+    let expected_values = keys.iter().map(|key| {
+        oracle_entries
+            .get(key)
+            .copied()
+            .unwrap_or_else(|| panic!("missing test oracle value for key {key}"))
+    });
     let call = PrecompileTester::assertPrecompileResultCall {
         precompile: ORACLE_PRECOMPILE_ADDRESS,
-        input: u256_word(key),
-        expectedOutput: u256_word(value),
+        input: u256_words(keys.iter().copied()),
+        expectedOutput: u256_words(expected_values),
     };
     let tx = client.make_tx(Some(tester_address), Some(Bytes::from(call.abi_encode())));
     let tx_hash = client
@@ -621,14 +664,14 @@ async fn assert_precompile_value(
     let receipt = client.wait_for_receipt(tx_hash).await;
     assert!(
         receipt.status(),
-        "precompile assertion tx for key {key} should succeed"
+        "precompile assertion tx for keys {keys:?} should succeed"
     );
     Ok(tx_hash)
 }
 
 async fn wait_for_pruned_txs_on_da(
     test_rollup: &TestRollup<PruningBlueprint>,
-    expected_by_hash: &BTreeMap<[u8; 32], u64>,
+    expected_by_hash: &BTreeMap<[u8; 32], BTreeSet<u64>>,
     oracle_entries: &BTreeMap<u64, u64>,
     mut last_checked_height: u64,
 ) -> anyhow::Result<()> {
@@ -644,7 +687,7 @@ async fn wait_for_pruned_txs_on_da(
                     for tx in batch.data.iter() {
                         let tx_hash = <RT as RuntimeTrait<S>>::Auth::compute_tx_hash(tx)?;
                         let tx_hash = <[u8; 32]>::from(tx_hash);
-                        let Some(expected_key) = expected_by_hash.get(&tx_hash) else {
+                        let Some(expected_keys) = expected_by_hash.get(&tx_hash) else {
                             continue;
                         };
                         let sequencing_data = tx
@@ -653,17 +696,20 @@ async fn wait_for_pruned_txs_on_da(
                             .expect("oracle tx should include sequencing data");
                         let sequencing_data =
                             OracleSequencingData::try_from_slice(sequencing_data)?;
+                        let actual_keys =
+                            sequencing_data.0.keys().copied().collect::<BTreeSet<_>>();
                         assert_eq!(
-                            sequencing_data.0.len(),
-                            1,
-                            "published tx should retain only the used oracle key"
+                            actual_keys, *expected_keys,
+                            "published tx should retain only the used oracle keys"
                         );
-                        assert_eq!(
-                            sequencing_data.0.get(expected_key),
-                            oracle_entries.get(expected_key),
-                            "published tx should retain the used oracle value"
-                        );
-                        found.insert(tx_hash, *expected_key);
+                        for expected_key in expected_keys {
+                            assert_eq!(
+                                sequencing_data.0.get(expected_key),
+                                oracle_entries.get(expected_key),
+                                "published tx should retain the used oracle value"
+                            );
+                        }
+                        found.insert(tx_hash, expected_keys.clone());
                     }
                 }
             }
@@ -695,8 +741,12 @@ fn set_oracle_data(data: BTreeMap<u64, u64>) {
     *ORACLE_DATA.lock().expect("oracle data mutex was poisoned") = OracleSequencingData(data);
 }
 
-fn u256_word(value: u64) -> Bytes {
-    Bytes::copy_from_slice(&U256::from(value).to_be_bytes::<32>())
+fn u256_words(values: impl IntoIterator<Item = u64>) -> Bytes {
+    let mut bytes = Vec::new();
+    for value in values {
+        bytes.extend_from_slice(&U256::from(value).to_be_bytes::<32>());
+    }
+    Bytes::from(bytes)
 }
 
 fn tx_hash_bytes(tx_hash: TxHash) -> [u8; 32] {

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_sequencing_data_pruning.rs
@@ -83,7 +83,7 @@ impl<S: Spec> EvmPrecompile<S> for OraclePrecompile<S> {
         gas_limit: u64,
         env: &mut EvmPrecompileEnv<'_, S, ST>,
     ) -> PrecompileResult {
-        if input.is_empty() || input.len() % 32 != 0 {
+        if input.is_empty() || !input.len().is_multiple_of(32) {
             return Err(PrecompileError::InvalidInput(format!(
                 "expected one or more 32-byte keys, got {} bytes",
                 input.len()

--- a/crates/full-node/sov-ethereum/tests/integration/evm/mod.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/mod.rs
@@ -22,6 +22,7 @@ mod evm_publish_reverted_txs;
 mod evm_rate_limit;
 mod evm_rpc_compliance_validation;
 mod evm_rpc_compliance_validation_2;
+mod evm_sequencing_data_pruning;
 mod evm_simulation_and_send_consistency;
 mod evm_soft_conf;
 mod evm_subscribe;

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -159,6 +159,7 @@ pub(crate) struct ExecutedTxResponse<S: Spec> {
     pub(crate) receipt: TransactionReceipt<S>,
     pub(crate) tx_changes: TxChangeSet,
     pub(crate) remaining_slot_gas: <S as Spec>::Gas,
+    pub(crate) sequencing_scratchpad: Option<sov_rollup_interface::Bytes>,
 }
 
 /// The channel responsible for notifying an async tx submitter of the txs result
@@ -249,6 +250,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             reward,
             penalty,
             execution_status,
+            sequencing_scratchpad,
         } = provisional_outcome;
         let MaybeExecuted::Executed(receipt) = execution_status else {
             self.send(
@@ -264,6 +266,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),
                 remaining_slot_gas: *slot_gas_meter_before_tx.remaining_preferred_slot_gas(), // Since we ignore this tx, the remaining gas limit is unchanged
+                sequencing_scratchpad,
             };
 
             self.send(gas_used, execution_time_micros, Ok(response));
@@ -292,6 +295,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             receipt: receipt.clone(),
             tx_changes: dirty_scratchpad.tx_changes(execution_context),
             remaining_slot_gas,
+            sequencing_scratchpad,
         };
 
         self.send(gas_used, execution_time_micros, Ok(response));

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -9,7 +9,7 @@ use borsh::BorshDeserialize;
 use sov_blob_storage::PreferredProofData;
 use sov_modules_api::capabilities::{
     get_maybe_timestamp_from_sequencing_data, BlobSelector, BlobSelectorOutput, ChainState,
-    FatalError, RollupHeight, TransactionAuthenticator,
+    FatalError, HasCapabilities, RollupHeight, SequencingDataHandler, TransactionAuthenticator,
 };
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{
@@ -303,8 +303,8 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         let result = self.apply_tx_to_in_progress_batch_inner(baked_tx).await;
 
         match result {
-            Ok((receipt, remaining_slot_gas, execution_time_micros, tx_changes)) => {
-                let accepted_tx = self.process_tx_receipt(&receipt, timestamp);
+            Ok((receipt, tx, remaining_slot_gas, execution_time_micros, tx_changes)) => {
+                let accepted_tx = self.process_tx_receipt(receipt, tx, timestamp);
                 if let Some(writer) = self.startup_transaction_cache_writer.as_mut() {
                     writer.insert(accepted_tx.clone()).await;
                 }
@@ -325,7 +325,13 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         &mut self,
         baked_tx: FullyBakedTxWithMaybeChangeSet,
     ) -> Result<
-        (TransactionReceipt<S>, <S as Spec>::Gas, u64, TxChangeSet),
+        (
+            TransactionReceipt<S>,
+            FullyBakedTx,
+            <S as Spec>::Gas,
+            u64,
+            TxChangeSet,
+        ),
         RollupBlockExecutorErrorWithBudget<S>,
     > {
         let Some(task_state) = self.rollup_block_task_state.as_mut() else {
@@ -366,9 +372,10 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         } = result;
 
         let ExecutedTxResponse {
-            receipt,
+            mut receipt,
             tx_changes,
             remaining_slot_gas,
+            sequencing_scratchpad,
         } = inner_result.map_err(|reason| RollupBlockExecutorErrorWithBudget {
             execution_time_micros,
             gas_used,
@@ -386,10 +393,17 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             });
         }
 
+        let mut tx = receipt
+            .body_to_save
+            .take()
+            .expect("Transaction receipts contain bodies when using sov-modules-stf-blueprint");
+        Self::finalize_tx_sequencing_data(&mut tx, sequencing_scratchpad);
+
         self.checkpoint.apply_tx_changes(tx_changes.clone());
 
         Ok((
             receipt,
+            tx,
             remaining_slot_gas,
             execution_time_micros,
             tx_changes,
@@ -639,12 +653,18 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
 
     fn process_tx_receipt(
         &mut self,
-        tx_receipt: &TransactionReceipt<S>,
+        tx_receipt: TransactionReceipt<S>,
+        tx: FullyBakedTx,
         timestamp: Option<HDTimestamp>,
     ) -> AcceptedTx<Confirmation<S, Rt>> {
+        let TransactionReceipt {
+            tx_hash,
+            body_to_save: _,
+            events,
+            receipt,
+        } = tx_receipt;
         let tx_number = self.next_tx_number;
-        let events = tx_receipt
-            .events
+        let events = events
             .iter()
             .zip(self.next_event_number..)
             .map(|(event, number)| {
@@ -658,18 +678,33 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         self.next_event_number += events.len() as u64;
         self.next_tx_number += 1;
         AcceptedTx {
-            tx: tx_receipt
-                .body_to_save
-                .clone()
-                .expect("Transaction receipts contain bodies when using sov-modules-stf-blueprint"),
-            tx_hash: tx_receipt.tx_hash,
+            tx,
+            tx_hash,
             confirmation: Confirmation {
                 events,
-                receipt: tx_receipt.receipt.clone().into(),
+                receipt: receipt.into(),
                 tx_number,
                 timestamp_nanos: timestamp,
             },
         }
+    }
+
+    fn finalize_tx_sequencing_data(
+        tx: &mut FullyBakedTx,
+        scratchpad: Option<sov_rollup_interface::Bytes>,
+    ) {
+        let Some(data) = tx.sequencing_data.as_ref() else {
+            return;
+        };
+        let Ok(decoded) = <Rt as HasCapabilities<S>>::SequencingData::try_from_slice(data) else {
+            tracing::warn!("Failed to deserialize sequencing data while finalizing transaction");
+            return;
+        };
+
+        let mut runtime = Rt::default();
+        let mut handler = runtime.sequencing_data_handler();
+        let finalized = handler.finalize_sequencing_data(decoded, scratchpad);
+        tx.set_sequencing_metadata(&finalized);
     }
 
     fn update_kernel_with_user_state_root(&mut self) {
@@ -786,8 +821,11 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             if batch_receipt.inner.da_address == self.da_address {
                 continue;
             }
-            for tx_receipt in batch_receipt.tx_receipts {
-                let accepted_tx = self.process_tx_receipt(&tx_receipt, None);
+            for mut tx_receipt in batch_receipt.tx_receipts {
+                let tx = tx_receipt.body_to_save.take().expect(
+                    "Transaction receipts contain bodies when using sov-modules-stf-blueprint",
+                );
+                let accepted_tx = self.process_tx_receipt(tx_receipt, tx, None);
                 forced_txs.push(accepted_tx);
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -832,9 +832,10 @@ where
         };
 
         let gas_used = accepted_tx.confirmation.gas_used();
+        let finalized_tx_len = accepted_tx.tx.len();
         let resource_used = ResourceUsed::new(1, tx_len, execution_time_micros, gas_used);
 
-        batch_size_tracker.add_tx(tx_len, execution_time_micros);
+        batch_size_tracker.add_tx(finalized_tx_len, execution_time_micros);
         let rx = executor_events_sender
             .send_accept_tx(accepted_tx, tx_changes, sequence_number)
             .await;

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -321,6 +321,7 @@ where
             Ok(ApplyTxResult {
                 receipt,
                 transaction_consumption,
+                ..
             }) => {
                 let sequencer_reward = transaction_consumption.priority_fee();
                 // ...and immediately store the new `StateCheckpoint`.

--- a/crates/full-node/sov-sequencer/tests/integration/sequencing_metadata.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/sequencing_metadata.rs
@@ -1,28 +1,113 @@
-use borsh::to_vec;
+use std::str::FromStr;
+use std::time::Duration;
+
+use borsh::{to_vec, BorshDeserialize};
+use sov_blob_storage::PreferredBatchData;
 use sov_mock_da::BlockProducingConfig;
-use sov_modules_api::capabilities::TransactionAuthenticator;
-use sov_modules_api::{EncodeCall, RawTx, Runtime};
+use sov_modules_api::capabilities::{
+    Guard, HasCapabilities, SequencingDataHandler, TransactionAuthenticator,
+};
+use sov_modules_api::{
+    BlobReaderTrait, Context, EncodeCall, HDTimestamp, RawTx, Runtime, Spec, TxState,
+};
 use sov_modules_stf_blueprint::GenesisParams;
-use sov_test_modules::sequencing_data::SequencingDataTester;
+use sov_rollup_interface::node::da::DaService;
+use sov_test_modules::sequencing_data::{SequencingDataTester, SCRATCHPAD_TIMESTAMP_NANOS};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
+use sov_test_utils::runtime::StandardProvenRollupCapabilities;
 use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::RtAgnosticBlueprint;
 use sov_test_utils::{
-    default_test_signed_transaction, generate_optimistic_runtime_with_kernel, TestSpec, TestUser,
+    default_test_signed_transaction, generate_runtime_without_capabilities, TestSpec, TestUser,
     TEST_BLOB_PROCESSING_TIMEOUT, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
 };
 
 use crate::utils::{new_test_rollup, tempdir_inside_codebase_dir, MAX_BATCH_EXECUTION_TIME_MILLIS};
 
-generate_optimistic_runtime_with_kernel!(
-    TestRuntime <=
-    kernel_type: sov_kernels::soft_confirmations::SoftConfirmationsKernel<'a, S>,
+const INITIAL_TIMESTAMP_NANOS: u128 = 1_893_456_000_000_000_000;
+
+generate_runtime_without_capabilities!(
+    name: TestRuntime,
     modules: [sequencing_data_tester: SequencingDataTester<S>],
+    operating_mode: sov_modules_api::runtime::OperatingMode::Optimistic,
+    minimal_genesis_config_type: sov_test_utils::runtime::genesis::optimistic::config::MinimalOptimisticGenesisConfig<S>,
+    runtime_trait_impl_bounds: [],
+    kernel_type: sov_kernels::soft_confirmations::SoftConfirmationsKernel<'a, S>,
+    auth_type: sov_modules_api::capabilities::RollupAuthenticator<S, Self>,
+    auth_call_wrapper: |auth_data| auth_data,
 );
 
 type S = TestSpec;
 type RT = TestRuntime<S>;
 type TestBlueprint = RtAgnosticBlueprint<S, RT>;
+
+struct TestSequencingDataHandler<'a, S: Spec> {
+    chain_state: &'a mut sov_test_utils::runtime::ChainState<S>,
+}
+
+impl<S: Spec> SequencingDataHandler<S> for TestSequencingDataHandler<'_, S> {
+    type SequencingData = HDTimestamp;
+
+    fn handle_sequencing_data(
+        &mut self,
+        data: Self::SequencingData,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> anyhow::Result<()> {
+        if !context.sequencer_is_preferred() {
+            return Ok(());
+        }
+
+        self.chain_state
+            .update_oracle_time_from_sequencing_data(data, state)
+    }
+
+    fn create_sequencing_data(&self) -> Self::SequencingData {
+        timestamp_from_nanos(INITIAL_TIMESTAMP_NANOS)
+    }
+
+    fn finalize_sequencing_data(
+        &mut self,
+        data: Self::SequencingData,
+        scratchpad: Option<sov_rollup_interface::Bytes>,
+    ) -> Self::SequencingData {
+        scratchpad
+            .as_deref()
+            .and_then(|bytes| timestamp_bytes_to_nanos(bytes).ok())
+            .map(timestamp_from_nanos)
+            .unwrap_or(data)
+    }
+}
+
+impl<S: Spec> HasCapabilities<S> for TestRuntime<S> {
+    type Capabilities<'a>
+        = StandardProvenRollupCapabilities<'a, S>
+    where
+        Self: 'a;
+    type SequencingData = HDTimestamp;
+
+    fn capabilities(&mut self) -> Guard<Self::Capabilities<'_>> {
+        Guard::new(StandardProvenRollupCapabilities {
+            bank: &mut self.bank,
+            gas_payer: (),
+            sequencer_registry: &mut self.sequencer_registry,
+            accounts: &mut self.accounts,
+            uniqueness: &mut self.uniqueness,
+            chain_state: &mut self.chain_state,
+            operator_incentives: &mut self.operator_incentives,
+            prover_incentives: &mut self.prover_incentives,
+            attester_incentives: &mut self.attester_incentives,
+        })
+    }
+
+    fn sequencing_data_handler(
+        &mut self,
+    ) -> impl SequencingDataHandler<S, SequencingData = Self::SequencingData> {
+        TestSequencingDataHandler {
+            chain_state: &mut self.chain_state,
+        }
+    }
+}
 
 fn create_genesis_params() -> (GenesisParams<GenesisConfig<S>>, TestUser<S>) {
     let genesis_config =
@@ -89,9 +174,64 @@ async fn sequencer_sets_timestamp_before_execution() {
         "test must submit a tx without sequencing metadata"
     );
 
-    test_rollup
+    let accepted_tx = test_rollup
         .api_client()
         .send_raw_tx_to_sequencer(&raw_tx)
         .await
         .expect("sequencer execution should insert sequencing metadata");
+    let accepted_tx_hash = accepted_tx.as_ref().id.to_string();
+    let mut last_checked_height = test_rollup
+        .da_service
+        .get_head_block_header()
+        .await
+        .unwrap()
+        .height;
+    test_rollup.force_close_batch().await.unwrap();
+
+    let published_tx = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            test_rollup.da_service.produce_block_now().await.unwrap();
+            let head_height = test_rollup
+                .da_service
+                .get_head_block_header()
+                .await
+                .unwrap()
+                .height;
+            for height in last_checked_height + 1..=head_height {
+                let mut block = test_rollup.da_service.get_block_at(height).await.unwrap();
+                for blob in block.batch_blobs.iter_mut() {
+                    let batch = PreferredBatchData::try_from_slice(blob.full_data())
+                        .expect("preferred batch blob should decode");
+                    if let Some(tx) = batch.data.iter().find_map(|tx| {
+                        let hash = <RT as Runtime<S>>::Auth::compute_tx_hash(tx)
+                            .expect("published transaction hash should compute");
+                        (hash.to_string() == accepted_tx_hash).then(|| tx.clone())
+                    }) {
+                        return tx;
+                    }
+                }
+            }
+            last_checked_height = head_height;
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the submitted tx to be published");
+    let sequencing_data = published_tx
+        .sequencing_data
+        .expect("published transaction should include finalized sequencing metadata");
+    assert_eq!(
+        timestamp_bytes_to_nanos(&sequencing_data).unwrap(),
+        SCRATCHPAD_TIMESTAMP_NANOS,
+        "sequencer should finalize metadata using the execution scratchpad"
+    );
+}
+
+fn timestamp_from_nanos(nanos: u128) -> HDTimestamp {
+    HDTimestamp::from_str(&nanos.to_string()).expect("u128 timestamp should parse")
+}
+
+fn timestamp_bytes_to_nanos(bytes: &[u8]) -> anyhow::Result<u128> {
+    let bytes = <[u8; 16]>::try_from(bytes)?;
+    Ok(u128::from_le_bytes(bytes))
 }

--- a/crates/module-system/module-implementations/sov-test-modules/src/sequencing_data.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/sequencing_data.rs
@@ -2,6 +2,9 @@ use anyhow::{bail, ensure, Context as _};
 use chrono::{TimeZone, Utc};
 use sov_modules_api::{Context, DaSpec, GenesisState, Module, ModuleId, ModuleInfo, Spec, TxState};
 
+#[cfg(feature = "native")]
+pub const SCRATCHPAD_TIMESTAMP_NANOS: u128 = 1_987_654_321_000_000_000;
+
 #[derive(Clone, ModuleInfo)]
 pub struct SequencingDataTester<S: Spec> {
     #[id]
@@ -45,6 +48,10 @@ impl<S: Spec> Module for SequencingDataTester<S> {
             timestamp,
             reasonable_range
         );
+        #[cfg(feature = "native")]
+        context
+            .sequencing_scratchpad()
+            .set(SCRATCHPAD_TIMESTAMP_NANOS.to_le_bytes().to_vec().into());
         Ok(())
     }
 }

--- a/crates/module-system/sov-modules-api/src/batch.rs
+++ b/crates/module-system/sov-modules-api/src/batch.rs
@@ -190,6 +190,9 @@ pub struct ProvisionalSequencerOutcome<S: Spec> {
     pub penalty: Amount,
     /// Whether the sequencer has run out of funds
     pub execution_status: MaybeExecuted<S>,
+    /// Native scratchpad recorded while executing with the transaction's sequencing data.
+    #[cfg(feature = "native")]
+    pub sequencing_scratchpad: Option<sov_rollup_interface::Bytes>,
 }
 
 /// The reason a transaction was rejected by the sequencer due to insufficient funds.
@@ -238,6 +241,8 @@ impl<S: Spec> ProvisionalSequencerOutcome<S> {
             reward: Amount::ZERO,
             penalty,
             execution_status: MaybeExecuted::SequencerOutOfFunds(reason),
+            #[cfg(feature = "native")]
+            sequencing_scratchpad: None,
         }
     }
 
@@ -247,6 +252,8 @@ impl<S: Spec> ProvisionalSequencerOutcome<S> {
             reward: Amount::ZERO,
             penalty,
             execution_status: MaybeExecuted::Executed(receipt),
+            #[cfg(feature = "native")]
+            sequencing_scratchpad: None,
         }
     }
     /// A convenient constructor for provisionally rewarding the sequencer
@@ -255,6 +262,8 @@ impl<S: Spec> ProvisionalSequencerOutcome<S> {
             reward: amount,
             penalty: Amount::ZERO,
             execution_status: MaybeExecuted::Executed(receipt),
+            #[cfg(feature = "native")]
+            sequencing_scratchpad: None,
         }
     }
 }

--- a/crates/module-system/sov-modules-api/src/module/spec.rs
+++ b/crates/module-system/sov-modules-api/src/module/spec.rs
@@ -2,9 +2,6 @@
 
 use core::fmt::Debug;
 
-#[cfg(feature = "native")]
-use std::sync::{Arc, Mutex};
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::crypto::{CredentialId, Signature};
@@ -175,42 +172,10 @@ impl SequencingContext {
     pub fn data(&self) -> &Option<Bytes> {
         &self.data
     }
-
-    /// Returns the native sequencing scratchpad.
-    #[cfg(feature = "native")]
-    pub fn scratchpad(&self) -> SequencingScratchpad {
-        self.scratchpad.clone()
-    }
-}
-
-/// Native-only scratchpad for recording data while finalizing sequencing metadata.
-#[cfg(feature = "native")]
-#[derive(Clone, Debug, Default)]
-pub struct SequencingScratchpad {
-    inner: Arc<Mutex<Option<Bytes>>>,
 }
 
 #[cfg(feature = "native")]
-impl SequencingScratchpad {
-    /// Replaces the scratchpad contents.
-    pub fn set(&self, value: Bytes) {
-        self.with_value(|slot| *slot = Some(value));
-    }
-
-    /// Takes the scratchpad contents, leaving it empty.
-    pub fn take(&self) -> Option<Bytes> {
-        self.with_value(Option::take)
-    }
-
-    /// Mutates the scratchpad contents under the scratchpad lock.
-    pub fn with_value<R>(&self, f: impl FnOnce(&mut Option<Bytes>) -> R) -> R {
-        let mut guard = self
-            .inner
-            .lock()
-            .expect("sequencing scratchpad mutex was poisoned");
-        f(&mut guard)
-    }
-}
+pub use native_sequencing::SequencingScratchpad;
 
 /// The context in which a transaction executes
 
@@ -253,18 +218,6 @@ impl<S: Spec> Context<S> {
     /// Returns the sequencing data
     pub fn sequencing_data(&self) -> &Option<Bytes> {
         self.sequencing.data()
-    }
-
-    /// Returns the native sequencing scratchpad.
-    #[cfg(feature = "native")]
-    pub fn sequencing_scratchpad(&self) -> SequencingScratchpad {
-        self.sequencing.scratchpad()
-    }
-
-    /// Takes the native sequencing scratchpad contents.
-    #[cfg(feature = "native")]
-    pub fn take_sequencing_scratchpad(&self) -> Option<Bytes> {
-        self.sequencing.scratchpad().take()
     }
 
     /// Returns the rollup address which will receive any gas refund from the transaction.
@@ -340,6 +293,59 @@ impl<S: Spec> Context<S> {
     /// Returns the sender's credentials.
     pub fn get_sender_credential<T: core::any::Any>(&self) -> Option<&T> {
         self.sender_credentials.get::<T>()
+    }
+}
+
+#[cfg(feature = "native")]
+mod native_sequencing {
+    use std::sync::{Arc, Mutex};
+
+    use sov_rollup_interface::Bytes;
+
+    /// Native-only scratchpad for recording data while finalizing sequencing metadata.
+    #[derive(Clone, Debug, Default)]
+    pub struct SequencingScratchpad {
+        inner: Arc<Mutex<Option<Bytes>>>,
+    }
+
+    impl SequencingScratchpad {
+        /// Replaces the scratchpad contents.
+        pub fn set(&self, value: Bytes) {
+            self.with_value(|slot| *slot = Some(value));
+        }
+
+        /// Takes the scratchpad contents, leaving it empty.
+        pub fn take(&self) -> Option<Bytes> {
+            self.with_value(Option::take)
+        }
+
+        /// Mutates the scratchpad contents under the scratchpad lock.
+        pub fn with_value<R>(&self, f: impl FnOnce(&mut Option<Bytes>) -> R) -> R {
+            let mut guard = self
+                .inner
+                .lock()
+                .expect("sequencing scratchpad mutex was poisoned");
+            f(&mut guard)
+        }
+    }
+
+    impl super::SequencingContext {
+        /// Returns the native sequencing scratchpad.
+        pub fn scratchpad(&self) -> super::SequencingScratchpad {
+            self.scratchpad.clone()
+        }
+    }
+
+    impl<S: super::Spec> super::Context<S> {
+        /// Returns the native sequencing scratchpad.
+        pub fn sequencing_scratchpad(&self) -> super::SequencingScratchpad {
+            self.sequencing.scratchpad()
+        }
+
+        /// Takes the native sequencing scratchpad contents.
+        pub fn take_sequencing_scratchpad(&self) -> Option<Bytes> {
+            self.sequencing.scratchpad().take()
+        }
     }
 }
 

--- a/crates/module-system/sov-modules-api/src/module/spec.rs
+++ b/crates/module-system/sov-modules-api/src/module/spec.rs
@@ -2,6 +2,9 @@
 
 use core::fmt::Debug;
 
+#[cfg(feature = "native")]
+use std::sync::{Arc, Mutex};
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::crypto::{CredentialId, Signature};
@@ -149,6 +152,66 @@ where
 /// slightly more restrictive traits defined in the module system.
 impl<C: CryptoHelper> CryptoSpecExt for C {}
 
+/// Sequencer-provided data plus native-only execution scratchpad.
+#[derive(Clone, Debug)]
+pub struct SequencingContext {
+    data: Option<Bytes>,
+    #[cfg(feature = "native")]
+    scratchpad: SequencingScratchpad,
+}
+
+impl SequencingContext {
+    /// Creates a new sequencing context.
+    #[must_use]
+    pub fn new(data: Option<Bytes>) -> Self {
+        Self {
+            data,
+            #[cfg(feature = "native")]
+            scratchpad: SequencingScratchpad::default(),
+        }
+    }
+
+    /// Returns the sequencing data.
+    pub fn data(&self) -> &Option<Bytes> {
+        &self.data
+    }
+
+    /// Returns the native sequencing scratchpad.
+    #[cfg(feature = "native")]
+    pub fn scratchpad(&self) -> SequencingScratchpad {
+        self.scratchpad.clone()
+    }
+}
+
+/// Native-only scratchpad for recording data while finalizing sequencing metadata.
+#[cfg(feature = "native")]
+#[derive(Clone, Debug, Default)]
+pub struct SequencingScratchpad {
+    inner: Arc<Mutex<Option<Bytes>>>,
+}
+
+#[cfg(feature = "native")]
+impl SequencingScratchpad {
+    /// Replaces the scratchpad contents.
+    pub fn set(&self, value: Bytes) {
+        self.with_value(|slot| *slot = Some(value));
+    }
+
+    /// Takes the scratchpad contents, leaving it empty.
+    pub fn take(&self) -> Option<Bytes> {
+        self.with_value(Option::take)
+    }
+
+    /// Mutates the scratchpad contents under the scratchpad lock.
+    pub fn with_value<R>(&self, f: impl FnOnce(&mut Option<Bytes>) -> R) -> R {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("sequencing scratchpad mutex was poisoned");
+        f(&mut guard)
+    }
+}
+
 /// The context in which a transaction executes
 
 #[derive(Clone, Debug)]
@@ -162,7 +225,7 @@ pub struct Context<S: Spec> {
     /// The DA layer address of the sequencer who included the transaction.
     sequencer_da_address: <S::Da as DaSpec>::Address,
     /// Sequencing data provided by the sequencer
-    sequencing_data: Option<Bytes>,
+    sequencing: SequencingContext,
     /// The rollup address that pays the gas fees for the transaction.
     gas_refund_recipient: S::Address,
     /// The execution context of the transaction.
@@ -189,7 +252,19 @@ impl<S: Spec> Context<S> {
 
     /// Returns the sequencing data
     pub fn sequencing_data(&self) -> &Option<Bytes> {
-        &self.sequencing_data
+        self.sequencing.data()
+    }
+
+    /// Returns the native sequencing scratchpad.
+    #[cfg(feature = "native")]
+    pub fn sequencing_scratchpad(&self) -> SequencingScratchpad {
+        self.sequencing.scratchpad()
+    }
+
+    /// Takes the native sequencing scratchpad contents.
+    #[cfg(feature = "native")]
+    pub fn take_sequencing_scratchpad(&self) -> Option<Bytes> {
+        self.sequencing.scratchpad().take()
     }
 
     /// Returns the rollup address which will receive any gas refund from the transaction.
@@ -256,7 +331,7 @@ impl<S: Spec> Context<S> {
             sequencer,
             sequencer_da_address,
             gas_refund_recipient: payer,
-            sequencing_data,
+            sequencing: SequencingContext::new(sequencing_data),
             execution_context,
             sequencer_type,
         }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
@@ -1,7 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_rollup_interface::stf::FullyBakedTx;
-#[cfg(feature = "native")]
-use sov_rollup_interface::Bytes;
 
 use crate::{capabilities::HasCapabilities, Context, HDTimestamp, Runtime, Spec, TxState};
 
@@ -29,7 +27,7 @@ pub trait SequencingDataHandler<S: Spec> {
     fn finalize_sequencing_data(
         &mut self,
         data: Self::SequencingData,
-        _scratchpad: Option<Bytes>,
+        _scratchpad: Option<sov_rollup_interface::Bytes>,
     ) -> Self::SequencingData {
         data
     }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
@@ -23,6 +23,24 @@ pub trait SequencingDataHandler<S: Spec> {
     fn create_sequencing_data(&self) -> Self::SequencingData;
 
     /// Finalizes sequencing data after native transaction execution.
+    ///
+    /// WARNING: this allows the sequencer to modify concensus data. If used carelessly, this can
+    /// easily result in a broken rollup. Implementations must take great care that their usecase
+    /// is consensus-safe.
+    ///
+    /// There are two main pitfalls to avoid:
+    /// 1. Causing a modified execution outcome. If the final `sequencing_data` is mutated in such
+    ///    a way that the execution output differs in *any* way (including subtle effects such as
+    ///    gas usage), this result cause a faulty sequencer.
+    /// 2. Growing the data size. The initial data size is used for batch size limit checks. If
+    ///    finalization here grows the data, this could result in an invalid batch, soft-locking
+    ///    and penalizing the preferred sequencer.
+    ///
+    /// A safe use for this would be if access logic uses the `scratchpad` to record
+    /// used entries in the SequencingData, and after execution the sequencer prunes any unused
+    /// entries to trim the transaction size. Since any entries accessed during execution remain
+    /// unchanged this would be guaranteed to not change execution outcomes, and shrinking the data
+    /// size is safe.
     #[cfg(feature = "native")]
     fn finalize_sequencing_data(
         &mut self,

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/sequencing_data.rs
@@ -1,5 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_rollup_interface::stf::FullyBakedTx;
+#[cfg(feature = "native")]
+use sov_rollup_interface::Bytes;
 
 use crate::{capabilities::HasCapabilities, Context, HDTimestamp, Runtime, Spec, TxState};
 
@@ -21,6 +23,16 @@ pub trait SequencingDataHandler<S: Spec> {
     /// Generates the sequencing data for a new transaction.
     #[cfg(feature = "native")]
     fn create_sequencing_data(&self) -> Self::SequencingData;
+
+    /// Finalizes sequencing data after native transaction execution.
+    #[cfg(feature = "native")]
+    fn finalize_sequencing_data(
+        &mut self,
+        data: Self::SequencingData,
+        _scratchpad: Option<Bytes>,
+    ) -> Self::SequencingData {
+        data
+    }
 }
 
 /// Trait for sequencing data that can be deserialized and serialized using borsh.

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -62,6 +62,10 @@ pub struct ApplyTxResult<S: Spec> {
     pub transaction_consumption: TransactionConsumption<S::Gas>,
     /// The transaction receipt.
     pub receipt: TransactionReceipt<S>,
+    /// Native scratchpad recorded while executing with the transaction's sequencing data.
+    #[cfg(feature = "native")]
+    #[serde(skip)]
+    pub sequencing_scratchpad: Option<sov_rollup_interface::Bytes>,
 }
 
 /// Genesis parameters for a blueprint

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -57,6 +57,8 @@ where
             ApplyTxResult::<S> {
                 transaction_consumption,
                 receipt,
+                #[cfg(feature = "native")]
+                sequencing_scratchpad: ctx.take_sequencing_scratchpad(),
             },
             tx_scratchpad,
         );
@@ -117,6 +119,8 @@ where
         ApplyTxResult::<S> {
             transaction_consumption,
             receipt,
+            #[cfg(feature = "native")]
+            sequencing_scratchpad: ctx.take_sequencing_scratchpad(),
         },
         tx_scratchpad,
     )

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -524,10 +524,20 @@ where
             AuthAndProcessOutcome::Applied {
                 transaction_consumption,
                 receipt,
-            } => ProvisionalSequencerOutcome::reward(
-                transaction_consumption.priority_fee().0,
-                receipt,
-            ),
+                #[cfg(feature = "native")]
+                sequencing_scratchpad,
+            } => {
+                let outcome = ProvisionalSequencerOutcome::reward(
+                    transaction_consumption.priority_fee().0,
+                    receipt,
+                );
+                #[cfg(feature = "native")]
+                let outcome = ProvisionalSequencerOutcome {
+                    sequencing_scratchpad,
+                    ..outcome
+                };
+                outcome
+            }
         };
 
         let provisional_reward = provisional_outcome.reward;
@@ -652,6 +662,8 @@ enum AuthAndProcessOutcome<S: Spec> {
     Applied {
         transaction_consumption: TransactionConsumption<S::Gas>,
         receipt: TransactionReceipt<S>,
+        #[cfg(feature = "native")]
+        sequencing_scratchpad: Option<sov_rollup_interface::Bytes>,
     },
 }
 
@@ -916,6 +928,8 @@ where
         Ok(ApplyTxResult {
             transaction_consumption,
             receipt,
+            #[cfg(feature = "native")]
+            sequencing_scratchpad,
         }) => {
             // The gas_used in the receipt is the sum of pre_exec_gas_meter.gas_used and the gas consumed during transaction execution.
             let gas_used = get_gas_used(&receipt);
@@ -926,6 +940,8 @@ where
                 outcome: AuthAndProcessOutcome::Applied {
                     receipt,
                     transaction_consumption,
+                    #[cfg(feature = "native")]
+                    sequencing_scratchpad,
                 },
             }
         }

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/unregistered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/unregistered.rs
@@ -320,6 +320,7 @@ where
         Ok(ApplyTxResult {
             transaction_consumption,
             receipt,
+            ..
         }) => {
             // We reward sequencer only if the registration transaction is successful.
             if receipt.receipt.is_successful() {


### PR DESCRIPTION
# Description

Adds machinery to enable `sequencing_data` to be mutated post-execution by the sequencer, and uses it to implement a proof-of-concept for oracle data mutation in an integration test which serves as an example of how this can actually be used by e.g. Relay.

The mutation is implemented in a capability trait method that gives a lot of freedom to rollup developers. This can let them break their own consensus, but the pitfalls are documented in a doc comment. I don't think there's a convenient way to statically prevent footguns here, so it's left as a well-documented but dangerous method. For our own usecase this is not a problem.

**Note to reviewers**: 700 lines are in the PoC integration test, of which a huge chunk is boilerplate overriting `HasCapabilities`. The ergonomics of this could be improved in a future PR.

**Future improvements**
A couple of aspects could be made more complex in the future if needed:
* Size tracking: the oracle data could be pretty large. Right now this is recorded in the batch size tracker pessimistically, and then updated after pruning. If this becomes a concern, the actual implementation could specify a max final size (i.e.: max oracle reads in a transaction) that's smaller than the total oracle snapshot, use that for the initial estimate, and fail transactions that would read more items than this limit.
* Intelligent (de)serialization: a naive oracle implementation requires serializing and deserializing the entire `sequencing_data` snapshot at every transaction and every precompile call. For a key-value map of oracle values, a custom serialization method could be implemented that does zero-copy accesses and can extract values for specific keys, keeping the entire oracle snapshot as serialized `Bytes` and avoiding the roundtrip full map ser/de.

I'll convert these to issues if we proceed with this PR and merge it into the SDK

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?
This
## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
