### PR TITLE
Update the default value of `leader_timeout_millis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-06-12
+- Preferred sequencer: increases the default `leader_timeout_millis` (leader-election) from 500ms to 1000ms. A leader is now considered inactive only after 1s without a heartbeat, reducing spurious failovers at the cost of slightly slower dead-leader detection. Configurable via `[sequencer.preferred.postgres_config.leader_election]`; existing configs that set the value explicitly are unaffected.
+
 # 2026-06-11
 - #2966 Genesis configs are now deserialized only when the rollup state is empty. Nodes restarting with populated state no longer read genesis files, so after a hard fork the on-disk genesis configs don't need to match the new binary's `GenesisConfig`; `operating_mode` and `genesis_da_height` are read from chain state instead. Fresh nodes (empty state) still require genesis files valid for the current binary.
   * **Breaking Change** `FullNodeBlueprint::create_new_rollup_with_genesis_params` is renamed to `create_new_rollup_with_genesis_source` and takes a `GenesisSource` (wrap existing params in `GenesisSource::CustomParams(...)`). The genesis source is only consulted when state is empty. `GenesisSource` moved from `sov-test-utils` to `sov-modules-rollup-blueprint` (re-exported at the old path).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-06-12
-- Preferred sequencer: increases the default `leader_timeout_millis` (leader-election) from 500ms to 1000ms. A leader is now considered inactive only after 1s without a heartbeat, reducing spurious failovers at the cost of slightly slower dead-leader detection. Configurable via `[sequencer.preferred.postgres_config.leader_election]`; existing configs that set the value explicitly are unaffected.
+- #2973 Preferred sequencer: increases the default `leader_timeout_millis` (leader-election) from 500ms to 1000ms. A leader is now considered inactive only after 1s without a heartbeat, reducing spurious failovers at the cost of slightly slower dead-leader detection. Configurable via `[sequencer.preferred.postgres_config.leader_election]`; existing configs that set the value explicitly are unaffected.
 
 # 2026-06-11
 - #2966 Genesis configs are now deserialized only when the rollup state is empty. Nodes restarting with populated state no longer read genesis files, so after a hard fork the on-disk genesis configs don't need to match the new binary's `GenesisConfig`; `operating_mode` and `genesis_da_height` are read from chain state instead. Fresh nodes (empty state) still require genesis files valid for the current binary.

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -194,7 +194,7 @@ impl LeaderElectionConfig {
 }
 
 const fn default_leader_timeout_millis() -> u64 {
-    500
+    1000
 }
 
 const fn default_leader_grace_period_millis() -> u64 {

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -71,7 +71,7 @@ expression: config
         "node_id": "node_1",
         "node_role": "Leader",
         "leader_election": {
-          "leader_timeout_millis": 500,
+          "leader_timeout_millis": 1000,
           "grace_period_millis": 10000,
           "heartbeat_interval_millis": 100
         }

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -71,7 +71,7 @@ expression: config
         "node_id": "node_1",
         "node_role": "Leader",
         "leader_election": {
-          "leader_timeout_millis": 500,
+          "leader_timeout_millis": 1000,
           "grace_period_millis": 10000,
           "heartbeat_interval_millis": 100
         }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -367,7 +367,7 @@
           "description": "Maximum time in milliseconds without a heartbeat before a leader is considered inactive.",
           "type": "integer",
           "format": "uint64",
-          "default": 500,
+          "default": 1000,
           "minimum": 0
         }
       }
@@ -497,7 +497,7 @@
           "default": {
             "grace_period_millis": 10000,
             "heartbeat_interval_millis": 100,
-            "leader_timeout_millis": 500
+            "leader_timeout_millis": 1000
           }
         },
         "node_id": {

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -119,7 +119,7 @@ ideal_lag_behind_finalized_slot = 3 # Ideal buffer of finalized slots to maintai
 #node_id = "node_1"
 #node_role = "Leader" # Other options are "Replica", "ReplicaNoLeaderSync", or "DbElected"
 #[sequencer.preferred.postgres_config.leader_election] # Configuration for leader election timing
-#leader_timeout_millis = 500 # Maximum time in milliseconds without a heartbeat before a leader is considered inactive
+#leader_timeout_millis = 1000 # Maximum time in milliseconds without a heartbeat before a leader is considered inactive
 #grace_period_millis = 10000 # Minimum time in milliseconds after leader acquisition before another node can take over
 #heartbeat_interval_millis = 100 # Interval in milliseconds between heartbeat updates
 


### PR DESCRIPTION
# Description

Update the default value of leader_timeout_millis to 1000ms


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
 
