### PR TITLE
Use blocking threads more aggressively for EVM RPC

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/estimate_gas.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/estimate_gas.rs
@@ -37,8 +37,8 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    pub async fn eth_estimate_gas(
-        parameters: JRpcParams<'static>,
+    pub fn eth_estimate_gas(
+        parameters: JRpcParams<'_>,
         ethereum: Arc<Ethereum<S, Seq>>,
         _: Extensions,
     ) -> RpcResult<U64> {

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -31,8 +31,8 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    pub async fn eth_get_logs(
-        parameters: JRpcParams<'static>,
+    pub fn eth_get_logs(
+        parameters: JRpcParams<'_>,
         ethereum: Arc<Ethereum<S, Seq>>,
         _: Extensions,
     ) -> Result<Vec<LogWithExecutionTimestamp>, ErrorObjectOwned> {
@@ -50,7 +50,7 @@ where
             state,
             ethereum.extension.response_size_limit,
         );
-        let LogsWithMaybeCursor { logs, cursor } = service.logs_for_filter().await?;
+        let LogsWithMaybeCursor { logs, cursor } = service.logs_for_filter()?;
 
         if cursor.is_some() {
             return Err(rpc_limit_exceeded(
@@ -61,8 +61,8 @@ where
         Ok(logs)
     }
 
-    pub async fn eth_get_logs_with_cursor(
-        parameters: JRpcParams<'static>,
+    pub fn eth_get_logs_with_cursor(
+        parameters: JRpcParams<'_>,
         ethereum: Arc<Ethereum<S, Seq>>,
         _: Extensions,
     ) -> Result<LogsWithMaybeCursor, ErrorObjectOwned> {
@@ -80,6 +80,6 @@ where
             state,
             ethereum.extension.response_size_limit,
         );
-        Ok(service.logs_for_filter().await?)
+        Ok(service.logs_for_filter()?)
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -117,7 +117,7 @@ where
         }
     }
 
-    pub async fn logs_for_filter(self) -> Result<LogsWithMaybeCursor> {
+    pub fn logs_for_filter(self) -> Result<LogsWithMaybeCursor> {
         match self.filter.block_option {
             FilterBlockOption::AtBlockHash(block_hash) => self.by_hash(block_hash),
             FilterBlockOption::Range {

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -133,10 +133,10 @@ where
         Handlers::realtime_send_raw_transaction,
     )?;
 
-    rpc.register_async_method("eth_estimateGas", Handlers::eth_estimate_gas)?;
+    rpc.register_blocking_method("eth_estimateGas", Handlers::eth_estimate_gas)?;
 
-    rpc.register_async_method("eth_getLogs", handlers::LogHandlers::<S, Seq>::eth_get_logs)?;
-    rpc.register_async_method(
+    rpc.register_blocking_method("eth_getLogs", handlers::LogHandlers::<S, Seq>::eth_get_logs)?;
+    rpc.register_blocking_method(
         "eth_getLogsWithCursor",
         handlers::LogHandlers::<S, Seq>::eth_get_logs_with_cursor,
     )?;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -63,7 +63,7 @@ where
     }
 
     /// Handler for `eth_getBlockByHash`
-    #[rpc_method(name = "eth_getBlockByHash")]
+    #[rpc_method(name = "eth_getBlockByHash", blocking)]
     pub fn get_block_by_hash(
         &self,
         block_hash: B256,
@@ -83,7 +83,7 @@ where
     }
 
     /// Handler for: `eth_getBlockByNumber`
-    #[rpc_method(name = "eth_getBlockByNumber")]
+    #[rpc_method(name = "eth_getBlockByNumber", blocking)]
     pub fn get_block_by_number(
         &self,
         block_id: Option<BlockId>,
@@ -235,7 +235,7 @@ where
     ///
     /// This endpoint helps wallets and users determine appropriate gas prices
     /// by exposing the rollup's EIP-1559 style base fee history.
-    #[rpc_method(name = "eth_feeHistory")]
+    #[rpc_method(name = "eth_feeHistory", blocking)]
     pub fn fee_history(
         &self,
         block_count: U64,
@@ -325,7 +325,7 @@ where
     }
 
     /// Handler for: `eth_getBlockReceipts`
-    #[rpc_method(name = "eth_getBlockReceipts")]
+    #[rpc_method(name = "eth_getBlockReceipts", blocking)]
     pub fn get_block_receipts(
         &self,
         block_id: Option<BlockId>,
@@ -376,7 +376,7 @@ where
     ///
     /// References:
     /// - Geth `doCall`: <https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go>
-    #[rpc_method(name = "eth_call")]
+    #[rpc_method(name = "eth_call", blocking)]
     pub fn eth_call(
         &self,
         request: TransactionRequest,
@@ -412,7 +412,7 @@ where
     ///
     /// See [`prepare_call_env`](crate::helpers::prepare_call_env) for the full
     /// affordability analysis and current divergence from geth.
-    #[rpc_method(name = "eth_createAccessList")]
+    #[rpc_method(name = "eth_createAccessList", blocking)]
     pub fn eth_create_access_list(
         &self,
         request: TransactionRequest,
@@ -482,7 +482,7 @@ where
     }
 
     /// Handler for `debug_traceBlockByNumber`
-    #[rpc_method(name = "debug_traceBlockByNumber")]
+    #[rpc_method(name = "debug_traceBlockByNumber", blocking)]
     pub fn debug_trace_block_by_number(
         &self,
         block: BlockNumberOrTag,
@@ -497,7 +497,7 @@ where
     }
 
     /// Handler for: `debug_traceTransaction`
-    #[rpc_method(name = "debug_traceTransaction")]
+    #[rpc_method(name = "debug_traceTransaction", blocking)]
     pub fn debug_trace_transaction(
         &self,
         tx_hash: B256,
@@ -568,8 +568,13 @@ where
             method = "eth_getBlockTransactionCountByNumber",
             "EVM module JSON-RPC request"
         );
-        let block = self.get_maybe_synthetic_block_for_rpc(block_id, false.into(), state)?;
-        Ok(block.map(|b| U64::from(b.transactions.len())))
+        let result = self
+            .get_maybe_sealed_block_by_id(block_id.unwrap_or_else(BlockId::latest), state)
+            .map(|block| {
+                block
+                    .map(|b| U64::from(b.transactions_end().saturating_sub(b.transactions_start())))
+            })?;
+        Ok(result)
     }
 
     /// Handler for: `eth_getBlockTransactionCountByHash`


### PR DESCRIPTION
# Description
This PR moves several of our Ethereum RPC methods to tokio's blocking thread pool. This should reduce the likelihood of runtime stalls under load. It also refactors eth_getBlockTransactionCountByNumber to avoid several unneeded state lookups.


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
