### PR TITLE
Remove confusing or unused methods of SlotNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2026-06-10
 - #2959 **Breaking Change** Ledger API: renames the `rollup_height` field to `slot_number` in the WebSocket slot-events subscription message (`SlotEvents`); the value was always a slot number, not a rollup height. Mirrors the #2886 `BatchResponse` rename.
+- #PR_NUMBER **Breaking Change** `sov-rollup-interface`: removes the unchecked slot-number coercions `SlotNumber::new_dangerous` (use `SlotNumber::new`), `SlotNumber::as_visible`, `RollupHeight::to_slot_number`, and `IntoSlotNumber::to_visible_slot_number`. These were stateless `u64` reinterpretations with no validation; cross-type conversion between slot numbers, visible slot numbers, and rollup heights must go through the `KernelWithSlotMapping` kernel capability instead.
 
 # 2026-06-08
 - #2953 Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2026-06-10
 - #2959 **Breaking Change** Ledger API: renames the `rollup_height` field to `slot_number` in the WebSocket slot-events subscription message (`SlotEvents`); the value was always a slot number, not a rollup height. Mirrors the #2886 `BatchResponse` rename.
-- #PR_NUMBER **Breaking Change** `sov-rollup-interface`: removes the unchecked slot-number coercions `SlotNumber::new_dangerous` (use `SlotNumber::new`), `SlotNumber::as_visible`, `RollupHeight::to_slot_number`, and `IntoSlotNumber::to_visible_slot_number`. These were stateless `u64` reinterpretations with no validation; cross-type conversion between slot numbers, visible slot numbers, and rollup heights must go through the `KernelWithSlotMapping` kernel capability instead.
+- #2963 **Breaking Change** `sov-rollup-interface`: removes the unchecked slot-number coercions `SlotNumber::new_dangerous` (use `SlotNumber::new`), `SlotNumber::as_visible`, `RollupHeight::to_slot_number`, and `IntoSlotNumber::to_visible_slot_number`. These were stateless `u64` reinterpretations with no validation; cross-type conversion between slot numbers, visible slot numbers, and rollup heights must go through the `KernelWithSlotMapping` kernel capability instead.
 
 # 2026-06-08
 - #2953 Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -915,7 +915,7 @@ impl LedgerStateProvider for LedgerDb {
             MAX_SLOTS_PER_REQUEST
         );
         let ids: Vec<_> = (start.get()..=end.get())
-            .map(|x| SlotIdentifier::Number(SlotNumber::new_dangerous(x)))
+            .map(|x| SlotIdentifier::Number(SlotNumber::new(x)))
             .collect();
         self.get_slots(&ids, query_mode).await
     }

--- a/crates/full-node/sov-db/src/schema/tables.rs
+++ b/crates/full-node/sov-db/src/schema/tables.rs
@@ -346,7 +346,7 @@ impl KeyDecoder<ModuleAccessoryState> for (AccessoryKey, SlotNumber) {
         let mut cursor = std::io::Cursor::new(data);
         let key = Vec::<u8>::deserialize_reader(&mut cursor)?;
         let version = cursor.read_u64::<BigEndian>()?;
-        Ok((key, SlotNumber::new_dangerous(version)))
+        Ok((key, SlotNumber::new(version)))
     }
 }
 
@@ -395,7 +395,7 @@ impl KeyDecoder<AccessoryKeysByVersion> for (SlotNumber, AccessoryKey) {
         let mut cursor = std::io::Cursor::new(data);
         let version = cursor.read_u64::<BigEndian>()?;
         let key = Vec::<u8>::deserialize_reader(&mut cursor)?;
-        Ok((SlotNumber::new_dangerous(version), key))
+        Ok((SlotNumber::new(version), key))
     }
 }
 

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -516,9 +516,7 @@ where
         next: Next,
     ) -> Result<Response, Response> {
         let identifier = match get_path_item(&path_values, "slotId")? {
-            NumberOrHash::Number(number) => {
-                SlotIdentifier::Number(SlotNumber::new_dangerous(number))
-            }
+            NumberOrHash::Number(number) => SlotIdentifier::Number(SlotNumber::new(number)),
             NumberOrHash::Hash(hash) => SlotIdentifier::Hash(hash.0),
         };
 

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -832,7 +832,7 @@ mod tests {
                 sequencer_storages: Vec::new(),
                 uncommitted_changes: uncommitted_changes.clone(),
                 rollup_height: RollupHeight::new(((idx + 1) / 2) as u64),
-                slot_number: SlotNumber::new_dangerous(idx as u64),
+                slot_number: SlotNumber::new(idx as u64),
             });
         }
 

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -145,12 +145,12 @@ impl<
 
     /// Get the next height to receive as a `SlotNumber`.
     pub fn next_height_to_receive(&self) -> SlotNumber {
-        SlotNumber::new_dangerous(self.next_height_to_receive.load(Ordering::SeqCst))
+        SlotNumber::new(self.next_height_to_receive.load(Ordering::SeqCst))
     }
 
     /// Increment next height to receive by one, returning the previous value.
     pub fn inc_next_height_to_receive(&self) -> SlotNumber {
-        SlotNumber::new_dangerous(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
+        SlotNumber::new(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
     }
 }
 
@@ -460,17 +460,17 @@ where
 
     /// Get the next height to receive as a `SlotNumber`.
     pub fn next_height_to_receive(&self) -> SlotNumber {
-        SlotNumber::new_dangerous(self.next_height_to_receive.load(Ordering::SeqCst))
+        SlotNumber::new(self.next_height_to_receive.load(Ordering::SeqCst))
     }
 
     /// Increment next height to receive by one, returning the previous value.
     pub fn inc_next_height_to_receive(&self) -> SlotNumber {
-        SlotNumber::new_dangerous(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
+        SlotNumber::new(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
     }
 
     /// Increment next height to receive by the requested amount, returning the previous value.
     pub fn inc_next_height_to_receive_by(&self, amount: u64) -> SlotNumber {
-        SlotNumber::new_dangerous(
+        SlotNumber::new(
             self.next_height_to_receive
                 .fetch_add(amount, Ordering::SeqCst),
         )
@@ -505,7 +505,7 @@ pub struct CursorHandle {
 impl CursorHandle {
     /// Increment next height to receive by the requested amount, returning the previous value.
     pub fn inc_next_height_to_receive_by(&self, amount: u64) -> SlotNumber {
-        SlotNumber::new_dangerous(
+        SlotNumber::new(
             self.next_height_to_receive
                 .fetch_add(amount, Ordering::SeqCst),
         )
@@ -899,7 +899,7 @@ mod tests {
             // Check if the old STF infos are pruned.
             for height in 1..test_case.nb_of_stf_infos {
                 let stf_info: Option<StateTransitionInfo<Vec<u8>, Vec<u8>, MockDaSpec>> =
-                    receiver.get(SlotNumber::new_dangerous(height))?;
+                    receiver.get(SlotNumber::new(height))?;
 
                 if height < oldest_height.get() {
                     // The old data was deleted from the Db.
@@ -927,12 +927,12 @@ mod tests {
             .unwrap();
         storage_manager.commit(&schema_batch);
         sender
-            .notify(SlotNumber::new_dangerous(rollup_height), ledger_db)
+            .notify(SlotNumber::new(rollup_height), ledger_db)
             .await
             .unwrap();
 
         let fetched_stf_info = receiver
-            .get(SlotNumber::new_dangerous(rollup_height))
+            .get(SlotNumber::new(rollup_height))
             .unwrap()
             .unwrap();
 
@@ -967,7 +967,7 @@ mod tests {
                 batch_blobs: vec![],
             },
             witness: vec![],
-            slot_number: SlotNumber::new_dangerous(height),
+            slot_number: SlotNumber::new(height),
         })
     }
 

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -418,7 +418,7 @@ where
         );
 
         let last_finalized_slot_number = finalized_transitions.iter().last().map(|t| {
-            SlotNumber::new_dangerous(
+            SlotNumber::new(
                 t.block_header
                     .height()
                     .saturating_sub(self.genesis_da_height),

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn make_chained_headers(count: usize) -> Vec<MockBlockHeader> {
 fn make_transition_info(
     da_block_header: MockBlockHeader,
 ) -> StateTransitionInfo<StateRoot, Vec<u8>, MockDaSpec> {
-    let slot_number = SlotNumber::new_dangerous(da_block_header.height + 1);
+    let slot_number = SlotNumber::new(da_block_header.height + 1);
     StateTransitionInfo::new(StateTransitionWitness {
         initial_state_root: Vec::default(),
         final_state_root: Vec::default(),

--- a/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
@@ -504,14 +504,14 @@ fn assert_values_maybe_with_proof<S: NativeStorage>(
 
     let next_version = expected_values.len() as u64;
     for (idx, expected_value) in expected_values.into_iter().enumerate() {
-        let version = SlotNumber::new_dangerous(idx as u64);
+        let version = SlotNumber::new(idx as u64);
         assert_eq!(expected_value, get_value(Some(version)));
     }
 
     // Future versions are not available
     // Checking 3 more next versions for extra confidence
     for version in next_version..(next_version + 3) {
-        let version = SlotNumber::new_dangerous(version);
+        let version = SlotNumber::new(version);
 
         assert_eq!(
             None,
@@ -546,11 +546,11 @@ fn assert_root_hashes<S: NativeStorage>(storage: &S, expected_root_hashes: Vec<S
         assert_eq!(
             expected_root_hash,
             storage
-                .get_root_hash(SlotNumber::new_dangerous(version as u64))
+                .get_root_hash(SlotNumber::new(version as u64))
                 .unwrap()
         );
     }
-    let future_root = storage.get_root_hash(SlotNumber::new_dangerous(next_version));
+    let future_root = storage.get_root_hash(SlotNumber::new(next_version));
     assert_eq!(
         future_root, None,
         "future and uncommitted versions must return None (mirrors get_historical's Option semantics)"

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/challenger.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/challenger.rs
@@ -152,11 +152,7 @@ fn test_valid_challenge() -> Result<(), Infallible> {
 
     let challenge_proof = runner
         .query_visible_state(|state| {
-            build_challenge(
-                state,
-                SlotNumber::new_dangerous(1),
-                bonded_challenger_address,
-            )
+            build_challenge(state, SlotNumber::new(1), bonded_challenger_address)
         })
         .unwrap();
 
@@ -170,7 +166,7 @@ fn test_valid_challenge() -> Result<(), Infallible> {
         input: ProofInput(make_challenge_blob(
             challenge_proof,
             true,
-            SlotNumber::new_dangerous(1),
+            SlotNumber::new(1),
         )),
         assert: Box::new(move |result, state| {
             assert_eq!(
@@ -265,11 +261,7 @@ fn test_invalid_challenge_initial_state_root() {
 
     let mut challenge_proof = runner
         .query_visible_state(|state| {
-            build_challenge(
-                state,
-                SlotNumber::new_dangerous(1),
-                bonded_challenger_address,
-            )
+            build_challenge(state, SlotNumber::new(1), bonded_challenger_address)
         })
         .unwrap();
 
@@ -279,7 +271,7 @@ fn test_invalid_challenge_initial_state_root() {
         &mut runner,
         expected_reward.0,
         &bonded_challenger,
-        make_challenge_blob(challenge_proof, true, SlotNumber::new_dangerous(1)),
+        make_challenge_blob(challenge_proof, true, SlotNumber::new(1)),
         SlashingReason::InvalidInitialHash,
     );
 }
@@ -292,11 +284,7 @@ fn test_invalid_challenge_transition() {
 
     let mut challenge_proof = runner
         .query_visible_state(|state| {
-            build_challenge(
-                state,
-                SlotNumber::new_dangerous(1),
-                bonded_challenger_address,
-            )
+            build_challenge(state, SlotNumber::new(1), bonded_challenger_address)
         })
         .unwrap();
 
@@ -306,7 +294,7 @@ fn test_invalid_challenge_transition() {
         &mut runner,
         expected_reward.0,
         &bonded_challenger,
-        make_challenge_blob(challenge_proof, true, SlotNumber::new_dangerous(1)),
+        make_challenge_blob(challenge_proof, true, SlotNumber::new(1)),
         SlashingReason::TransitionInvalid,
     );
 }
@@ -319,11 +307,7 @@ fn test_invalid_challenge_proof() {
 
     let challenge_proof = runner
         .query_visible_state(|state| {
-            build_challenge(
-                state,
-                SlotNumber::new_dangerous(1),
-                bonded_challenger_address,
-            )
+            build_challenge(state, SlotNumber::new(1), bonded_challenger_address)
         })
         .unwrap();
 
@@ -331,7 +315,7 @@ fn test_invalid_challenge_proof() {
         &mut runner,
         expected_reward.0,
         &bonded_challenger,
-        make_challenge_blob(challenge_proof, false, SlotNumber::new_dangerous(1)),
+        make_challenge_blob(challenge_proof, false, SlotNumber::new(1)),
         SlashingReason::InvalidZkProof,
     );
 }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/mod.rs
@@ -207,7 +207,7 @@ pub mod mocks {
         /// Create a new mock kernel with the given slot numbers
         pub fn new(true_slot_number: u64, visible_slot_number: u64) -> Self {
             Self {
-                true_slot_number: SlotNumber::new_dangerous(true_slot_number),
+                true_slot_number: SlotNumber::new(true_slot_number),
                 visible_slot_number: VisibleSlotNumber::new_dangerous(visible_slot_number),
                 next_sequence_number: 0,
                 phantom: core::marker::PhantomData,
@@ -228,7 +228,8 @@ pub mod mocks {
             true_slot_number: SlotNumber,
             _state: &mut crate::ApiStateAccessor<S>,
         ) -> Option<VisibleSlotNumber> {
-            Some(true_slot_number.as_visible())
+            // The mock models a based rollup, so the visible slot number equals the true one.
+            Some(VisibleSlotNumber::new_dangerous(true_slot_number.get()))
         }
 
         fn current_rollup_height(
@@ -252,7 +253,7 @@ pub mod mocks {
             height: super::RollupHeight,
             _state: &mut crate::state::ApiStateAccessor<S>,
         ) -> Option<SlotNumber> {
-            Some(SlotNumber::new_dangerous(height.get()))
+            Some(SlotNumber::new(height.get()))
         }
 
         fn base_fee_per_gas_at(
@@ -280,7 +281,7 @@ pub mod mocks {
             height: RollupHeight,
             _state: &S::Storage,
         ) -> Option<SlotNumber> {
-            Some(SlotNumber::new_dangerous(height.get()))
+            Some(SlotNumber::new(height.get()))
         }
     }
 

--- a/crates/rollup-interface/src/common/slot_numbering.rs
+++ b/crates/rollup-interface/src/common/slot_numbering.rs
@@ -46,7 +46,13 @@ impl SlotNumber {
     /// The largest possible [`SlotNumber`].
     pub const MAX: Self = Self(u64::MAX);
 
-    /// Wraps a [`u64`] into a [`SlotNumber`].
+    /// Wraps a raw [`u64`] that is already a slot number.
+    ///
+    /// The caller asserts the value really is a slot number — e.g. decoded from storage or a
+    /// ledger key, or derived from a DA height. There is no validation. To obtain a
+    /// [`SlotNumber`] from a [`RollupHeight`] or [`VisibleSlotNumber`] (which only coincide
+    /// with the slot number for a based rollup), go through the kernel's `KernelWithSlotMapping`
+    /// instead — there is no correct stateless conversion.
     pub const fn new(height: u64) -> Self {
         Self(height)
     }
@@ -86,12 +92,6 @@ impl SlotNumber {
         self.0
     }
 
-    /// Constructs a [`SlotNumber`] from a [`u64`]. This method should be used with caution,
-    /// since passing a [`SlotNumber`] that is not a valid height can lead to unexpected results.
-    pub fn new_dangerous(height: u64) -> Self {
-        Self(height)
-    }
-
     /// Calculates the difference between two [`SlotNumber`]s as a [`u64`].
     ///
     /// # Panics
@@ -128,16 +128,6 @@ impl SlotNumber {
     pub fn checked_sub(&self, rhs: u64) -> Option<Self> {
         self.0.checked_sub(rhs).map(Self)
     }
-    /// Casts this value into a [`SlotNumber`].
-    ///
-    /// <div class="warning">
-    /// This type cast is NEVER safe (as far as I can tell; I don't see edge
-    /// cases in which we'd truly want to do this). All usages of this method
-    /// should be reviewed AND removed.
-    /// </div>
-    pub fn as_visible(&self) -> VisibleSlotNumber {
-        VisibleSlotNumber::new_dangerous(self.get())
-    }
 
     /// Iterates over all [`SlotNumber`]s in the range `[self, end]`.
     pub fn range_inclusive(&self, end: Self) -> impl Iterator<Item = Self> {
@@ -150,13 +140,10 @@ impl SlotNumber {
     }
 }
 
-/// Easy initialization of [`SlotNumber`] and [`VisibleSlotNumber`].
+/// Easy initialization of [`SlotNumber`].
 pub trait IntoSlotNumber {
     /// Creates a new [`SlotNumber`].
     fn to_slot_number(self) -> SlotNumber;
-
-    /// Creates a new [`VisibleSlotNumber`].
-    fn to_visible_slot_number(self) -> VisibleSlotNumber;
 }
 
 macro_rules! impl_into_slot_number {
@@ -164,10 +151,6 @@ macro_rules! impl_into_slot_number {
         impl IntoSlotNumber for $t {
             fn to_slot_number(self) -> SlotNumber {
                 SlotNumber::new(self as _)
-            }
-
-            fn to_visible_slot_number(self) -> VisibleSlotNumber {
-                VisibleSlotNumber::new_dangerous(self as _)
             }
         }
     };
@@ -348,11 +331,5 @@ impl RollupHeight {
     #[must_use]
     pub fn saturating_add(self, rhs: u64) -> Self {
         Self(self.0.saturating_add(rhs))
-    }
-
-    /// Convert a rollup height to a slot number
-    #[must_use]
-    pub fn to_slot_number(&self) -> SlotNumber {
-        SlotNumber::new_dangerous(self.0)
     }
 }

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
@@ -153,7 +153,7 @@ fn create_test_rt_genesis_config<S: Spec>(
             minimum_attester_bond: user_stake,
             minimum_challenger_bond: user_stake,
             initial_attesters: vec![(admin, user_stake.value(S::initial_base_fee_per_gas()))],
-            rollup_finality_period: SlotNumber::new_dangerous(TEST_ROLLUP_FINALITY_PERIOD),
+            rollup_finality_period: SlotNumber::new(TEST_ROLLUP_FINALITY_PERIOD),
             maximum_attested_height: TEST_MAX_ATTESTED_HEIGHT,
             light_client_finalized_height: TEST_LIGHT_CLIENT_FINALIZED_HEIGHT,
         },


### PR DESCRIPTION
# Description

* `new` and `new_dangerous` essentially the same. `new` does not perform any extra validation and there's no guideline when it should be used.
* `as_visible` is never used and factually wrong without state (except for based rollups w/o preferred sequencer)
* `to_visible_slot_number` also not used and also can be a footgun

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
