### PR TITLE
Add cheap user state root sequencer-node consistency check, even when expensive checks are disabled

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -33,9 +33,9 @@ use sov_blob_sender::{new_blob_id, BlobInternalId};
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::{RollupHeight, SequencingDataHandler};
 use sov_modules_api::state::{ApiStateAccessor, ConcurrentStateCheckpoint};
-use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateCheckpoint, VersionReader};
+use sov_modules_api::{FullyBakedTx, HexString, Runtime, Spec, StateCheckpoint, VersionReader};
 use sov_rollup_full_node_interface::StateUpdateInfo;
-use sov_state::Storage;
+use sov_state::{NativeStorage, ProvableNamespace, StateRoot, Storage};
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -654,6 +654,8 @@ where
 
         Self::common_for_final_catchup_and_new_storage(&mut inner, info.clone()).await;
 
+        Self::check_cached_state_root_against_node(&inner, &info, new_rollup_height).await;
+
         // Compute finalized_rollup_height from the finalized slot to avoid over-pruning during reorgs.
         // Only prune state roots for heights that are finalized on the DA layer.
         let finalized_rollup_height = {
@@ -683,6 +685,51 @@ where
             .executor
             .state_roots
             .retain(|height, _| *height > finalized_rollup_height);
+    }
+
+    async fn check_cached_state_root_against_node(
+        inner: &Inner<S, Rt>,
+        info: &StateUpdateInfo<S::Storage>,
+        new_rollup_height: RollupHeight,
+    ) {
+        let Some(sequencer_root) = inner.executor.state_roots.get(&new_rollup_height) else {
+            debug!(
+                %new_rollup_height,
+                "Skipping sequencer/node state root sanity check; no cached sequencer root is available"
+            );
+            return;
+        };
+
+        let Some(node_root) = info.storage.get_root_hash(info.slot_number) else {
+            debug!(
+                %new_rollup_height,
+                slot_number = %info.slot_number,
+                "Skipping sequencer/node state root sanity check; node root is not available"
+            );
+            return;
+        };
+
+        let sequencer_user_root = sequencer_root.namespace_root(ProvableNamespace::User);
+        let node_user_root = node_root.namespace_root(ProvableNamespace::User);
+
+        if sequencer_user_root == node_user_root {
+            debug!(
+                %new_rollup_height,
+                slot_number = %info.slot_number,
+                user_root = %HexString(sequencer_user_root),
+                "Sequencer/node user state root sanity check passed"
+            );
+            return;
+        }
+
+        tracing::error!(
+            %new_rollup_height,
+            slot_number = %info.slot_number,
+            sequencer_user_root = %HexString(sequencer_user_root),
+            node_user_root = %HexString(node_user_root),
+            "Sequencer user state root does not match the node user state root. This indicates a sequencer/node state divergence."
+        );
+        crate::preferred::exit_rollup(&inner.shutdown_sender).await;
     }
 
     async fn process_final_catchup(

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -638,23 +638,23 @@ where
         // Note that we use `StateCheckpoint::new(info.storage.clone(), ...)` *without* passing any intermediate state. This
         // is because we want to see what the height of the checkpoint we just received is, not the height of the sequencer's intermediate state.
         let mut rt = Rt::default();
-        let new_rollup_height =
+        let node_rollup_height =
             StateCheckpoint::new(info.storage.clone(), &rt.kernel()).rollup_height_to_access();
 
         inner
             .executor
             .uncommitted_changes
-            .prune_changes_through(new_rollup_height.get());
+            .prune_changes_through(node_rollup_height.get());
         let uncommitted_changes = inner.executor.uncommitted_changes.clone();
         inner
             .executor
             .checkpoint
             .replace_storage(info.storage.clone(), Box::new(uncommitted_changes));
-        tracing::debug!(%new_rollup_height, "Storage has been replaced");
+        tracing::debug!(%node_rollup_height, "Storage has been replaced");
 
         Self::common_for_final_catchup_and_new_storage(&mut inner, info.clone()).await;
 
-        Self::check_cached_state_root_against_node(&inner, &info, new_rollup_height).await;
+        Self::check_cached_state_root_against_node(&inner, &info, node_rollup_height).await;
 
         // Compute finalized_rollup_height from the finalized slot to avoid over-pruning during reorgs.
         // Only prune state roots for heights that are finalized on the DA layer.
@@ -690,11 +690,11 @@ where
     async fn check_cached_state_root_against_node(
         inner: &Inner<S, Rt>,
         info: &StateUpdateInfo<S::Storage>,
-        new_rollup_height: RollupHeight,
+        node_rollup_height: RollupHeight,
     ) {
-        let Some(sequencer_root) = inner.executor.state_roots.get(&new_rollup_height) else {
+        let Some(sequencer_root) = inner.executor.state_roots.get(&node_rollup_height) else {
             debug!(
-                %new_rollup_height,
+                %node_rollup_height,
                 "Skipping sequencer/node state root sanity check; no cached sequencer root is available"
             );
             return;
@@ -702,7 +702,7 @@ where
 
         let Some(node_root) = info.storage.get_root_hash(info.slot_number) else {
             debug!(
-                %new_rollup_height,
+                %node_rollup_height,
                 slot_number = %info.slot_number,
                 "Skipping sequencer/node state root sanity check; node root is not available"
             );
@@ -714,7 +714,7 @@ where
 
         if sequencer_user_root == node_user_root {
             debug!(
-                %new_rollup_height,
+                %node_rollup_height,
                 slot_number = %info.slot_number,
                 user_root = %HexString(sequencer_user_root),
                 "Sequencer/node user state root sanity check passed"
@@ -723,7 +723,7 @@ where
         }
 
         tracing::error!(
-            %new_rollup_height,
+            %node_rollup_height,
             slot_number = %info.slot_number,
             sequencer_user_root = %HexString(sequencer_user_root),
             node_user_root = %HexString(node_user_root),


### PR DESCRIPTION
# Description

Adds an unconditional check of the sequencer user root against the node user root in `process_new_storage()`.

This does require a RocksDB lookup for the node root. We could avoid this by adding the node state root to the `StateUpdateInfo`, since I think the node has it available in-memory and just doesn't send this to the sequencer; I don't know whether the extra complexity in changing the type signature here is worth the tradeoff, so I've left it simple for now.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
