### PR TITLE
Add rollup height websocket subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-06-10
+- #2960 Chain state: Adds a WebSocket subscription streaming the current rollup height. New endpoint `GET /modules/chain-state/rollup-height/ws` sends the current rollup height (`current_heights.0`) on connection and a new value each time the height advances.
+
 # 2026-06-08
 - #2953 Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-06-10
-- #2960 Chain state: Adds a WebSocket subscription streaming the current rollup height. New endpoint `GET /modules/chain-state/rollup-height/ws` sends the current rollup height (`current_heights.0`) on connection and a new value each time the height advances.
+- #2960 Chain state: Adds a WebSocket subscription streaming the current rollup height. New endpoint `GET /modules/chain-state/rollup-height/ws` sends the current rollup height (`current_heights.0`) on connection, then every subsequent height in order as the rollup height advances (heights are never skipped or repeated).
 - #2959 **Breaking Change** Ledger API: renames the `rollup_height` field to `slot_number` in the WebSocket slot-events subscription message (`SlotEvents`); the value was always a slot number, not a rollup height. Mirrors the #2886 `BatchResponse` rename.
 
 # 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2026-06-10
 - #2960 Chain state: Adds a WebSocket subscription streaming the current rollup height. New endpoint `GET /modules/chain-state/rollup-height/ws` sends the current rollup height (`current_heights.0`) on connection, then every subsequent height in order as the rollup height advances (heights are never skipped or repeated).
+- #2960 **Breaking Change** Module REST API: `ApiState::build` now requires a node shutdown receiver (`watch::Receiver<()>`), exposed to handlers via the new `ApiState::shutdown_receiver()`. This gives module custom REST APIs (e.g. WebSocket subscriptions) a real graceful-shutdown signal instead of each handler faking one.
 - #2959 **Breaking Change** Ledger API: renames the `rollup_height` field to `slot_number` in the WebSocket slot-events subscription message (`SlotEvents`); the value was always a slot number, not a rollup height. Mirrors the #2886 `BatchResponse` rename.
 
 # 2026-06-08

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11439,6 +11439,7 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tracing",
  "tracing-panic",
  "tracing-subscriber 0.3.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11261,6 +11261,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "futures",
  "schemars 1.2.1",
  "serde",
  "sov-bank",

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -83,7 +83,10 @@ where
 
         let tx_status_manager = TxStatusManager::default();
 
-        let (api_state, checkpoint_sender) = Self::api_state(latest_state_update.storage.clone());
+        let (api_state, checkpoint_sender) = Self::api_state(
+            latest_state_update.storage.clone(),
+            shutdown_sender.subscribe(),
+        );
 
         let (blobs_sender_channel, _) = broadcast::channel(preferred_config.events_channel_size);
 
@@ -335,6 +338,7 @@ where
 
     fn api_state(
         storage: S::Storage,
+        shutdown_receiver: watch::Receiver<()>,
     ) -> (
         ApiState<S>,
         watch::Sender<Arc<ConcurrentStateCheckpoint<S>>>,
@@ -355,6 +359,7 @@ where
             checkpoint_receiver,
             runtime.kernel_with_slot_mapping(),
             None,
+            shutdown_receiver,
         );
         (api_state, checkpoint_sender)
     }

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -154,6 +154,7 @@ where
             checkpoint_receiver,
             kernel_with_slot_mapping,
             None,
+            shutdown_receiver.clone(),
         );
 
         let txsm = TxStatusManager::default();

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -49,6 +49,7 @@ pub struct TestStatelessSequencer<R, S: Spec, Da: DaService> {
     tx_status_manager: TxStatusManager<S::Da>,
     _r: PhantomData<R>,
     state_sender: watch::Sender<Arc<ConcurrentStateCheckpoint<S>>>,
+    shutdown_receiver: watch::Receiver<()>,
     api_ledger_db: LedgerDb,
 }
 
@@ -104,6 +105,7 @@ where
             tx_status_manager,
             _r: Default::default(),
             state_sender,
+            shutdown_receiver: shutdown_receiver.clone(),
             api_ledger_db: ledger_db.clone(),
         };
 
@@ -199,6 +201,7 @@ where
             self.state_sender.subscribe(),
             runtime.kernel_with_slot_mapping(),
             None,
+            self.shutdown_receiver.clone(),
         )
     }
 

--- a/crates/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true }
 tracing = { workspace = true }
+futures = { workspace = true, optional = true }
 
 sov-modules-api = { workspace = true }
 sov-rollup-interface = { workspace = true }
@@ -40,6 +41,7 @@ sov-bank = { workspace = true, features = ["test-utils"] }
 default = []
 test-utils = []
 native = [
+	"dep:futures",
 	"sov-chain-state/native",
 	"sov-mock-da/native",
 	"sov-mock-zkvm/native",

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -55,15 +55,6 @@ impl<S: Spec> ChainState<S> {
         use futures::StreamExt;
 
         ws.on_upgrade(move |socket| async move {
-            // No shutdown receiver is plumbed through to module custom REST APIs, so we
-            // keep a local sender alive for the lifetime of the connection: the helper's
-            // shutdown arm then never fires, and the task instead terminates on client
-            // disconnect, ping timeout, or stream end. Stream end covers node shutdown:
-            // dropping the checkpoint sender makes `changed()` return `Err`, ending the
-            // stream.
-            let (_shutdown_tx, shutdown_rx) =
-                sov_modules_api::prelude::tokio::sync::watch::channel(());
-
             let stream = futures::stream::unfold(
                 (
                     state.checkpoint_receiver(),
@@ -105,7 +96,7 @@ impl<S: Spec> ChainState<S> {
             sov_modules_api::rest::utils::serve_generic_ws_subscription(
                 socket,
                 stream,
-                shutdown_rx,
+                state.shutdown_receiver(),
             )
             .await;
         })

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -43,9 +43,10 @@ impl<S: Spec> ChainState<S> {
     }
 
     /// WebSocket handler that streams the current [`RollupHeight`] to the client: the
-    /// latest height is sent on connection, and a new value is pushed every time the
-    /// rollup height advances (deduplicated, since the underlying checkpoint updates
-    /// once per slot but the rollup height only advances when a block is produced).
+    /// latest height is sent on connection, then every subsequent height is pushed in
+    /// order as the rollup height advances. Heights are never skipped or repeated:
+    /// checkpoint updates that don't advance the height are ignored, and a height jump
+    /// is streamed one value at a time.
     #[cfg(feature = "native")]
     async fn subscribe_rollup_height(
         state: ApiState<S, Self>,
@@ -79,7 +80,7 @@ impl<S: Spec> ChainState<S> {
                                 latest_seen =
                                     (height_to_send < latest_height).then_some(latest_height);
                                 return Some((
-                                    Ok::<_, RollupHeightWsError>(height_to_send),
+                                    Ok::<_, std::convert::Infallible>(height_to_send),
                                     (checkpoint_rx, last_sent, latest_seen),
                                 ));
                             }
@@ -96,7 +97,6 @@ impl<S: Spec> ChainState<S> {
                         // is equivalent to reading it from state.
                         let height = checkpoint_rx.borrow().rollup_height_to_access();
                         latest_seen = Some(height);
-                        // Height unchanged: wait for the next checkpoint update.
                     }
                 },
             )
@@ -109,20 +109,6 @@ impl<S: Spec> ChainState<S> {
             )
             .await;
         })
-    }
-}
-
-/// Uninhabited error for the rollup-height subscription stream. Reading the height
-/// from the current checkpoint is infallible, so this is never constructed; it exists
-/// only to satisfy the `ReportableWsError` bound of `serve_generic_ws_subscription`.
-#[cfg(feature = "native")]
-#[derive(Debug)]
-enum RollupHeightWsError {}
-
-#[cfg(feature = "native")]
-impl sov_modules_api::rest::utils::errors::ReportableWsError for RollupHeightWsError {
-    fn to_json(&self) -> String {
-        match *self {}
     }
 }
 
@@ -157,16 +143,16 @@ mod tests {
     #[test]
     fn rollup_height_subscription_sends_initial_latest_only() {
         assert_eq!(
-            Some(RollupHeight::new(7)),
-            next_unsent_rollup_height(None, RollupHeight::new(7))
+            next_unsent_rollup_height(None, RollupHeight::new(7)),
+            Some(RollupHeight::new(7))
         );
     }
 
     #[test]
     fn rollup_height_subscription_ignores_unchanged_height() {
         assert_eq!(
-            None,
-            next_unsent_rollup_height(Some(RollupHeight::new(7)), RollupHeight::new(7))
+            next_unsent_rollup_height(Some(RollupHeight::new(7)), RollupHeight::new(7)),
+            None
         );
     }
 
@@ -182,12 +168,12 @@ mod tests {
         }
 
         assert_eq!(
+            emitted_heights,
             vec![
                 RollupHeight::new(8),
                 RollupHeight::new(9),
                 RollupHeight::new(10)
-            ],
-            emitted_heights
+            ]
         );
     }
 }

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -67,39 +67,36 @@ impl<S: Spec> ChainState<S> {
                 (
                     state.checkpoint_receiver(),
                     Option::<RollupHeight>::None,
-                    false,
+                    Option::<RollupHeight>::None,
                 ),
-                move |(mut checkpoint_rx, mut last_sent, started)| {
-                    let state = state.clone();
-                    async move {
-                        loop {
-                            // Skip the wait on the first iteration so the client receives
-                            // the current height immediately on connection.
-                            if started && checkpoint_rx.changed().await.is_err() {
-                                return None;
-                            }
-
-                            let mut accessor = match state.build_api_state_accessor(None) {
-                                Ok(accessor) => accessor,
-                                Err(error) => {
-                                    tracing::debug!(
-                                        ?error,
-                                        "Failed to build API state accessor; ending rollup height subscription"
-                                    );
-                                    return None;
-                                }
-                            };
-                            let height = state.rollup_height(&mut accessor).unwrap_infallible();
-
-                            if last_sent != Some(height) {
-                                last_sent = Some(height);
+                |(mut checkpoint_rx, mut last_sent, mut latest_seen)| async move {
+                    loop {
+                        if let Some(latest_height) = latest_seen.take() {
+                            if let Some(height_to_send) =
+                                next_unsent_rollup_height(last_sent, latest_height)
+                            {
+                                last_sent = Some(height_to_send);
+                                latest_seen =
+                                    (height_to_send < latest_height).then_some(latest_height);
                                 return Some((
-                                    Ok::<_, RollupHeightWsError>(height),
-                                    (checkpoint_rx, last_sent, true),
+                                    Ok::<_, RollupHeightWsError>(height_to_send),
+                                    (checkpoint_rx, last_sent, latest_seen),
                                 ));
                             }
-                            // Height unchanged: wait for the next checkpoint update.
                         }
+
+                        // Skip the wait before the first send so the client receives
+                        // the current height immediately on connection.
+                        if last_sent.is_some() && checkpoint_rx.changed().await.is_err() {
+                            return None;
+                        }
+
+                        // The height is fixed at checkpoint creation (`current_heights.0`
+                        // is only written at slot boundaries), so reading the watch value
+                        // is equivalent to reading it from state.
+                        let height = checkpoint_rx.borrow().rollup_height_to_access();
+                        latest_seen = Some(height);
+                        // Height unchanged: wait for the next checkpoint update.
                     }
                 },
             )
@@ -116,8 +113,8 @@ impl<S: Spec> ChainState<S> {
 }
 
 /// Uninhabited error for the rollup-height subscription stream. Reading the height
-/// from in-memory state is infallible, so this is never constructed; it exists only to
-/// satisfy the `ReportableWsError` bound of `serve_generic_ws_subscription`.
+/// from the current checkpoint is infallible, so this is never constructed; it exists
+/// only to satisfy the `ReportableWsError` bound of `serve_generic_ws_subscription`.
 #[cfg(feature = "native")]
 #[derive(Debug)]
 enum RollupHeightWsError {}
@@ -130,6 +127,18 @@ impl sov_modules_api::rest::utils::errors::ReportableWsError for RollupHeightWsE
 }
 
 #[cfg(feature = "native")]
+fn next_unsent_rollup_height(
+    last_sent: Option<RollupHeight>,
+    latest_height: RollupHeight,
+) -> Option<RollupHeight> {
+    match last_sent {
+        None => Some(latest_height),
+        Some(last_sent) if last_sent < latest_height => last_sent.checked_add(1),
+        Some(_) => None,
+    }
+}
+
+#[cfg(feature = "native")]
 impl<S: Spec> HasCustomRestApi for ChainState<S> {
     type Spec = S;
 
@@ -138,5 +147,47 @@ impl<S: Spec> HasCustomRestApi for ChainState<S> {
             .route("/setup-mode-is-active", get(Self::is_in_setup_mode_handler))
             .route("/rollup-height/ws", get(Self::subscribe_rollup_height))
             .with_state(state.with(self.clone()))
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rollup_height_subscription_sends_initial_latest_only() {
+        assert_eq!(
+            Some(RollupHeight::new(7)),
+            next_unsent_rollup_height(None, RollupHeight::new(7))
+        );
+    }
+
+    #[test]
+    fn rollup_height_subscription_ignores_unchanged_height() {
+        assert_eq!(
+            None,
+            next_unsent_rollup_height(Some(RollupHeight::new(7)), RollupHeight::new(7))
+        );
+    }
+
+    #[test]
+    fn rollup_height_subscription_fills_gap_one_height_at_a_time() {
+        let latest_height = RollupHeight::new(10);
+        let mut last_sent = Some(RollupHeight::new(7));
+        let mut emitted_heights = Vec::new();
+
+        while let Some(height_to_send) = next_unsent_rollup_height(last_sent, latest_height) {
+            emitted_heights.push(height_to_send);
+            last_sent = Some(height_to_send);
+        }
+
+        assert_eq!(
+            vec![
+                RollupHeight::new(8),
+                RollupHeight::new(9),
+                RollupHeight::new(10)
+            ],
+            emitted_heights
+        );
     }
 }

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -81,7 +81,13 @@ impl<S: Spec> ChainState<S> {
 
                             let mut accessor = match state.build_api_state_accessor(None) {
                                 Ok(accessor) => accessor,
-                                Err(_) => return None,
+                                Err(error) => {
+                                    tracing::debug!(
+                                        ?error,
+                                        "Failed to build API state accessor; ending rollup height subscription"
+                                    );
+                                    return None;
+                                }
                             };
                             let height = state.rollup_height(&mut accessor).unwrap_infallible();
 

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -11,7 +11,7 @@ use sov_modules_api::{
     ApiStateAccessor,
 };
 #[cfg(feature = "native")]
-use sov_rollup_interface::common::VisibleSlotNumber;
+use sov_rollup_interface::common::{RollupHeight, VisibleSlotNumber};
 
 use crate::ChainState;
 
@@ -41,6 +41,86 @@ impl<S: Spec> ChainState<S> {
             .unwrap_infallible()
             .into())
     }
+
+    /// WebSocket handler that streams the current [`RollupHeight`] to the client: the
+    /// latest height is sent on connection, and a new value is pushed every time the
+    /// rollup height advances (deduplicated, since the underlying checkpoint updates
+    /// once per slot but the rollup height only advances when a block is produced).
+    #[cfg(feature = "native")]
+    async fn subscribe_rollup_height(
+        state: ApiState<S, Self>,
+        ws: axum::extract::ws::WebSocketUpgrade,
+    ) -> axum::response::Response {
+        use futures::StreamExt;
+
+        ws.on_upgrade(move |socket| async move {
+            // No shutdown receiver is plumbed through to module custom REST APIs, so we
+            // keep a local sender alive for the lifetime of the connection: the helper's
+            // shutdown arm then never fires, and the task instead terminates on client
+            // disconnect, ping timeout, or stream end. Stream end covers node shutdown:
+            // dropping the checkpoint sender makes `changed()` return `Err`, ending the
+            // stream.
+            let (_shutdown_tx, shutdown_rx) =
+                sov_modules_api::prelude::tokio::sync::watch::channel(());
+
+            let stream = futures::stream::unfold(
+                (
+                    state.checkpoint_receiver(),
+                    Option::<RollupHeight>::None,
+                    false,
+                ),
+                move |(mut checkpoint_rx, mut last_sent, started)| {
+                    let state = state.clone();
+                    async move {
+                        loop {
+                            // Skip the wait on the first iteration so the client receives
+                            // the current height immediately on connection.
+                            if started && checkpoint_rx.changed().await.is_err() {
+                                return None;
+                            }
+
+                            let mut accessor = match state.build_api_state_accessor(None) {
+                                Ok(accessor) => accessor,
+                                Err(_) => return None,
+                            };
+                            let height = state.rollup_height(&mut accessor).unwrap_infallible();
+
+                            if last_sent != Some(height) {
+                                last_sent = Some(height);
+                                return Some((
+                                    Ok::<_, RollupHeightWsError>(height),
+                                    (checkpoint_rx, last_sent, true),
+                                ));
+                            }
+                            // Height unchanged: wait for the next checkpoint update.
+                        }
+                    }
+                },
+            )
+            .boxed();
+
+            sov_modules_api::rest::utils::serve_generic_ws_subscription(
+                socket,
+                stream,
+                shutdown_rx,
+            )
+            .await;
+        })
+    }
+}
+
+/// Uninhabited error for the rollup-height subscription stream. Reading the height
+/// from in-memory state is infallible, so this is never constructed; it exists only to
+/// satisfy the `ReportableWsError` bound of `serve_generic_ws_subscription`.
+#[cfg(feature = "native")]
+#[derive(Debug)]
+enum RollupHeightWsError {}
+
+#[cfg(feature = "native")]
+impl sov_modules_api::rest::utils::errors::ReportableWsError for RollupHeightWsError {
+    fn to_json(&self) -> String {
+        match *self {}
+    }
 }
 
 #[cfg(feature = "native")]
@@ -50,6 +130,7 @@ impl<S: Spec> HasCustomRestApi for ChainState<S> {
     fn custom_rest_api(&self, state: ApiState<S>) -> axum::Router<()> {
         axum::Router::new()
             .route("/setup-mode-is-active", get(Self::is_in_setup_mode_handler))
+            .route("/rollup-height/ws", get(Self::subscribe_rollup_height))
             .with_state(state.with(self.clone()))
     }
 }

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -176,6 +176,9 @@ pub struct ApiState<S: Spec, T = ()> {
     kernel: Arc<dyn KernelWithSlotMapping<S>>,
     /// The `height` query parameter extracted from the request, when applicable.
     requested_height: Option<HeightParam>,
+    /// Signals node shutdown so long-lived handlers (e.g. WebSocket subscriptions)
+    /// can terminate gracefully.
+    shutdown_receiver: watch::Receiver<()>,
 }
 
 impl<S: Spec, T> ApiState<S, T> {
@@ -186,12 +189,14 @@ impl<S: Spec, T> ApiState<S, T> {
         checkpoint_receiver: watch::Receiver<Arc<ConcurrentStateCheckpoint<S>>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         requested_height: Option<HeightParam>,
+        shutdown_receiver: watch::Receiver<()>,
     ) -> Self {
         Self {
             inner,
             checkpoint_receiver,
             kernel,
             requested_height,
+            shutdown_receiver,
         }
     }
 
@@ -202,6 +207,7 @@ impl<S: Spec, T> ApiState<S, T> {
             checkpoint_receiver: self.checkpoint_receiver,
             kernel: self.kernel,
             requested_height: self.requested_height,
+            shutdown_receiver: self.shutdown_receiver,
         }
     }
 
@@ -284,6 +290,12 @@ impl<S: Spec, T> ApiState<S, T> {
     /// Returns the checkpoint receiver.
     pub fn checkpoint_receiver(&self) -> watch::Receiver<Arc<ConcurrentStateCheckpoint<S>>> {
         self.checkpoint_receiver.clone()
+    }
+
+    /// Returns a receiver that is notified on node shutdown. Long-lived handlers
+    /// (e.g. WebSocket subscriptions) should select on it to terminate gracefully.
+    pub fn shutdown_receiver(&self) -> watch::Receiver<()> {
+        self.shutdown_receiver.clone()
     }
 }
 

--- a/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
@@ -139,11 +139,13 @@ async fn rest_api_routes() {
             StateCheckpoint::new(storage, &MockKernel::<TestSpec>::default()),
         )));
     let runtime = MyRuntime::<TestSpec>::default();
+    let (_shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
     let state = ApiState::build(
         Arc::new(()),
         receiver,
         Arc::new(MockKernel::default()),
         None,
+        shutdown_receiver,
     );
 
     let router = runtime.rest_api(state);

--- a/crates/utils/sov-rest-utils/src/errors.rs
+++ b/crates/utils/sov-rest-utils/src/errors.rs
@@ -19,6 +19,14 @@ pub trait ReportableWsError: std::fmt::Debug + Sized + Send + Sync + 'static {
     }
 }
 
+/// Lets infallible subscription streams (`Result<T, Infallible>`) be served without
+/// each caller defining its own uninhabited error type.
+impl ReportableWsError for std::convert::Infallible {
+    fn to_json(&self) -> String {
+        match *self {}
+    }
+}
+
 /// A 404 response useful as a [`axum::Router::fallback`].
 pub async fn global_404(OriginalUri(uri): OriginalUri) -> Response {
     ErrorObject {

--- a/crates/utils/sov-test-utils/src/runtime/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/mod.rs
@@ -178,6 +178,9 @@ pub struct TestRunner<
     checkpoint_sender: watch::Sender<Arc<ConcurrentStateCheckpoint<S>>>,
     /// The corresponding receiving end of the channel.
     checkpoint_receiver: watch::Receiver<Arc<ConcurrentStateCheckpoint<S>>>,
+    /// Held for the runner's lifetime so REST API handlers only observe shutdown
+    /// when the runner is dropped.
+    shutdown_sender: watch::Sender<()>,
     axum_server: axum_server::Handle<std::net::SocketAddr>,
     /// Test runner configuration.
     pub config: RunnerConfig<S::Da>,
@@ -512,6 +515,7 @@ where
             axum_server: Default::default(),
             checkpoint_sender: sender,
             checkpoint_receiver: receiver,
+            shutdown_sender: watch::channel(()).0,
             config,
         };
 
@@ -899,6 +903,7 @@ where
             self.checkpoint_receiver.clone(),
             self.runtime().kernel_with_slot_mapping(),
             None,
+            self.shutdown_sender.subscribe(),
         );
 
         let router = self.runtime().rest_api(state);

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -116,6 +116,7 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-tungstenite = { workspace = true, features = ["connect"] }
 tracing-subscriber = { workspace = true }
 rand = { workspace = true }
 

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -330,6 +330,84 @@ async fn check_historical_data(client: &demo_stf_json_client::Client) -> anyhow:
     Ok(())
 }
 
+/// The chain-state module exposes a WebSocket subscription that streams the current
+/// rollup height (`current_heights.0`): the latest value on connection, then a new value
+/// each time the height advances.
+#[tokio::test(flavor = "multi_thread")]
+async fn chain_state_rollup_height_subscription_streams_live_height() -> anyhow::Result<()> {
+    let test_rollup = RollupBuilder::<MockDemoRollup<Native>>::new(
+        test_genesis_source(OperatingMode::Zk),
+        TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
+        0,
+    )
+    .enable_prover()
+    .start()
+    .await?;
+
+    // Warm up so the sequencer starts advancing the rollup height (mirrors `setup`).
+    test_rollup.da_service.produce_n_blocks_now(5).await?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let mut height_sub = test_rollup
+        .client
+        .client
+        .subscribe_to_ws::<u64>("/modules/chain-state/rollup-height/ws")
+        .await?;
+
+    // The current rollup height is pushed immediately on connection.
+    let first = tokio::time::timeout(Duration::from_secs(10), height_sub.next())
+        .await
+        .context("timed out waiting for the initial rollup height")?
+        .context("subscription closed before sending the initial rollup height")??;
+
+    // Submit a transaction and produce more blocks to advance the chain (mirrors `setup`).
+    let key_and_address = read_private_key::<TestSpec>("tx_signer_private_key.json");
+    let msg = RuntimeCall::<TestSpec>::SyntheticLoad(
+        sov_synthetic_load::CallMessage::ReadAndSetHeavyState {
+            number_of_new_values: 10,
+            max_heavy_state_size: 30,
+            salt: 10_000,
+        },
+    );
+    let tx = default_test_signed_transaction_with_nonce::<Runtime<TestSpec>, TestSpec>(
+        &key_and_address.private_key,
+        &msg,
+        0,
+        &CHAIN_HASH,
+    );
+    test_rollup.client.client.send_tx_to_sequencer(&tx).await?;
+    test_rollup.da_service.produce_n_blocks_now(3).await?;
+
+    // The subscription must push strictly greater rollup heights as the chain advances.
+    let mut latest = first;
+    while latest <= first {
+        let next = tokio::time::timeout(Duration::from_secs(10), height_sub.next())
+            .await
+            .context("timed out waiting for the rollup height to advance")?
+            .context("subscription closed before the rollup height advanced")??;
+        assert!(
+            next >= latest,
+            "rollup height stream must be monotonic non-decreasing, got {next} after {latest}"
+        );
+        latest = next;
+    }
+
+    // The streamed value is the chain-state rollup height (`current_heights.0`): it tracks
+    // committed state and is never ahead of it. Re-read via REST as a race-free bound.
+    let current_heights = test_rollup
+        .client
+        .query_rest_endpoint::<ValueResponse>("/modules/chain-state/state/current-heights")
+        .await
+        .context("querying chain-state current-heights")?;
+    assert!(
+        latest <= current_heights.value[0],
+        "streamed rollup height {latest} must not exceed chain-state current_heights.0 ({})",
+        current_heights.value[0]
+    );
+
+    Ok(())
+}
+
 fn check_not_found_error(
     credential_id_response: demo_stf_json_client::Error<RuntimeError>,
     expected_title: &str,

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -66,19 +66,21 @@ async fn trailing_slashes_handled() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Starts a rollup and warms it up so the sequencer begins advancing the rollup height.
+/// Starts a rollup and warms it up so the sequencer is synced and ready to accept
+/// transactions. No prover is needed (these tests assert nothing about proofs), and the
+/// sequencer's state root consistency checks stay enabled: without proof blobs the
+/// sequencer and node state roots cannot diverge, so any mismatch is a real bug worth
+/// failing the test for.
 async fn start_warm_rollup() -> anyhow::Result<TestRollup<MockDemoRollup<Native>>> {
     let test_rollup = RollupBuilder::<MockDemoRollup<Native>>::new(
         test_genesis_source(OperatingMode::Zk),
         TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
         0,
     )
-    .enable_prover()
     .start()
     .await?;
 
-    test_rollup.da_service.produce_n_blocks_now(5).await?;
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    test_rollup.produce_enough_finalized_slots().await;
 
     Ok(test_rollup)
 }

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -11,8 +11,9 @@ use sov_bank::config_gas_token_id;
 use sov_cli::wallet_state::PrivateKeyAndAddress;
 use sov_demo_rollup::MockDemoRollup;
 use sov_modules_api::execution_mode::Native;
+use sov_modules_api::transaction::Transaction;
 use sov_modules_api::OperatingMode;
-use sov_test_utils::test_rollup::{read_private_key, RollupBuilder};
+use sov_test_utils::test_rollup::{read_private_key, RollupBuilder, TestRollup};
 use sov_test_utils::{
     default_test_signed_transaction_with_nonce, TEST_DEFAULT_MOCK_DA_ON_SUBMIT,
     TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
@@ -65,7 +66,8 @@ async fn trailing_slashes_handled() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn setup() -> anyhow::Result<demo_stf_json_client::Client> {
+/// Starts a rollup and warms it up so the sequencer begins advancing the rollup height.
+async fn start_warm_rollup() -> anyhow::Result<TestRollup<MockDemoRollup<Native>>> {
     let test_rollup = RollupBuilder::<MockDemoRollup<Native>>::new(
         test_genesis_source(OperatingMode::Zk),
         TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
@@ -78,6 +80,10 @@ async fn setup() -> anyhow::Result<demo_stf_json_client::Client> {
     test_rollup.da_service.produce_n_blocks_now(5).await?;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
+    Ok(test_rollup)
+}
+
+fn synthetic_load_tx() -> Transaction<Runtime<TestSpec>, TestSpec> {
     // Based on an assumption that this key is admin in sov-value-setter
     let key_and_address = read_private_key::<TestSpec>("tx_signer_private_key.json");
     let msg = RuntimeCall::<TestSpec>::SyntheticLoad(
@@ -88,12 +94,18 @@ async fn setup() -> anyhow::Result<demo_stf_json_client::Client> {
         },
     );
 
-    let tx = default_test_signed_transaction_with_nonce::<Runtime<TestSpec>, TestSpec>(
+    default_test_signed_transaction_with_nonce::<Runtime<TestSpec>, TestSpec>(
         &key_and_address.private_key,
         &msg,
         0,
         &CHAIN_HASH,
-    );
+    )
+}
+
+async fn setup() -> anyhow::Result<demo_stf_json_client::Client> {
+    let test_rollup = start_warm_rollup().await?;
+
+    let tx = synthetic_load_tx();
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await?;
     test_rollup.client.client.send_tx_to_sequencer(&tx).await?;
     slot_subscription.next().await;
@@ -335,18 +347,7 @@ async fn check_historical_data(client: &demo_stf_json_client::Client) -> anyhow:
 /// each time the height advances.
 #[tokio::test(flavor = "multi_thread")]
 async fn chain_state_rollup_height_subscription_streams_live_height() -> anyhow::Result<()> {
-    let test_rollup = RollupBuilder::<MockDemoRollup<Native>>::new(
-        test_genesis_source(OperatingMode::Zk),
-        TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
-        0,
-    )
-    .enable_prover()
-    .start()
-    .await?;
-
-    // Warm up so the sequencer starts advancing the rollup height (mirrors `setup`).
-    test_rollup.da_service.produce_n_blocks_now(5).await?;
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    let test_rollup = start_warm_rollup().await?;
 
     let mut height_sub = test_rollup
         .client
@@ -360,37 +361,22 @@ async fn chain_state_rollup_height_subscription_streams_live_height() -> anyhow:
         .context("timed out waiting for the initial rollup height")?
         .context("subscription closed before sending the initial rollup height")??;
 
-    // Submit a transaction and produce more blocks to advance the chain (mirrors `setup`).
-    let key_and_address = read_private_key::<TestSpec>("tx_signer_private_key.json");
-    let msg = RuntimeCall::<TestSpec>::SyntheticLoad(
-        sov_synthetic_load::CallMessage::ReadAndSetHeavyState {
-            number_of_new_values: 10,
-            max_heavy_state_size: 30,
-            salt: 10_000,
-        },
-    );
-    let tx = default_test_signed_transaction_with_nonce::<Runtime<TestSpec>, TestSpec>(
-        &key_and_address.private_key,
-        &msg,
-        0,
-        &CHAIN_HASH,
-    );
+    // Submit a transaction and produce more blocks to advance the chain.
+    let tx = synthetic_load_tx();
     test_rollup.client.client.send_tx_to_sequencer(&tx).await?;
     test_rollup.da_service.produce_n_blocks_now(3).await?;
 
-    // The subscription must push strictly greater rollup heights as the chain advances.
-    let mut latest = first;
-    while latest <= first {
-        let next = tokio::time::timeout(Duration::from_secs(10), height_sub.next())
-            .await
-            .context("timed out waiting for the rollup height to advance")?
-            .context("subscription closed before the rollup height advanced")??;
-        assert!(
-            next >= latest,
-            "rollup height stream must be monotonic non-decreasing, got {next} after {latest}"
-        );
-        latest = next;
-    }
+    // Heights are pushed in order without skips or repeats, so the first push after the
+    // chain advances must be exactly the next height.
+    let next = tokio::time::timeout(Duration::from_secs(10), height_sub.next())
+        .await
+        .context("timed out waiting for the rollup height to advance")?
+        .context("subscription closed before the rollup height advanced")??;
+    assert_eq!(
+        next,
+        first + 1,
+        "subscription must push consecutive rollup heights, got {next} after {first}"
+    );
 
     // The streamed value is the chain-state rollup height (`current_heights.0`): it tracks
     // committed state and is never ahead of it. Re-read via REST as a race-free bound.
@@ -400,8 +386,8 @@ async fn chain_state_rollup_height_subscription_streams_live_height() -> anyhow:
         .await
         .context("querying chain-state current-heights")?;
     assert!(
-        latest <= current_heights.value[0],
-        "streamed rollup height {latest} must not exceed chain-state current_heights.0 ({})",
+        next <= current_heights.value[0],
+        "streamed rollup height {next} must not exceed chain-state current_heights.0 ({})",
         current_heights.value[0]
     );
 

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use demo_stf::runtime::{Runtime, RuntimeCall};
 use demo_stf_json_client::types::RuntimeError;
 use demo_stf_json_client::Error;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use sov_bank::config_gas_token_id;
 use sov_cli::wallet_state::PrivateKeyAndAddress;
@@ -392,6 +392,84 @@ async fn chain_state_rollup_height_subscription_streams_live_height() -> anyhow:
         "streamed rollup height {next} must not exceed chain-state current_heights.0 ({})",
         current_heights.value[0]
     );
+
+    Ok(())
+}
+
+/// Opens a websocket subscription to `path` and keeps it actively engaged from a
+/// background task: pings the server every 100ms, replies to server pings, and drains
+/// pushed data frames. Returns once the server has answered a first ping, proving the
+/// subscription is live. The task exits when the connection is closed.
+async fn spawn_active_ws_subscription(
+    base_url: &str,
+    path: &str,
+) -> anyhow::Result<tokio::task::JoinHandle<()>> {
+    use tokio_tungstenite::tungstenite::{Bytes, Message};
+
+    let url = format!("{base_url}{path}").replace("http://", "ws://");
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await?;
+
+    // One ping/pong roundtrip before returning: proves the server-side subscription
+    // loop is actually serving this connection.
+    ws.send(Message::Ping(Bytes::new())).await?;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws.next().await {
+                Some(Ok(Message::Pong(_))) => break Ok(()),
+                // Skip data frames, e.g. the initial rollup-height push.
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => break Err(anyhow::Error::from(e)),
+                None => break Err(anyhow::anyhow!("ws closed before the first pong")),
+            }
+        }
+    })
+    .await
+    .context("server did not answer the first ping")??;
+
+    Ok(tokio::spawn(async move {
+        let mut ping_interval = tokio::time::interval(Duration::from_millis(100));
+        loop {
+            tokio::select! {
+                _ = ping_interval.tick() => {
+                    if ws.send(Message::Ping(Bytes::new())).await.is_err() {
+                        break; // The connection is closed.
+                    }
+                }
+                msg = ws.next() => match msg {
+                    Some(Ok(Message::Ping(data))) => {
+                        // A send failure means the connection is closing; the next
+                        // poll of the socket breaks the loop.
+                        let _ = ws.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
+                    Some(Ok(_)) => {} // Drain data frames.
+                },
+            }
+        }
+    }))
+}
+
+/// The node must shut down cleanly while a websocket subscription is open and
+/// actively exchanging ping/pong traffic.
+#[tokio::test(flavor = "multi_thread")]
+async fn rollup_shuts_down_cleanly_with_active_ws_subscription() -> anyhow::Result<()> {
+    let test_rollup = start_warm_rollup().await?;
+
+    let ws_task = spawn_active_ws_subscription(
+        &test_rollup.client.base_url,
+        "/modules/chain-state/rollup-height/ws",
+    )
+    .await?;
+
+    // The open, actively pinging subscription must not block shutdown.
+    tokio::time::timeout(Duration::from_secs(3), test_rollup.shutdown())
+        .await
+        .context("rollup did not shut down within 3s while a ws subscription was open")??;
+
+    // Clean shutdown closes the connection, which ends the background task.
+    tokio::time::timeout(Duration::from_secs(3), ws_task)
+        .await
+        .context("server did not close the ws connection on shutdown")??;
 
     Ok(())
 }


### PR DESCRIPTION
# Description

So it can be used by sov-rollup-manager for more precise detection of the height instead of polling


Adds shutdown receiver watch channel to API state.

## Follow up

Potential optimization can be done for waking up subscription only when rollup height changed, instead of on every accept tx

Current path:

- The WS stream waits on checkpoint_rx.changed() in:
  https://github.com/Sovereign-Labs/sovereign-sdk/blob/19b33b6a222e68a715acc9e3ce73fe6477a8d299/crates/module-system/module-implementations/sov-chain-state/src/query.rs#L82-L84
- Preferred sequencer sends checkpoint notifications for accepted tx changes even when rollup height is unchanged:
  https://github.com/Sovereign-Labs/sovereign-sdk/blob/26e6a0bbf2779488c3b0f65485b74da303f6b152/crates/full-node/sov-sequencer/src/preferred/side_effects.rs#L195-L200
- The subscription then borrows the checkpoint, sees the same height, and emits nothing.

So with N connected height subscribers and U accepted-tx checkpoint notifications/sec, you can get about N * U useless async wakeups/sec. For a few clients this is noise. For many dashboards/indexers, or a busy preferred sequencer, this becomes avoidable executor churn on the same node that is handling tx intake.

----

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2341

## Testing
New tests are added

## Docs
Docstrings are provided
