### PR TITLE
SOV-2: Fix unchecked fields during deserialization

### DIFF
--- a/crates/module-system/hyperlane/src/igp/metadata.rs
+++ b/crates/module-system/hyperlane/src/igp/metadata.rs
@@ -36,8 +36,6 @@ impl IGPMetadata {
     const EXPECTED_VARIANT: u16 = 1;
 
     pub(crate) fn deserialize(buf: &[u8]) -> Result<Self> {
-        type U256 = ruint::Uint<256, 4>;
-
         let mut cursor = buf;
 
         // variant (0:2): reject unknown versions so a future format isn't misparsed.
@@ -57,7 +55,7 @@ impl IGPMetadata {
 
         // gas limit (34:66): Hyperlane uses a u256 but our amounts are u128, so
         // anything beyond u128::MAX is rejected.
-        let gas_limit = U256::from_be_bytes(read_field::<32>(&mut cursor)?);
+        let gas_limit = ruint::Uint::<256, 4>::from_be_bytes(read_field::<32>(&mut cursor)?);
         let gas_limit: u128 = gas_limit
             .try_into()
             .map_err(|_| Error::new(ErrorKind::InvalidData, "Gas limit exceeds u128 maximum"))?;

--- a/crates/module-system/hyperlane/src/igp/metadata.rs
+++ b/crates/module-system/hyperlane/src/igp/metadata.rs
@@ -2,7 +2,9 @@ use std::io::{Error, ErrorKind, Result};
 
 use sov_bank::Amount;
 
-/// Metadata with fields for IGP, we skip first fields since we don't need them.
+/// IGP metadata following Hyperlane's `StandardHookMetadata` layout. We only
+/// retain the gas limit; `variant` is validated on deserialization and the other
+/// fields are advisory and ignored.
 ///
 /// See <https://docs.hyperlane.xyz/docs/reference/libraries/hookmetadata>
 ///
@@ -14,54 +16,60 @@ use sov_bank::Amount;
 pub struct IGPMetadata {
     /// Gas limit.
     ///
-    /// NOTE: in Hyperlane they use u256 but we only write/read last 16 bytes since sovereign sdk
-    /// uses u128 for amount.
+    /// NOTE: Hyperlane encodes this as a u256, but Sovereign SDK uses u128 for
+    /// amounts, so values exceeding `u128::MAX` are rejected during deserialization.
     pub gas_limit: Amount,
 }
 
-impl IGPMetadata {
-    pub(crate) fn deserialize(buf: &[u8]) -> Result<Self> {
-        const MIN_LENGTH: usize = 66;
-        const GAS_LIMIT_OFFSET: usize = 34;
+/// Reads the next `N` bytes from `buf`, advancing it past them.
+fn read_field<const N: usize>(buf: &mut &[u8]) -> Result<[u8; N]> {
+    let (field, rest) = buf
+        .split_at_checked(N)
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "IGPMetadata is too short"))?;
+    *buf = rest;
+    Ok(field.try_into().expect("slice length checked above"))
+}
 
-        if buf.len() < MIN_LENGTH {
+impl IGPMetadata {
+    /// The only metadata format version we support, matching Hyperlane's
+    /// `StandardHookMetadata.VARIANT`.
+    const EXPECTED_VARIANT: u16 = 1;
+
+    pub(crate) fn deserialize(buf: &[u8]) -> Result<Self> {
+        type U256 = ruint::Uint<256, 4>;
+
+        let mut cursor = buf;
+
+        // variant (0:2): reject unknown versions so a future format isn't misparsed.
+        let variant = u16::from_be_bytes(read_field(&mut cursor)?);
+        if variant != Self::EXPECTED_VARIANT {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 format!(
-                    "Expected at least {MIN_LENGTH} bytes for IGPMetadata, got {}",
-                    buf.len()
+                    "Unsupported IGPMetadata variant: expected {}, got {variant}",
+                    Self::EXPECTED_VARIANT
                 ),
             ));
         }
 
-        // Extract gas_limit from position 34-66
-        // We only need the last 16 bytes for u128
-        // So check if first 16 are zeroes
-        let first_half = &buf[GAS_LIMIT_OFFSET..GAS_LIMIT_OFFSET + 16];
-        if !first_half.iter().all(|&b| b == 0) {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Gas limit exceeds u128 maximum",
-            ));
-        }
+        // msg.value (2:34): advisory, the gas paymaster doesn't act on it.
+        read_field::<32>(&mut cursor)?;
 
-        let gas_limit = match buf[GAS_LIMIT_OFFSET + 16..GAS_LIMIT_OFFSET + 32].try_into() {
-            Ok(bytes) => bytes,
-            Err(_) => {
-                return Err(Error::new(
-                    ErrorKind::InvalidData,
-                    "Failed to convert gas limit bytes to array",
-                ))
-            }
-        };
-        let gas_limit = u128::from_be_bytes(gas_limit);
-
+        // gas limit (34:66): Hyperlane uses a u256 but our amounts are u128, so
+        // anything beyond u128::MAX is rejected.
+        let gas_limit = U256::from_be_bytes(read_field::<32>(&mut cursor)?);
+        let gas_limit: u128 = gas_limit
+            .try_into()
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "Gas limit exceeds u128 maximum"))?;
         if gas_limit == 0 {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "Gas limit is not set, all bytes are 0",
             ));
         }
+
+        // refund address (66:86) and trailing custom metadata are advisory; we
+        // charge exactly the required gas and never refund, so they're ignored.
 
         Ok(Self {
             gas_limit: Amount(gas_limit),
@@ -77,38 +85,37 @@ mod tests {
 
     use super::IGPMetadata;
 
+    /// Builds a valid `StandardHookMetadata` buffer (variant 1, zero msg.value,
+    /// zero refund address) with the given gas limit.
+    fn valid_buf(gas_limit: u128) -> Vec<u8> {
+        let mut buf = vec![0_u8; 86];
+        // variant = 1
+        buf[0..2].copy_from_slice(&1u16.to_be_bytes());
+        // gas limit lives in the lower 16 bytes of the (34:66) field
+        buf[34 + 16..34 + 32].copy_from_slice(&gas_limit.to_be_bytes());
+        buf
+    }
+
     #[test]
     fn igp_metadata_deserialize() {
-        let metadata = IGPMetadata {
-            gas_limit: Amount(14235043),
-        };
-        let mut buf = vec![0_u8; 86];
-        let gas_limit_bytes = metadata.gas_limit.0.to_be_bytes();
-        buf[34 + 16..34 + 32].copy_from_slice(&gas_limit_bytes);
+        let buf = valid_buf(14235043);
         let decoded = IGPMetadata::deserialize(&buf).expect("should deserialize");
-        assert_eq!(decoded.gas_limit, metadata.gas_limit);
+        assert_eq!(decoded.gas_limit, Amount(14235043));
     }
 
     #[test]
     fn igp_metadata_deserialize_max_u128() {
-        let metadata = IGPMetadata {
-            gas_limit: Amount(u128::MAX),
-        };
-        let mut buf = vec![0_u8; 86];
-        let gas_limit_bytes = metadata.gas_limit.0.to_be_bytes();
-        buf[34 + 16..34 + 32].copy_from_slice(&gas_limit_bytes);
+        let buf = valid_buf(u128::MAX);
         let decoded = IGPMetadata::deserialize(&buf).expect("should deserialize");
-        assert_eq!(decoded.gas_limit, metadata.gas_limit);
+        assert_eq!(decoded.gas_limit, Amount(u128::MAX));
     }
 
     #[test]
     fn igp_metadata_deserialize_exceeds_u128() {
         // This simulates a U256 value that's too large for u128
-        let mut buf = vec![0_u8; 86];
+        let mut buf = valid_buf(u128::MAX);
         // Set the first byte of the gas limit to non-zero
         buf[34] = 1;
-        // Fill the rest with valid data
-        buf[34 + 16..34 + 32].copy_from_slice(&u128::MAX.to_be_bytes());
 
         let result = IGPMetadata::deserialize(&buf);
         assert!(result.is_err());
@@ -120,7 +127,7 @@ mod tests {
 
     #[test]
     fn igp_metadata_deserialize_zero_gas_limit() {
-        let buf = vec![0_u8; 86];
+        let buf = valid_buf(0);
 
         let result = IGPMetadata::deserialize(&buf);
         assert!(result.is_err());
@@ -132,13 +139,60 @@ mod tests {
 
     #[test]
     fn igp_metadata_deserialize_buffer_too_small() {
-        let buf = vec![0_u8; 65]; // MIN_LENGTH is 66
+        // Truncated partway through the gas limit field.
+        let buf = valid_buf(14235043);
+        let result = IGPMetadata::deserialize(&buf[..65]);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidData);
+            assert_eq!(e.to_string(), "IGPMetadata is too short");
+        }
+    }
+
+    #[test]
+    fn igp_metadata_deserialize_unsupported_variant() {
+        let mut buf = valid_buf(14235043);
+        // variant = 2 is not a format we understand
+        buf[0..2].copy_from_slice(&2u16.to_be_bytes());
 
         let result = IGPMetadata::deserialize(&buf);
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(e.kind(), ErrorKind::InvalidData);
-            assert!(e.to_string().contains("Expected at least 66 bytes"));
+            assert_eq!(
+                e.to_string(),
+                "Unsupported IGPMetadata variant: expected 1, got 2"
+            );
         }
+    }
+
+    #[test]
+    fn igp_metadata_deserialize_ignores_nonzero_msg_value() {
+        let mut buf = valid_buf(14235043);
+        // A non-zero msg.value (2:34) must not affect parsing.
+        buf[33] = 0x42;
+
+        let decoded = IGPMetadata::deserialize(&buf).expect("non-zero msg.value should be ignored");
+        assert_eq!(decoded.gas_limit, Amount(14235043));
+    }
+
+    #[test]
+    fn igp_metadata_deserialize_ignores_nonzero_refund_address() {
+        let mut buf = valid_buf(14235043);
+        // A non-zero refund address (66:86) is the common case and must be accepted.
+        buf[66] = 0xab;
+
+        let decoded =
+            IGPMetadata::deserialize(&buf).expect("non-zero refund address should be ignored");
+        assert_eq!(decoded.gas_limit, Amount(14235043));
+    }
+
+    #[test]
+    fn igp_metadata_deserialize_refund_address_omitted() {
+        // Exactly 66 bytes: the refund address field is omitted, which is fine.
+        let buf = valid_buf(14235043);
+        let decoded = IGPMetadata::deserialize(&buf[..66])
+            .expect("should deserialize without refund address");
+        assert_eq!(decoded.gas_limit, Amount(14235043));
     }
 }


### PR DESCRIPTION
# Description

Fixes audit issue `SOV-2` from our hyperlane audit. We're taking a permissive approach as opposed to their recommended zero check since the value is discarded and it's what the EVM contract does.

  ## SOV-02 Unchecked Fields During `IGPMetadata` Deserialisation

  **Asset:** `igp/metadata.rs`
  **Status:** Open
  **Rating:** Severity: Medium · Impact: High · Likelihood: Low

  ### Description

  The deserialization logic for `IGPMetadata` only processes the `gasLimit` field, neglecting other fields. This oversight can lead to incorrect metadata interpretation, potential mishandling of funds if `msgValue` is manipulated, or unexpected behaviour if `variant` or `refundAddress` do not conform to expected values.

  The metadata also contains several other fields:

  - `variant` describes the format version of the metadata. It should be checked that this is equal to `1`, the expected version for this format. Otherwise, future versions may be deserialised incorrectly.
  - `msgValue` specifies to the relayer how much native tokens they should attach to the contract call. If this feature is not intended to be supported, it should be checked that `msgValue` is equal to zero. Currently, the sender of the message can set this to an arbitrary value without having to pay for it.
  - `refundAddress` specifies to the relayer which address should receive the refund for any excess gas. If this feature is not intended to be supported, it should be checked that it is set to zero.

  ```rust
  // igp/metadata.rs
  pub(crate) fn deserialize(buf: &[u8]) -> Result {
      const MIN_LENGTH: usize = 66;
      const GAS_LIMIT_OFFSET: usize = 34;
      if buf.len() < MIN_LENGTH {
          return Err(Error::new(
              ErrorKind::InvalidData,
              format!(
                  "Expected at least {MIN_LENGTH} bytes for IGPMetadata, got {}",
                  buf.len()
              ),
          ));
      }
      // ...
      let gas_limit = match buf[GAS_LIMIT_OFFSET + 16..GAS_LIMIT_OFFSET + 32].try_into() {
          Ok(bytes) => bytes,
          Err(_) => {
              return Err(Error::new(
                  ErrorKind::InvalidData,
                  "Failed to convert gas limit bytes to array",
              ))
          }
      };
      // ...
      Ok(Self {
          gas_limit: Amount(gas_limit),
      })
  }
  ```

  ### Recommendations

  Modify `IGPMetadata::deserialize()` such that it fully deserialises `IGPMetadata` and validates all of its fields.
