### PR TITLE
Asyncifiying logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12031,6 +12031,7 @@ dependencies = [
  "sov-stf-runner",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-panic",
  "tracing-subscriber 0.3.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,6 +274,7 @@ tower-http = "0.6"
 tower-request-id = "0.3"
 tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.18" } # There's hardly any reason to disable its default features.
+tracing-appender = { version = "0.2", default-features = false }
 tracing-test = { version = "0.2.5", features = [
     "no-env-filter",
 ] } # https://docs.rs/tracing-test/latest/tracing_test/#per-crate-filtering

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -315,7 +315,7 @@ async fn test_submit_proof_correct() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multi_sender_multi_namespace_full_verification_roundtrip() -> anyhow::Result<()> {
-    let _guard = sov_test_utils::initialize_logging();
+    sov_test_utils::initialize_logging();
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let base_config = dev_node.get_config().await?;
 

--- a/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["sync", "signal"], optional = true }
 tracing = { workspace = true, optional = true }
 tracing-panic = { version = "0.1.2", optional = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
+tracing-appender = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"], optional = true }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "rt-tokio"], optional = true }
@@ -73,6 +74,7 @@ native = [
 	"tracing",
 	"tracing-panic",
 	"tracing-subscriber",
+	"tracing-appender",
 	"hex",
 	"opentelemetry",
 	"opentelemetry_sdk",

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -44,7 +44,20 @@ pub fn initialize_logging() -> Option<OtelGuard> {
 
     let get_env_filter = || EnvFilter::from_str(&env_filter).unwrap();
 
+    // Route stdout through a non-blocking, lossy, bounded writer so a slow or backpressuring
+    // stdout consumer can never block tokio worker threads. With the default blocking
+    // `std::io::stdout()` writer, a log-storm (e.g. the per-retry warnings emitted by every DA
+    // task during a Celestia outage) makes workers block mid-poll inside `write(2)`, which
+    // freezes the entire runtime — including DA-independent tasks like the heartbeat (incident
+    // 2026-06). The node logs for its whole lifetime, so we keep the writer's worker thread
+    // alive by leaking the guard; this deliberately keeps the return type unchanged, since it is
+    // consumed (often unbound) at many call sites. Trade-off: the last buffered lines may not
+    // flush on an abrupt exit.
+    let (non_blocking, worker_guard) = tracing_appender::non_blocking(std::io::stdout());
+    std::mem::forget(worker_guard);
+
     let mut layers = fmt::layer()
+        .with_writer(non_blocking)
         .with_filter(get_env_filter())
         .with_filter(IgnoreSpan(ExecutionContext::SEQUENCER_WARM_UP))
         .boxed();

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -30,10 +30,21 @@ where
     }
 }
 
+/// Guard that must be held for the entire lifetime of the process for logging to keep working: it
+/// owns the non-blocking stdout writer's worker thread and, when enabled, the OpenTelemetry
+/// providers. Dropping it flushes buffered logs and stops non-blocking logging (and OTEL export).
+#[must_use = "logging stops when this guard is dropped; hold it for the lifetime of the program"]
+pub struct LoggingGuard {
+    // Fields drop in declaration order, so `_worker` (declared last) flushes the stdout writer
+    // after everything else, including OTEL shutdown.
+    _otel: Option<OtelGuard>,
+    _worker: tracing_appender::non_blocking::WorkerGuard,
+}
+
 /// Default [`tracing`] initialization for the rollup node.
-/// Returns optional [`OtelGuard`] which should be held through the lifetime of the caller,
-/// so traces and logs are exported in that time.
-pub fn initialize_logging() -> Option<OtelGuard> {
+/// Returns a [`LoggingGuard`] which must be held through the lifetime of the caller, so logs keep
+/// being written and traces/logs exported during that time. Dropping it stops logging.
+pub fn initialize_logging() -> LoggingGuard {
     let env_filter = env::var("RUST_LOG").unwrap_or_else(|_| default_rust_log_value().to_string());
 
     let otel: Option<OtelGuard> = if should_init_open_telemetry_exporter() {
@@ -44,20 +55,16 @@ pub fn initialize_logging() -> Option<OtelGuard> {
 
     let get_env_filter = || EnvFilter::from_str(&env_filter).unwrap();
 
-    // Route stdout through a non-blocking, lossy, bounded writer so a slow or backpressuring
-    // stdout consumer can never block tokio worker threads.
-    // With the default blocking `std::io::stdout()` writer, a log-storm `lossy(true)`
-    // (also the default, but set explicitly because it is load-bearing: `lossy(false)`
-    // would re-introduce the blocking) drops lines when the buffer is full rather
-    // than blocking. The node logs for its whole lifetime, so we keep the writer's worker thread
-    // alive by leaking the guard; this deliberately keeps the return type unchanged, since it is
-    // consumed (often unbound) at many call sites.
-    // Trade-off: the last buffered lines may not flush on an abrupt exit.
+    // Route stdout through a non-blocking, lossy, bounded writer so a slow or backpressuring stdout
+    // consumer can never block tokio worker threads. With the default blocking `std::io::stdout()`
+    // writer, a log-storm. `lossy(true)` (also the default,
+    // but set explicitly because it is load-bearing: `lossy(false)` would re-introduce the blocking)
+    // drops lines when the buffer is full instead of blocking. `worker_guard` is returned in the
+    // `LoggingGuard` so the writer thread lives for the process and flushes on graceful shutdown.
     let (non_blocking, worker_guard) =
         tracing_appender::non_blocking::NonBlockingBuilder::default()
             .lossy(true)
             .finish(std::io::stdout());
-    std::mem::forget(worker_guard);
 
     let mut layers = fmt::layer()
         .with_writer(non_blocking)
@@ -90,7 +97,11 @@ pub fn initialize_logging() -> Option<OtelGuard> {
 
     log_info_about_logging(&env_filter);
     set_tracing_panic_hook();
-    otel
+
+    LoggingGuard {
+        _otel: otel,
+        _worker: worker_guard,
+    }
 }
 
 /// A good default for [`EnvFilter`] when `RUST_LOG` is not set.

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -45,15 +45,18 @@ pub fn initialize_logging() -> Option<OtelGuard> {
     let get_env_filter = || EnvFilter::from_str(&env_filter).unwrap();
 
     // Route stdout through a non-blocking, lossy, bounded writer so a slow or backpressuring
-    // stdout consumer can never block tokio worker threads. With the default blocking
-    // `std::io::stdout()` writer, a log-storm (e.g. the per-retry warnings emitted by every DA
-    // task during a Celestia outage) makes workers block mid-poll inside `write(2)`, which
-    // freezes the entire runtime — including DA-independent tasks like the heartbeat (incident
-    // 2026-06). The node logs for its whole lifetime, so we keep the writer's worker thread
+    // stdout consumer can never block tokio worker threads.
+    // With the default blocking `std::io::stdout()` writer, a log-storm `lossy(true)`
+    // (also the default, but set explicitly because it is load-bearing: `lossy(false)`
+    // would re-introduce the blocking) drops lines when the buffer is full rather
+    // than blocking. The node logs for its whole lifetime, so we keep the writer's worker thread
     // alive by leaking the guard; this deliberately keeps the return type unchanged, since it is
-    // consumed (often unbound) at many call sites. Trade-off: the last buffered lines may not
-    // flush on an abrupt exit.
-    let (non_blocking, worker_guard) = tracing_appender::non_blocking(std::io::stdout());
+    // consumed (often unbound) at many call sites.
+    // Trade-off: the last buffered lines may not flush on an abrupt exit.
+    let (non_blocking, worker_guard) =
+        tracing_appender::non_blocking::NonBlockingBuilder::default()
+            .lossy(true)
+            .finish(std::io::stdout());
     std::mem::forget(worker_guard);
 
     let mut layers = fmt::layer()

--- a/crates/utils/sov-test-utils/src/lib.rs
+++ b/crates/utils/sov-test-utils/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 pub use generators::MessageGenerator;
 pub use interface::*;
+pub use logging::initialize_logging;
 pub use rt_agnostic_blueprint::{
     AdditionalSequencerApis, NoAdditionalApis, ParallelProverFactory, ProverFactory,
     RtAgnosticBlueprint, RtAgnosticBlueprintWithApis,
@@ -28,7 +29,6 @@ use sov_modules_api::{
     Amount, BasicGasMeter, CryptoSpec, Gas, GasArray, KernelStateValue, Spec, StateCheckpoint,
 };
 pub use sov_modules_api::{EncodeCall, TxProcessingError, TxReceiptContents};
-pub use sov_modules_rollup_blueprint::logging::initialize_logging;
 pub use sov_modules_stf_blueprint::get_gas_used;
 use sov_modules_stf_blueprint::{BatchReceipt, StfBlueprint};
 use sov_rollup_interface::common::SlotNumber;

--- a/crates/utils/sov-test-utils/src/logging.rs
+++ b/crates/utils/sov-test-utils/src/logging.rs
@@ -86,3 +86,13 @@ fn initialize_logging_with_filter(filter: &str) {
         tracing::warn!(%error, "Cannot init logging, already happened.");
     }
 }
+
+/// Initialize logging for tests and benchmarks.
+///
+/// Unlike the production [`sov_modules_rollup_blueprint::logging::initialize_logging`], this leaks
+/// the returned guard. Test and bench processes are short-lived and frequently call this without
+/// binding the result; leaking keeps logging alive for the whole process without forcing every call
+/// site to hold the guard. Do **not** use this in production code.
+pub fn initialize_logging() {
+    std::mem::forget(sov_modules_rollup_blueprint::logging::initialize_logging());
+}


### PR DESCRIPTION
# Description

To prevent tokio runtime from freezing all background tasks and stalling the process.

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
 

## Testing
All existing tests are passing

## Docs
No updates
