### PR TITLE
Fixing rollup_height / slot_number comments

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -40,7 +40,7 @@ pub(crate) const DB_LOCK_POISONED: &str = "Internal db lock is poisoned";
 #[derive(Default, Clone, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 pub struct ItemNumbers {
-    /// The rollup height
+    /// The slot number
     pub slot_number: SlotNumber,
     /// The batch number
     pub batch_number: u64,
@@ -631,7 +631,7 @@ impl LedgerDb {
         Ok(schema_batch)
     }
 
-    /// Get [`StoredStfInfo`] for the given rollup height.
+    /// Get [`StoredStfInfo`] for the given slot number.
     pub fn get_stf_info(&self, slot_num: SlotNumber) -> anyhow::Result<Option<StoredStfInfo>> {
         let db = self.db.read().expect(DB_LOCK_POISONED).clone();
         db.get::<StfInfoByNumber>(&slot_num)

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -315,7 +315,7 @@ impl<S: Spec> ChainState<S> {
         Ok(visible_slot_number)
     }
 
-    /// Returns transition height in the current slot
+    /// Sets the visible slot number to use for the next block.
     pub fn set_next_visible_slot_number(
         &mut self,
         next_visible_slot_number: VisibleSlotNumber,

--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -417,14 +417,14 @@ impl<S: Spec, T> ProofProcessor<S> for StandardProvenRollupCapabilities<'_, S, T
     fn process_challenge<ST: TxState<S> + GetGasPrice<Spec = S>>(
         &mut self,
         proof: sov_rollup_interface::optimistic::SerializedChallenge,
-        rollup_height: SlotNumber,
+        slot_number: SlotNumber,
         prover_address: &<S as Spec>::Address,
         state: &mut ST,
     ) -> Result<SovStateTransitionPublicData<S>, InvalidProofError> {
         let result = self.attester_incentives.process_challenge(
             prover_address,
             &proof,
-            rollup_height,
+            slot_number,
             state,
         )?;
 

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/proof.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/proof.rs
@@ -58,7 +58,7 @@ pub trait ProofProcessor<S: Spec> {
     fn process_challenge<ST: TxState<S> + GetGasPrice<Spec = S>>(
         &mut self,
         proof: SerializedChallenge,
-        rollup_height: SlotNumber,
+        slot_number: SlotNumber,
         prover_address: &S::Address,
         state: &mut ST,
     ) -> anyhow::Result<SovStateTransitionPublicData<S>, InvalidProofError>;

--- a/crates/rollup-interface/src/node/ledger_api.rs
+++ b/crates/rollup-interface/src/node/ledger_api.rs
@@ -189,7 +189,7 @@ impl From<IncludeChildren> for QueryMode {
     bound = "B: Serialize + DeserializeOwned, Tx: TxReceiptContents, E: Serialize + DeserializeOwned"
 )]
 pub struct SlotResponse<B, Tx: TxReceiptContents, E> {
-    /// The rollup height.
+    /// The slot number.
     pub number: u64,
     /// The hex encoded slot hash.
     #[serde(with = "hex_string_serde")]
@@ -225,7 +225,7 @@ pub struct BatchResponse<B, Tx: TxReceiptContents, E> {
     /// The custom receipt specified by the rollup. This typically contains
     /// information about the outcome of the batch.
     pub receipt: B,
-    /// The rollup height this batch belongs to.
+    /// The slot number this batch belongs to.
     pub slot_number: SlotNumber,
 }
 
@@ -264,9 +264,9 @@ pub enum ItemOrHash<T> {
 /// An RPC response for the latest aggregated proof info.
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProofInfoResponse {
-    /// Initial rollup height
+    /// The initial slot number.
     pub initial_slot_number: u64,
-    /// Final rollup height.
+    /// The final slot number.
     pub final_slot_number: u64,
 }
 
@@ -293,10 +293,10 @@ pub trait LedgerStateProvider {
     /// The error type for fallible methods on this trait.
     type Error: std::fmt::Display + Send + Sync + 'static;
 
-    /// Get the latest rollup height in the ledger.
+    /// Get the latest slot number in the ledger.
     async fn get_head_slot_number(&self) -> Result<SlotNumber, Self::Error>;
 
-    /// Get the latest rollup height in the ledger.
+    /// Get the latest finalized slot number in the ledger.
     async fn get_latest_finalized_slot_number(&self) -> Result<SlotNumber, Self::Error>;
 
     /// Get the latest slot in the ledger.
@@ -543,7 +543,7 @@ pub trait LedgerStateProvider {
         T: TxReceiptContents,
         E: for<'a> TryFrom<(u64, &'a StoredEvent), Error = anyhow::Error> + Send + Sync;
 
-    /// Resolve a [`SlotIdentifier`] into a rollup height.
+    /// Resolve a [`SlotIdentifier`] into a slot number.
     async fn resolve_slot_identifier(
         &self,
         slot_id: &SlotIdentifier,


### PR DESCRIPTION
# Description

Fixes comments and docstrings where rollup height and slot number are mixed up

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates