### PR TITLE
Support in-place nomt bucket growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6811,8 +6811,9 @@ dependencies = [
 
 [[package]]
 name = "nomt"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a65036105486a9d88c99f95867de7e5b5d69280ef9048c10c9530a4566b3c3e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6839,17 +6840,16 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
- "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6812,8 +6812,7 @@ dependencies = [
 [[package]]
 name = "nomt"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc31b6dd2f30dc674b0bdeafbf3790eded499072eb17c79212f3dcfa31b0baf"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -6841,15 +6840,16 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "arrayvec",
  "bitvec",
+ "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,10 +213,8 @@ reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6
 rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "0aa43d4e581e047ba8d8e7a662ec6ade32b2cae3" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
-# nomt-core = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
-# nomt = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
-nomt-core = { git = "https://github.com/thrumdev/nomt.git", rev = "cf1672b2bb9e89e07f6d939f6b7e404417c3120a", features = ["borsh", "serde"] }
-nomt = { git = "https://github.com/thrumdev/nomt.git", rev = "cf1672b2bb9e89e07f6d939f6b7e404417c3120a", features = ["borsh", "serde"] }
+nomt-core = { version = "1.0.5", default-features = false, features = ["borsh", "serde"] }
+nomt = { version = "1.0.5", default-features = false, features = ["borsh", "serde"] }
 concread = { version = "0.5.7" }
 
 anyhow = { version = "1.0.95" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,8 +213,10 @@ reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6
 rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "0aa43d4e581e047ba8d8e7a662ec6ade32b2cae3" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
-nomt-core = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
-nomt = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
+# nomt-core = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
+# nomt = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
+nomt-core = { git = "https://github.com/Sovereign-Labs/nomt", rev = "c85fb01f526b9eee742bafbdc89c4a58313b249b", features = ["borsh", "serde"] }
+nomt = { git = "https://github.com/Sovereign-Labs/nomt", rev = "c85fb01f526b9eee742bafbdc89c4a58313b249b", features = ["borsh", "serde"] }
 concread = { version = "0.5.7" }
 
 anyhow = { version = "1.0.95" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,8 +215,8 @@ nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 # nomt-core = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
 # nomt = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
-nomt-core = { git = "https://github.com/Sovereign-Labs/nomt", rev = "c85fb01f526b9eee742bafbdc89c4a58313b249b", features = ["borsh", "serde"] }
-nomt = { git = "https://github.com/Sovereign-Labs/nomt", rev = "c85fb01f526b9eee742bafbdc89c4a58313b249b", features = ["borsh", "serde"] }
+nomt-core = { git = "https://github.com/thrumdev/nomt.git", rev = "cf1672b2bb9e89e07f6d939f6b7e404417c3120a", features = ["borsh", "serde"] }
+nomt = { git = "https://github.com/thrumdev/nomt.git", rev = "cf1672b2bb9e89e07f6d939f6b7e404417c3120a", features = ["borsh", "serde"] }
 concread = { version = "0.5.7" }
 
 anyhow = { version = "1.0.95" }

--- a/crates/bench/sp1-microbenches/guest-celestia/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-celestia/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
+checksum = "4f86e61ab96fbc1b7813af01e7c6d7b961b4378f1ea8393004d283a2645e0a4d"
 dependencies = [
  "bytes",
  "prost",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
+checksum = "5953f83018cece71231810e8c31fbcc754dde3c1bfeb50c56019a09875a46461"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -1273,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
+checksum = "fff132b51d68778adf4efe988f004421b4263e01ea317831b118b04a810e7c16"
 dependencies = [
  "js-sys",
 ]

--- a/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
@@ -1152,17 +1152,16 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
- "blake3",
  "borsh",
  "digest",
  "ruint",
  "serde",
- "sha2",
 ]
 
 [[package]]

--- a/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
@@ -1153,15 +1153,16 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "arrayvec",
  "bitvec",
+ "blake3",
  "borsh",
  "digest",
  "ruint",
  "serde",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/full-node/sov-db/src/config.rs
+++ b/crates/full-node/sov-db/src/config.rs
@@ -168,7 +168,7 @@ pub struct RollupDbConfig {
     /// More details at [`Options::commit_concurrency`]
     pub user_commit_concurrency: Option<usize>,
     /// Value is determined by the expected size of the state. Recommended to start with 15_000_000.
-    /// Cannot be changed for the existing database.
+    /// Can be increased for an existing database, but cannot be decreased.
     /// More details at [`Options::hashtable_buckets`]
     pub user_hashtable_buckets: Option<u32>,
     /// Sets whether to preallocate the hashtable file for user db.
@@ -188,7 +188,7 @@ pub struct RollupDbConfig {
     /// Number of concurrent commit workers for the kernel state.
     /// More details at [`Options::commit_concurrency`]
     pub kernel_commit_concurrency: Option<usize>,
-    /// Cannot be changed for the existing database.
+    /// Can be increased for an existing database, but cannot be decreased.
     /// More details at [`Options::hashtable_buckets`]
     pub kernel_hashtable_buckets: Option<u32>,
     /// Sets whether to preallocate the hashtable file for kernel db.
@@ -253,15 +253,7 @@ impl RollupDbConfig {
             self.kernel_commit_concurrency
                 .expect("`kernel_commit_concurrency` concurrency must be set"),
         );
-        if let Some(hashtable_buckets) = self.kernel_hashtable_buckets {
-            opts.hashtable_buckets(hashtable_buckets);
-        } else if cfg!(debug_assertions) {
-            // 2MB
-            opts.hashtable_buckets(500);
-        } else {
-            // 1000MB
-            opts.hashtable_buckets(self.kernel_hashtable_buckets.unwrap_or(256_000));
-        }
+        opts.hashtable_buckets(self.kernel_hashtable_buckets());
 
         if let Some(preallocate_ht) = self.kernel_preallocate_ht {
             opts.preallocate_ht(preallocate_ht);
@@ -282,6 +274,18 @@ impl RollupDbConfig {
         opts
     }
 
+    pub(crate) fn kernel_hashtable_buckets(&self) -> u32 {
+        self.kernel_hashtable_buckets.unwrap_or_else(|| {
+            if cfg!(debug_assertions) {
+                // 2MB
+                500
+            } else {
+                // 1000MB
+                256_000
+            }
+        })
+    }
+
     pub(crate) fn get_user_options(&self) -> Options {
         let mut opts = nomt_default_options();
         // Enabling rollback for user space too, to be able to sync with the historical state.
@@ -291,10 +295,7 @@ impl RollupDbConfig {
             self.user_commit_concurrency
                 .expect("`user_commit_concurrency` must be set"),
         );
-        opts.hashtable_buckets(
-            self.user_hashtable_buckets
-                .expect("`user_hashtable_buckets` must be set"),
-        );
+        opts.hashtable_buckets(self.user_hashtable_buckets());
         if let Some(preallocate_ht) = self.user_preallocate_ht {
             opts.preallocate_ht(preallocate_ht);
         }
@@ -310,6 +311,11 @@ impl RollupDbConfig {
 
         opts.path(self.path.join("user_nomt_db"));
         opts
+    }
+
+    pub(crate) fn user_hashtable_buckets(&self) -> u32 {
+        self.user_hashtable_buckets
+            .expect("`user_hashtable_buckets` must be set")
     }
 
     pub(crate) fn pruner(&self) -> PrunerConfig {

--- a/crates/full-node/sov-db/src/config.rs
+++ b/crates/full-node/sov-db/src/config.rs
@@ -275,7 +275,7 @@ impl RollupDbConfig {
     }
 
     pub(crate) fn kernel_hashtable_buckets(&self) -> u32 {
-        self.kernel_hashtable_buckets.unwrap_or_else(|| {
+        self.kernel_hashtable_buckets.unwrap_or({
             if cfg!(debug_assertions) {
                 // 2MB
                 500

--- a/crates/full-node/sov-db/src/metrics/nomt.rs
+++ b/crates/full-node/sov-db/src/metrics/nomt.rs
@@ -13,7 +13,7 @@ use sov_rollup_interface::reexports::digest;
 ///
 /// **Diagnostic signals:**
 /// - Occupancy > 0.9 → NOMT emits a warning log; hash collisions start to degrade lookups
-///   and inserts. Remediation: resync the database with a larger `hash_table_capacity`.
+///   and inserts. Remediation: increase the NOMT hashtable bucket config and restart.
 /// - `page_cache_misses / page_requests` rising → working set has outgrown the page cache.
 ///   Remediation: raise the NOMT page-cache size or add RAM.
 /// - `avg_page_fetch_time_ns` spiking while miss ratio is flat → underlying disk is saturated
@@ -43,7 +43,7 @@ impl NomtDbMetric {
             tracing::warn!(
                 %db,
                 rate = hash_table_utilization.occupancy_rate(),
-                "Occupancy rate for NOMT hashtable is too high. Please update buckets size and resync database");
+                "Occupancy rate for NOMT hashtable is too high. Please increase the configured bucket count and restart the node");
         }
         let metrics = nomt.metrics();
         Self {

--- a/crates/full-node/sov-db/src/metrics/nomt.rs
+++ b/crates/full-node/sov-db/src/metrics/nomt.rs
@@ -43,7 +43,7 @@ impl NomtDbMetric {
             tracing::warn!(
                 %db,
                 rate = hash_table_utilization.occupancy_rate(),
-                "Occupancy rate for NOMT hashtable is too high. Please increase the configured bucket count and restart the node");
+                "Occupancy rate for NOMT hashtable is too high. Please increase the configured bucket count and restart the node to resize the hashtable (note that this can take some time on the next startup).");
         }
         let metrics = nomt.metrics();
         Self {

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -6,7 +6,7 @@ use crate::config::RollupDbConfig;
 use crate::metrics::nomt::{MerklizedCommitMetric, NomtBeginSessionMetric, NomtDbMetric};
 use anyhow::Context;
 use nomt::hasher::BinaryHasher;
-use nomt::{Nomt, Overlay, SessionParams, WitnessMode};
+use nomt::{Nomt, Options, Overlay, SessionParams, WitnessMode};
 pub use rockbound::versioned_db::HistoricalValueError;
 use sov_rollup_interface::reexports::digest;
 
@@ -25,15 +25,38 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
     pub fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
         tracing::debug!(options = ?config, "Opening NOMT");
 
-        let kernel = {
-            let opts = config.get_kernel_options();
-            Nomt::<BinaryHasher<H>>::open(opts)?
-        };
+        let kernel = Nomt::<BinaryHasher<H>>::open(config.get_kernel_options())?;
+        let user = Nomt::<BinaryHasher<H>>::open(config.get_user_options())?;
 
-        let user = {
-            let opts = config.get_user_options();
-            Nomt::<BinaryHasher<H>>::open(opts)?
-        };
+        let kernel_buckets =
+            check_nomt_hashtable_buckets(KERNEL, &kernel, config.kernel_hashtable_buckets())?;
+        let user_buckets =
+            check_nomt_hashtable_buckets(USER, &user, config.user_hashtable_buckets())?;
+
+        if kernel_buckets.needs_growth() || user_buckets.needs_growth() {
+            drop(kernel);
+            drop(user);
+
+            if kernel_buckets.needs_growth() {
+                grow_nomt_hashtable(KERNEL, kernel_buckets, config.get_kernel_options())?;
+            }
+            if user_buckets.needs_growth() {
+                grow_nomt_hashtable(USER, user_buckets, config.get_user_options())?;
+            }
+
+            let kernel = open_nomt_after_hashtable_growth(
+                KERNEL,
+                config.kernel_hashtable_buckets(),
+                config.get_kernel_options(),
+            )?;
+            let user = open_nomt_after_hashtable_growth(
+                USER,
+                config.user_hashtable_buckets(),
+                config.get_user_options(),
+            )?;
+
+            return Ok(Self { user, kernel });
+        }
 
         Ok(Self { user, kernel })
     }
@@ -116,6 +139,80 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             tracker.submit(kernel_metrics);
         });
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NomtHashtableBuckets {
+    current: usize,
+    configured: usize,
+}
+
+impl NomtHashtableBuckets {
+    fn needs_growth(&self) -> bool {
+        self.current < self.configured
+    }
+}
+
+fn check_nomt_hashtable_buckets<H>(
+    db: &'static str,
+    nomt: &Nomt<BinaryHasher<H>>,
+    configured_buckets: u32,
+) -> anyhow::Result<NomtHashtableBuckets>
+where
+    H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync,
+{
+    let buckets = NomtHashtableBuckets {
+        current: nomt.hash_table_utilization().capacity,
+        configured: configured_buckets as usize,
+    };
+
+    anyhow::ensure!(
+        buckets.current <= buckets.configured,
+        "configured NOMT hashtable bucket count for {db} ({}) is smaller than the existing on-disk bucket count ({}); shrinking is not supported",
+        buckets.configured,
+        buckets.current,
+    );
+
+    Ok(buckets)
+}
+
+fn grow_nomt_hashtable(
+    db: &'static str,
+    buckets: NomtHashtableBuckets,
+    options: Options,
+) -> anyhow::Result<()> {
+    tracing::info!(
+        %db,
+        current_buckets = buckets.current,
+        configured_buckets = buckets.configured,
+        "Growing NOMT hashtable to match configured bucket count"
+    );
+
+    nomt::grow_hashtable(&options).with_context(|| {
+        format!(
+            "failed to grow NOMT hashtable for {db} from {} to {} buckets",
+            buckets.current, buckets.configured
+        )
+    })
+}
+
+fn open_nomt_after_hashtable_growth<H>(
+    db: &'static str,
+    configured_buckets: u32,
+    options: Options,
+) -> anyhow::Result<Nomt<BinaryHasher<H>>>
+where
+    H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync,
+{
+    let nomt = Nomt::<BinaryHasher<H>>::open(options)?;
+    let buckets = check_nomt_hashtable_buckets(db, &nomt, configured_buckets)?;
+    anyhow::ensure!(
+        !buckets.needs_growth(),
+        "NOMT hashtable for {db} has {} buckets after growth, expected {}",
+        buckets.current,
+        buckets.configured,
+    );
+    Ok(nomt)
 }
 
 #[derive(Debug)]
@@ -358,6 +455,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use nomt::trie::KeyPath;
     use sha2::Digest;
 
@@ -369,6 +468,77 @@ mod tests {
         let raw_data = key.to_be_bytes();
         let key_path: KeyPath = H::digest(raw_data).into();
         (key_path, Some(raw_data.to_vec()))
+    }
+
+    fn config_with_buckets(path: PathBuf, buckets: u32) -> RollupDbConfig {
+        let mut config = RollupDbConfig::default_in_path(path);
+        config.user_hashtable_buckets = Some(buckets);
+        config.kernel_hashtable_buckets = Some(buckets);
+        config
+    }
+
+    fn commit_value(state_db: &NomtStateDb<H>, key: u64) {
+        let (key_path, data) = from_key(key);
+        let writes = vec![(key_path, nomt::KeyReadWrite::Write(data))];
+
+        let user_session = state_db.user.begin_session(SessionParams::default());
+        let finished_user_session = user_session.finish(writes.clone()).unwrap();
+
+        let kernel_session = state_db.kernel.begin_session(SessionParams::default());
+        let finished_kernel_session = kernel_session.finish(writes).unwrap();
+
+        let overlay = StateFinishedSession::new(finished_user_session, finished_kernel_session)
+            .into_state_overlay();
+        state_db.commit(overlay).unwrap();
+    }
+
+    fn assert_value(state_db: &NomtStateDb<H>, key: u64) {
+        let (key_path, expected_value) = from_key(key);
+        let user_session = state_db.user.begin_session(SessionParams::default());
+        assert_eq!(user_session.read(key_path).unwrap(), expected_value);
+
+        let kernel_session = state_db.kernel.begin_session(SessionParams::default());
+        assert_eq!(kernel_session.read(key_path).unwrap(), expected_value);
+    }
+
+    #[test]
+    fn opening_existing_db_grows_hashtable_to_configured_bucket_count() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().to_path_buf();
+
+        let state_db = NomtStateDb::<H>::new(config_with_buckets(db_path.clone(), 4096)).unwrap();
+        commit_value(&state_db, 7);
+        let roots_before_growth = state_db.get_root_hashes();
+        drop(state_db);
+
+        let state_db = NomtStateDb::<H>::new(config_with_buckets(db_path, 8192)).unwrap();
+
+        assert_eq!(state_db.user.hash_table_utilization().capacity, 8192);
+        assert_eq!(state_db.kernel.hash_table_utilization().capacity, 8192);
+        assert_eq!(state_db.get_root_hashes().user, roots_before_growth.user);
+        assert_eq!(
+            state_db.get_root_hashes().kernel,
+            roots_before_growth.kernel
+        );
+        assert_value(&state_db, 7);
+    }
+
+    #[test]
+    fn opening_existing_db_rejects_smaller_configured_bucket_count() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().to_path_buf();
+
+        let state_db = NomtStateDb::<H>::new(config_with_buckets(db_path.clone(), 8192)).unwrap();
+        drop(state_db);
+
+        let err = match NomtStateDb::<H>::new(config_with_buckets(db_path, 4096)) {
+            Ok(_) => panic!("opening with fewer NOMT hashtable buckets should fail"),
+            Err(err) => err,
+        };
+        let err = format!("{err:#}");
+
+        assert!(err.contains("shrinking is not supported"), "{err}");
+        assert!(err.contains("kernel_state"), "{err}");
     }
 
     #[test]

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -367,7 +367,7 @@
           "description": "Maximum time in milliseconds without a heartbeat before a leader is considered inactive.",
           "type": "integer",
           "format": "uint64",
-          "default": 500,
+          "default": 1000,
           "minimum": 0
         }
       }
@@ -471,6 +471,15 @@
           "format": "uint32",
           "minimum": 0
         },
+        "rpc_aggregation": {
+          "description": "In-process aggregation of JSON-RPC call statistics. When the section is\nomitted, defaults are used.",
+          "$ref": "#/$defs/RpcAggregationConfig",
+          "default": {
+            "flush_interval_secs": 10,
+            "max_slow_call_points_per_window": 10,
+            "slow_call_threshold_ms": 500
+          }
+        },
         "telegraf_address": {
           "description": "A UDP or TCP socket where Telegraf has `inputs.socket_listener`, something like `udp://127.0.0.1:8094`.\nLocalhost is preferred for latency and reliability reasons.",
           "$ref": "#/$defs/TelegrafSocketConfig"
@@ -497,7 +506,7 @@
           "default": {
             "grace_period_millis": 10000,
             "heartbeat_interval_millis": 100,
-            "leader_timeout_millis": 500
+            "leader_timeout_millis": 1000
           }
         },
         "node_id": {
@@ -684,6 +693,92 @@
         "max_concurrent_proof_blobs"
       ]
     },
+    "PrunerConfig": {
+      "description": "State-version pruning policy: how (and whether) old historical versions of state keys\nare deleted.\n\nDefaults to [`PrunerConfig::Off`] (full history retained). In config files, omitting the\n`pruner` section disables pruning; otherwise select a variant, e.g.\n`[storage.pruner.periodic]` or `[storage.pruner.once_at_startup]`.",
+      "oneOf": [
+        {
+          "description": "Never prune; the node retains full history.",
+          "type": "string",
+          "const": "off"
+        },
+        {
+          "description": "Prune exactly once, synchronously, at node startup (before block processing begins),\nthen never again during this run. This performs all pruning I/O up front, when there\nis no live read/write traffic to compete with, instead of interfering on every\nfinalized block as [`PrunerConfig::Periodic`] does.",
+          "type": "object",
+          "properties": {
+            "once_at_startup": {
+              "type": "object",
+              "properties": {
+                "compact_after": {
+                  "description": "If `true`, run a full RocksDB compaction on the pruned column families after the\nstartup prune completes, dropping the resulting tombstones and reclaiming disk\nspace. This is heavy (it rewrites the affected column families) and only sensible\nfor the one-time startup prune, so it is off by default.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "max_batch_size": {
+                  "description": "Maximum number of keys deleted per internal batch. Omitting it in config falls back\nto [`default_max_pruning_batch_size`].\n\nWithin each pass the user-state pruner is served first and the kernel-state pruner\nonly gets the leftover budget, so while user state has more than `max_batch_size`\nprunable keys the kernel pruner waits for user pruning to catch up. This only adds\npasses here, since the startup prune runs to completion before block processing; the\ndisk-growth effect of this ordering is a steady-state [`PrunerConfig::Periodic`]\nconcern.",
+                  "type": "integer",
+                  "format": "uint",
+                  "default": 300000,
+                  "minimum": 1
+                },
+                "versions_to_keep": {
+                  "description": "Number of recent versions to retain for historical querying.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 1
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "versions_to_keep"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "once_at_startup"
+          ]
+        },
+        {
+          "description": "Periodically prune in the background during finalization (the historical behavior):\nroughly every `block_interval` finalized DA blocks a background pruner is spawned and\nits delete batch is committed on a subsequent finalize.",
+          "type": "object",
+          "properties": {
+            "periodic": {
+              "type": "object",
+              "properties": {
+                "block_interval": {
+                  "description": "Run the pruner roughly every `block_interval` finalized DA blocks.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0
+                },
+                "max_batch_size": {
+                  "description": "Maximum number of keys deleted per batch. Omitting it in config falls back to\n[`default_max_pruning_batch_size`].\n\nWithin each pass the user-state pruner is served first and the kernel-state pruner\nonly gets the leftover budget, so while user state has more than `max_batch_size`\nprunable keys the kernel pruner makes no progress and kernel historical state can\ngrow on disk until user pruning catches up; raising `max_batch_size` shortens that\nwindow.",
+                  "type": "integer",
+                  "format": "uint",
+                  "default": 300000,
+                  "minimum": 1
+                },
+                "versions_to_keep": {
+                  "description": "Number of recent versions to retain for historical querying.",
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 1
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "block_interval",
+                "versions_to_keep"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "periodic"
+          ]
+        }
+      ]
+    },
     "RandomizationBehaviour": {
       "description": "Defines the behavior of randomization applied to blobs or blocks.\n\nThis configurable behavior determines how blobs are processed and returned to the caller\nduring various stages of the block production process.\nRandomization may involve reordering, shuffling, skipping, or altering the chain's length,\nwhile preserving certain constraints such as finality.",
       "oneOf": [
@@ -860,7 +955,7 @@
           "minimum": 0
         },
         "kernel_hashtable_buckets": {
-          "description": "Can be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Cannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"
@@ -913,32 +1008,10 @@
           "description": "Path where all databases are stored",
           "type": "string"
         },
-        "pruner_block_interval": {
-          "description": "Pruner\nDefines how often pruner is going to be started.\nMeasure by DA blocks.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0
-        },
-        "pruner_max_batch_size": {
-          "description": "Maximum number of keys to prune in a single batch.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
-        },
-        "pruner_versions_to_keep": {
-          "description": "These many versions will be available for historical querying.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0
+        "pruner": {
+          "description": "State-version pruning policy. Defaults to [`PrunerConfig::Off`] (full history\nretained) when omitted from config.\n\nThe struct uses `#[serde(deny_unknown_fields)]`, so the deprecated flat\n`pruner_block_interval` / `pruner_versions_to_keep` / `pruner_max_batch_size` keys (and any\nother unknown key) are rejected at parse time rather than silently ignored.",
+          "$ref": "#/$defs/PrunerConfig",
+          "default": "off"
         },
         "state_cache_size": {
           "description": "The size of the cache which holds hot key-value pairs in the flat state database. Default is 1 GiB.\nA larger cache size can improve execution speed at the cost of more memory usage.",
@@ -959,7 +1032,7 @@
           "minimum": 0
         },
         "user_hashtable_buckets": {
-          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCan be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"
@@ -1002,6 +1075,7 @@
           ]
         }
       },
+      "additionalProperties": false,
       "required": [
         "path"
       ]
@@ -1011,6 +1085,33 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0
+    },
+    "RpcAggregationConfig": {
+      "description": "Configuration for in-process aggregation of JSON-RPC call statistics.",
+      "type": "object",
+      "properties": {
+        "flush_interval_secs": {
+          "description": "How often aggregated RPC statistics are flushed to the metrics server,\nin seconds. One point per `(method, transport)` pair is emitted per\nwindow, and only for pairs that saw traffic.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 10,
+          "minimum": 0
+        },
+        "max_slow_call_points_per_window": {
+          "description": "Maximum number of individual slow-call points emitted per flush window,\nso that a flood of slow queries degrades to \"the aggregate shows many\nslow calls\" instead of crowding out other metrics.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 10,
+          "minimum": 0
+        },
+        "slow_call_threshold_ms": {
+          "description": "Calls at least this slow emit an individual metric point (subject to\n`max_slow_call_points_per_window`) and a debug-level log line with the\nrequest parameters.",
+          "type": "integer",
+          "format": "uint64",
+          "default": 500,
+          "minimum": 0
+        }
+      }
     },
     "RunnerConfig": {
       "description": "Configuration for StateTransitionRunner.",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -955,7 +955,7 @@
           "minimum": 0
         },
         "kernel_hashtable_buckets": {
-          "description": "Cannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Can be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"
@@ -1032,7 +1032,7 @@
           "minimum": 0
         },
         "user_hashtable_buckets": {
-          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCan be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -367,7 +367,7 @@
           "description": "Maximum time in milliseconds without a heartbeat before a leader is considered inactive.",
           "type": "integer",
           "format": "uint64",
-          "default": 1000,
+          "default": 500,
           "minimum": 0
         }
       }
@@ -471,15 +471,6 @@
           "format": "uint32",
           "minimum": 0
         },
-        "rpc_aggregation": {
-          "description": "In-process aggregation of JSON-RPC call statistics. When the section is\nomitted, defaults are used.",
-          "$ref": "#/$defs/RpcAggregationConfig",
-          "default": {
-            "flush_interval_secs": 10,
-            "max_slow_call_points_per_window": 10,
-            "slow_call_threshold_ms": 500
-          }
-        },
         "telegraf_address": {
           "description": "A UDP or TCP socket where Telegraf has `inputs.socket_listener`, something like `udp://127.0.0.1:8094`.\nLocalhost is preferred for latency and reliability reasons.",
           "$ref": "#/$defs/TelegrafSocketConfig"
@@ -506,7 +497,7 @@
           "default": {
             "grace_period_millis": 10000,
             "heartbeat_interval_millis": 100,
-            "leader_timeout_millis": 1000
+            "leader_timeout_millis": 500
           }
         },
         "node_id": {
@@ -693,92 +684,6 @@
         "max_concurrent_proof_blobs"
       ]
     },
-    "PrunerConfig": {
-      "description": "State-version pruning policy: how (and whether) old historical versions of state keys\nare deleted.\n\nDefaults to [`PrunerConfig::Off`] (full history retained). In config files, omitting the\n`pruner` section disables pruning; otherwise select a variant, e.g.\n`[storage.pruner.periodic]` or `[storage.pruner.once_at_startup]`.",
-      "oneOf": [
-        {
-          "description": "Never prune; the node retains full history.",
-          "type": "string",
-          "const": "off"
-        },
-        {
-          "description": "Prune exactly once, synchronously, at node startup (before block processing begins),\nthen never again during this run. This performs all pruning I/O up front, when there\nis no live read/write traffic to compete with, instead of interfering on every\nfinalized block as [`PrunerConfig::Periodic`] does.",
-          "type": "object",
-          "properties": {
-            "once_at_startup": {
-              "type": "object",
-              "properties": {
-                "compact_after": {
-                  "description": "If `true`, run a full RocksDB compaction on the pruned column families after the\nstartup prune completes, dropping the resulting tombstones and reclaiming disk\nspace. This is heavy (it rewrites the affected column families) and only sensible\nfor the one-time startup prune, so it is off by default.",
-                  "type": "boolean",
-                  "default": false
-                },
-                "max_batch_size": {
-                  "description": "Maximum number of keys deleted per internal batch. Omitting it in config falls back\nto [`default_max_pruning_batch_size`].\n\nWithin each pass the user-state pruner is served first and the kernel-state pruner\nonly gets the leftover budget, so while user state has more than `max_batch_size`\nprunable keys the kernel pruner waits for user pruning to catch up. This only adds\npasses here, since the startup prune runs to completion before block processing; the\ndisk-growth effect of this ordering is a steady-state [`PrunerConfig::Periodic`]\nconcern.",
-                  "type": "integer",
-                  "format": "uint",
-                  "default": 300000,
-                  "minimum": 1
-                },
-                "versions_to_keep": {
-                  "description": "Number of recent versions to retain for historical querying.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 1
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "versions_to_keep"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "once_at_startup"
-          ]
-        },
-        {
-          "description": "Periodically prune in the background during finalization (the historical behavior):\nroughly every `block_interval` finalized DA blocks a background pruner is spawned and\nits delete batch is committed on a subsequent finalize.",
-          "type": "object",
-          "properties": {
-            "periodic": {
-              "type": "object",
-              "properties": {
-                "block_interval": {
-                  "description": "Run the pruner roughly every `block_interval` finalized DA blocks.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 0
-                },
-                "max_batch_size": {
-                  "description": "Maximum number of keys deleted per batch. Omitting it in config falls back to\n[`default_max_pruning_batch_size`].\n\nWithin each pass the user-state pruner is served first and the kernel-state pruner\nonly gets the leftover budget, so while user state has more than `max_batch_size`\nprunable keys the kernel pruner makes no progress and kernel historical state can\ngrow on disk until user pruning catches up; raising `max_batch_size` shortens that\nwindow.",
-                  "type": "integer",
-                  "format": "uint",
-                  "default": 300000,
-                  "minimum": 1
-                },
-                "versions_to_keep": {
-                  "description": "Number of recent versions to retain for historical querying.",
-                  "type": "integer",
-                  "format": "uint64",
-                  "minimum": 1
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "block_interval",
-                "versions_to_keep"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "periodic"
-          ]
-        }
-      ]
-    },
     "RandomizationBehaviour": {
       "description": "Defines the behavior of randomization applied to blobs or blocks.\n\nThis configurable behavior determines how blobs are processed and returned to the caller\nduring various stages of the block production process.\nRandomization may involve reordering, shuffling, skipping, or altering the chain's length,\nwhile preserving certain constraints such as finality.",
       "oneOf": [
@@ -955,7 +860,7 @@
           "minimum": 0
         },
         "kernel_hashtable_buckets": {
-          "description": "Cannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Can be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"
@@ -1008,10 +913,32 @@
           "description": "Path where all databases are stored",
           "type": "string"
         },
-        "pruner": {
-          "description": "State-version pruning policy. Defaults to [`PrunerConfig::Off`] (full history\nretained) when omitted from config.\n\nThe struct uses `#[serde(deny_unknown_fields)]`, so the deprecated flat\n`pruner_block_interval` / `pruner_versions_to_keep` / `pruner_max_batch_size` keys (and any\nother unknown key) are rejected at parse time rather than silently ignored.",
-          "$ref": "#/$defs/PrunerConfig",
-          "default": "off"
+        "pruner_block_interval": {
+          "description": "Pruner\nDefines how often pruner is going to be started.\nMeasure by DA blocks.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "pruner_max_batch_size": {
+          "description": "Maximum number of keys to prune in a single batch.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "pruner_versions_to_keep": {
+          "description": "These many versions will be available for historical querying.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
         },
         "state_cache_size": {
           "description": "The size of the cache which holds hot key-value pairs in the flat state database. Default is 1 GiB.\nA larger cache size can improve execution speed at the cost of more memory usage.",
@@ -1032,7 +959,7 @@
           "minimum": 0
         },
         "user_hashtable_buckets": {
-          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCannot be changed for the existing database.\nMore details at [`Options::hashtable_buckets`]",
+          "description": "Value is determined by the expected size of the state. Recommended to start with 15_000_000.\nCan be increased for an existing database, but cannot be decreased.\nMore details at [`Options::hashtable_buckets`]",
           "type": [
             "integer",
             "null"
@@ -1075,7 +1002,6 @@
           ]
         }
       },
-      "additionalProperties": false,
       "required": [
         "path"
       ]
@@ -1085,33 +1011,6 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0
-    },
-    "RpcAggregationConfig": {
-      "description": "Configuration for in-process aggregation of JSON-RPC call statistics.",
-      "type": "object",
-      "properties": {
-        "flush_interval_secs": {
-          "description": "How often aggregated RPC statistics are flushed to the metrics server,\nin seconds. One point per `(method, transport)` pair is emitted per\nwindow, and only for pairs that saw traffic.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 10,
-          "minimum": 0
-        },
-        "max_slow_call_points_per_window": {
-          "description": "Maximum number of individual slow-call points emitted per flush window,\nso that a flood of slow queries degrades to \"the aggregate shows many\nslow calls\" instead of crowding out other metrics.",
-          "type": "integer",
-          "format": "uint32",
-          "default": 10,
-          "minimum": 0
-        },
-        "slow_call_threshold_ms": {
-          "description": "Calls at least this slow emit an individual metric point (subject to\n`max_slow_call_points_per_window`) and a debug-level log line with the\nrequest parameters.",
-          "type": "integer",
-          "format": "uint64",
-          "default": 500,
-          "minimum": 0
-        }
-      }
     },
     "RunnerConfig": {
       "description": "Configuration for StateTransitionRunner.",

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -777,6 +777,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1065,6 +1079,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -1130,6 +1150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,7 +1213,7 @@ version = "4.1.3"
 source = "git+https://github.com/risc0/curve25519-dalek?tag=curve25519-4.1.3-risczero.0#385adda1fa3b66d9aaa8b8fcc99ddc324d33ba32"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "crypto-bigint",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2246,7 +2275,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2494,15 +2523,16 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nomt-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "arrayvec",
  "bitvec",
+ "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3967,7 +3997,7 @@ source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.9.9-risczer
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -3978,7 +4008,7 @@ version = "0.10.9"
 source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.9-risczero.0#8631fabdea7bdffa97b11868e04e73491d8e5bcf"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -777,20 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
+checksum = "4f86e61ab96fbc1b7813af01e7c6d7b961b4378f1ea8393004d283a2645e0a4d"
 dependencies = [
  "bytes",
  "prost",
@@ -961,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
+checksum = "5953f83018cece71231810e8c31fbcc754dde3c1bfeb50c56019a09875a46461"
 dependencies = [
  "base64",
  "bech32",
@@ -1017,11 +1003,10 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
- "core2",
  "multibase",
  "multihash",
  "unsigned-varint",
@@ -1043,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "proptest",
  "serde_core",
 ]
@@ -1079,12 +1064,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -1132,28 +1111,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1213,7 +1174,7 @@ version = "4.1.3"
 source = "git+https://github.com/risc0/curve25519-dalek?tag=curve25519-4.1.3-risczero.0#385adda1fa3b66d9aaa8b8fcc99ddc324d33ba32"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "crypto-bigint",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -2275,7 +2236,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -2382,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "1.0.0"
+version = "1.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
+checksum = "fff132b51d68778adf4efe988f004421b4263e01ea317831b118b04a810e7c16"
 dependencies = [
  "js-sys",
 ]
@@ -2484,11 +2445,10 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
  "unsigned-varint",
 ]
 
@@ -2522,17 +2482,16 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
- "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3997,7 +3956,7 @@ source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.9.9-risczer
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4008,7 +3967,7 @@ version = "0.10.9"
 source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.9-risczero.0#8631fabdea7bdffa97b11868e04e73491d8e5bcf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -774,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -2068,9 +2068,9 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3931,13 +3931,14 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -3957,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -3971,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -3126,17 +3126,16 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
- "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -3127,15 +3127,16 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "arrayvec",
  "bitvec",
+ "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -3114,17 +3114,16 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.4"
-source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b43245e3ed2b32eaf8c062506ec16a4ff3f08e0373c29c2b0b202e8c325409"
 dependencies = [
  "arrayvec",
  "bitvec",
- "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -3115,15 +3115,16 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
+source = "git+https://github.com/Sovereign-Labs/nomt?rev=c85fb01f526b9eee742bafbdc89c4a58313b249b#c85fb01f526b9eee742bafbdc89c4a58313b249b"
 dependencies = [
  "arrayvec",
  "bitvec",
+ "blake3",
  "borsh",
  "digest 0.10.7",
  "ruint",
  "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Updates to the upstream NOMT commit that added support to `grow_hashtable()`. Adds rollup support to grow the on-disk NOMT DB in-place if the config is changed.

Since this is non-reversible, gate the operation behind an explicit CLI flag to avoid accidental config changes from blowing up disk usage.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
