### PR TITLE
Clean setup up of demo-rollup tests and ensure state root checks

### DIFF
--- a/examples/demo-rollup/tests/bank/helpers.rs
+++ b/examples/demo-rollup/tests/bank/helpers.rs
@@ -283,7 +283,6 @@ pub async fn start_test_rollup(
         TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
         test_case.finalization_blocks,
     )
-    .enable_prover()
     .set_config(|c| {
         c.max_concurrent_batch_blobs = 16777216;
         c.rollup_prover_config = prover_config;

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -22,7 +22,6 @@ use sov_mock_da::BlockProducingConfig;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::Spec;
 use sov_sequencer::{SeqConfigExtension, SovRateLimiterConfig};
-use sov_stf_runner::processes::RollupProverConfig;
 use sov_test_utils::test_rollup::{RollupBuilder, TestRollup};
 
 use crate::test_helpers::test_genesis_source;
@@ -49,11 +48,9 @@ async fn start_node(
         },
         finalization_blocks,
     )
-    .enable_prover()
     .with_rate_limiter(rate_limiter)
     .set_config(|c| {
         c.max_concurrent_batch_blobs = 65536;
-        c.rollup_prover_config = RollupProverConfig::Disabled;
         c.aggregated_proof_block_jump = 5;
         c.max_infos_in_db = 30;
         c.max_channel_size = 20;
@@ -135,10 +132,8 @@ pub async fn setup_test_rollup_with_paymaster(
         },
         finalization_blocks,
     )
-    .enable_prover()
     .set_config(|c| {
         c.max_concurrent_batch_blobs = 65536;
-        c.rollup_prover_config = RollupProverConfig::Disabled;
         c.aggregated_proof_block_jump = 5;
         c.max_infos_in_db = 30;
         c.max_channel_size = 20;
@@ -167,10 +162,8 @@ pub async fn setup_test_rollup_with_selective_paymaster(
         },
         finalization_blocks,
     )
-    .enable_prover()
     .set_config(|c| {
         c.max_concurrent_batch_blobs = 65536;
-        c.rollup_prover_config = RollupProverConfig::Disabled;
         c.aggregated_proof_block_jump = 5;
         c.max_infos_in_db = 30;
         c.max_channel_size = 20;

--- a/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
+++ b/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
@@ -34,7 +34,6 @@ use sov_modules_api::{Amount, CryptoSpec, OperatingMode, RawTx, Runtime as Runti
 use sov_modules_macros::config_value;
 use sov_rollup_interface::node::da::DaService;
 use sov_sequencer::ForcedTxBatchNotification;
-use sov_stf_runner::processes::RollupProverConfig;
 use sov_synthetic_load::CallMessage as SyntheticLoadCall;
 use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::test_rollup::{read_private_key, RollupBuilder};
@@ -353,11 +352,9 @@ async fn setup_with_block_producing(
         block_producing,
         FINALIZATION_BLOCKS,
     )
-    .enable_prover()
     .set_config(|c| {
         c.max_concurrent_batch_blobs = 65536;
         c.automatic_batch_production = true;
-        c.rollup_prover_config = RollupProverConfig::Disabled;
         c.max_channel_size = 1;
         c.max_infos_in_db = 1;
         if let sov_sequencer::SequencerKindConfig::Preferred(ref mut seq) = c.sequencer_config {

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -35,7 +35,6 @@ async fn trailing_slashes_handled() -> anyhow::Result<()> {
         TEST_DEFAULT_MOCK_DA_ON_SUBMIT,
         0,
     )
-    .enable_prover()
     .with_standard_sequencer()
     .start()
     .await?;

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -19,7 +19,6 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_sequencer::SeqConfigExtension;
-use sov_stf_runner::processes::RollupProverConfig;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::{RollupBuilder, StoragePath, TestRollup};
 use std::sync::Arc;
@@ -38,14 +37,12 @@ async fn start_node(
         BlockProducingConfig::Manual,
         0,
     )
-    .enable_prover()
     .set_da_config(|da_config: &mut MockDaConfig| {
         da_config.da_layer = Some(da_layer);
     })
     .set_config(|c| {
         c.storage = StoragePath::Tmp(location);
         c.max_concurrent_batch_blobs = 65536;
-        c.rollup_prover_config = RollupProverConfig::Disabled;
         c.aggregated_proof_block_jump = 5;
         c.max_infos_in_db = 30;
         c.max_channel_size = 20;

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -17,7 +17,6 @@ use sov_full_node_configs::sequencer::SequencerKindConfig;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::{CryptoSpec, OperatingMode, RawTx, Runtime, Spec, TxHash};
 use sov_modules_rollup_blueprint::logging::default_rust_log_value;
-use sov_stf_runner::processes::RollupProverConfig;
 use sov_test_utils::logging::LogCollector;
 use sov_test_utils::test_rollup::StoragePath;
 use sov_test_utils::test_rollup::{read_private_key, RollupBuilder, TestRollup};
@@ -107,9 +106,7 @@ async fn start_rollup(
             StoragePath::Tmp(rollup_storage_path.clone()),
             false,
         )
-        .enable_prover()
         .set_config(|c| {
-            c.rollup_prover_config = RollupProverConfig::Disabled;
             c.aggregated_proof_block_jump = 10;
             c.max_concurrent_batch_blobs = 92;
             if let SequencerKindConfig::Preferred(seq_config) = &mut c.sequencer_config {


### PR DESCRIPTION
# Description

Test helpers were silently disabling a real correctness assertion. RollupBuilder::enable_prover() does two things: sets RollupProverConfig::Prove and turns off the preferred sequencer's state-root consistency check (the two genuinely conflict — replayed proof blobs diverge the speculative root). That coupling is correct for real prover tests.

The problem: several demo-rollup tests called .enable_prover() and then immediately overrode c.rollup_prover_config = RollupProverConfig::Disabled. Net effect — no prover ran, but the consistency check was silently off via enable_prover()'s side effect. Those tests were running with a real correctness assertion (the sequencer recomputes the user-state-root each slot and panics on mismatch) needlessly disabled.



- **Bucket A** (evm/evm_test_helper.rs, forced_sequencer_registration, resync, restart/crash): removed .enable_prover(), the …= Disabled override, and the now-unused RollupProverConfig import. The builder defaults (verified: prover Disabled, sequencer Preferred, checks ON) land exactly where we want — no prover, checks enabled.
- **Bucket C** (rest_api trailing_slashes_handled): removed .enable_prover() — it used a standard sequencer (checks flag is a no-op there), so it was only running a pointless prover.
- **Bucket D** (bank/helpers.rs): removed only .enable_prover() — set_config already set both fields per operating mode, so this was a no-op simplification preserving exact per-mode semantics.

Deliberately untouched: the 7 genuine-prover (**Bucket B**) sites, enable_prover() itself, and every test assertion.

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Test only cleanup 

## Docs
No updates
