### PR TITLE
Bake risc0 recursion into base image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -22,15 +22,6 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     unzip \
     && sudo rm -rf /var/lib/apt/lists/*
 
-ARG RISC0_RECURSION_ZKR_SHA=744b999f0a35b3c86753311c7efb2a0054be21727095cf105af6ee7d3f4d8849
-ENV RECURSION_SRC_PATH=/opt/risc0-zkrs/recursion_zkr.zip
-RUN sudo mkdir -p /opt/risc0-zkrs \
-    && curl -fsSL "https://risc0-artifacts.s3.us-west-2.amazonaws.com/zkr/${RISC0_RECURSION_ZKR_SHA}.zip" -o /tmp/recursion_zkr.zip \
-    && sudo install -m 0644 /tmp/recursion_zkr.zip "${RECURSION_SRC_PATH}" \
-    && echo "${RISC0_RECURSION_ZKR_SHA}  ${RECURSION_SRC_PATH}" | sha256sum -c - \
-    && unzip -t "${RECURSION_SRC_PATH}" >/dev/null \
-    && rm -f /tmp/recursion_zkr.zip
-
 # Build and install mold linker from source
 RUN git clone https://github.com/rui314/mold.git /tmp/mold \
     && cd /tmp/mold \
@@ -99,10 +90,19 @@ RUN . /home/runner/.cargo/env \
         && rm -rf /home/runner/.cargo/git;
 SHELL ["/bin/sh", "-c"]
 
+ARG RISC0_RECURSION_ZKR_SHA=744b999f0a35b3c86753311c7efb2a0054be21727095cf105af6ee7d3f4d8849
+ENV RECURSION_SRC_PATH=/opt/risc0-zkrs/recursion_zkr.zip
+RUN sudo mkdir -p /opt/risc0-zkrs \
+    && curl -fsSL "https://risc0-artifacts.s3.us-west-2.amazonaws.com/zkr/${RISC0_RECURSION_ZKR_SHA}.zip" -o /tmp/recursion_zkr.zip \
+    && sudo install -m 0644 /tmp/recursion_zkr.zip "${RECURSION_SRC_PATH}" \
+    && echo "${RISC0_RECURSION_ZKR_SHA}  ${RECURSION_SRC_PATH}" | sha256sum -c - \
+    && unzip -t "${RECURSION_SRC_PATH}" >/dev/null \
+    && rm -f /tmp/recursion_zkr.zip
+
 # Install SP1 toolchain (AMD64 only - SP1 doesn't support ARM64)
 RUN . /home/runner/.cargo/env \
         && curl -L https://sp1up.succinct.xyz | bash \
-        && /home/runner/.sp1/bin/sp1up --version 6.2.2 \
+        && /home/runner/.sp1/bin/sp1up --version 6.2.4 \
         && /home/runner/.sp1/bin/cargo-prove prove install-toolchain \
         && rm -rf /home/runner/.cargo/registry \
         && rm -rf /home/runner/.cargo/git

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -22,6 +22,15 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     unzip \
     && sudo rm -rf /var/lib/apt/lists/*
 
+ARG RISC0_RECURSION_ZKR_SHA=744b999f0a35b3c86753311c7efb2a0054be21727095cf105af6ee7d3f4d8849
+ENV RECURSION_SRC_PATH=/opt/risc0-zkrs/recursion_zkr.zip
+RUN sudo mkdir -p /opt/risc0-zkrs \
+    && curl -fsSL "https://risc0-artifacts.s3.us-west-2.amazonaws.com/zkr/${RISC0_RECURSION_ZKR_SHA}.zip" -o /tmp/recursion_zkr.zip \
+    && sudo install -m 0644 /tmp/recursion_zkr.zip "${RECURSION_SRC_PATH}" \
+    && echo "${RISC0_RECURSION_ZKR_SHA}  ${RECURSION_SRC_PATH}" | sha256sum -c - \
+    && unzip -t "${RECURSION_SRC_PATH}" >/dev/null \
+    && rm -f /tmp/recursion_zkr.zip
+
 # Build and install mold linker from source
 RUN git clone https://github.com/rui314/mold.git /tmp/mold \
     && cd /tmp/mold \


### PR DESCRIPTION
# Description

To reduce errors on download. Original failure:

```
    Checking sov-modules-rollup-blueprint v0.3.0 (https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=282e3d0f932fb1331abde209be5976f25015bab9#282e3d0f)
error: failed to run custom build command for `risc0-circuit-recursion v4.0.4`

Caused by:
  process didn't exit successfully: `/home/runner/work/_temp/rollup-starter/target/debug/build/risc0-circuit-recursion-2bf890550a36115c/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=RECURSION_SRC_PATH

  --- stderr
  Downloading https://risc0-artifacts.s3.us-west-2.amazonaws.com/zkr/744b999f0a35b3c86753311c7efb2a0054be21727095cf105af6ee7d3f4d8849.zip

  thread 'main' (21507) panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/risc0-circuit-recursion-4.0.4/build.rs:80:47:
  called `Result::unwrap()` on an `Err` value: Verification(/home/runner/work/_temp/rollup-starter/target/debug/build/risc0-circuit-recursion-2c14e643b8e3732f/out/recursion_zkr.zip: (verification: FAILED):
    1: https://risc0-artifacts.s3.us-west-2.amazonaws.com/zkr/744b999f0a35b3c86753311c7efb2a0054be21727095cf105af6ee7d3f4d8849.zip with status 200
  )
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

SP1 toolchain upgrade too

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
