### PR TITLE
Do not mark skipped blob during shutdown as accepted

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -290,8 +290,7 @@ where
         latest_known_processing_state: BlobExecutionStatus<Da::Spec>,
     ) -> anyhow::Result<()> {
         if self.shutdown_receiver.has_changed()? {
-            info!("BlobSender: shutdown signal received, skipping blob submission");
-            return Ok(());
+            anyhow::bail!("BlobSender: shutdown signal received, skipping blob submission");
         }
 
         // It is ok to hold the lock here because:

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -3,6 +3,7 @@ mod in_flight_blob;
 mod metrics;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -40,9 +41,23 @@ use tracing::{debug, error, info, trace};
 pub type BlobInternalId = u128;
 
 const LEDGER_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const BLOB_SENDER_SHUTDOWN_MESSAGE: &str =
+    "BlobSender: shutdown signal received, skipping blob submission";
 
 /// If a blob is not published within this number of retries, the rollup will exit.
 pub const MAX_NB_OF_BLOB_SUBMISSION_RETRIES: u8 = 3;
+
+/// Returned when a caller tries to submit a new blob after shutdown has started.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobSenderShutdownError;
+
+impl fmt::Display for BlobSenderShutdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(BLOB_SENDER_SHUTDOWN_MESSAGE)
+    }
+}
+
+impl std::error::Error for BlobSenderShutdownError {}
 
 /// See [`BlobInternalId`].
 pub fn new_blob_id() -> BlobInternalId {
@@ -290,7 +305,7 @@ where
         latest_known_processing_state: BlobExecutionStatus<Da::Spec>,
     ) -> anyhow::Result<()> {
         if self.shutdown_receiver.has_changed()? {
-            anyhow::bail!("BlobSender: shutdown signal received, skipping blob submission");
+            return Err(BlobSenderShutdownError.into());
         }
 
         // It is ok to hold the lock here because:

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -194,6 +194,36 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn blob_sender_rejects_new_blob_after_shutdown() -> anyhow::Result<()> {
+    let deps = create_deps().await;
+    let (mut blob_sender, handle) = create_blob_sender(
+        Duration::from_secs(20),
+        &deps,
+        None,
+        BlobSelectorStatus::Accepted,
+    )
+    .await;
+
+    deps.shutdown_sender.send(())?;
+
+    let data = Arc::new([11, 2, 3, 4, 5]);
+    let error = blob_sender
+        .publish_proof_blob(data, 11u8 as BlobInternalId)
+        .await
+        .expect_err("publishing after shutdown must fail");
+
+    assert!(
+        error.to_string().contains("shutdown signal received"),
+        "unexpected error: {error:?}"
+    );
+    assert_eq!(blob_sender.nb_of_concurrent_proof_blob_submissions(), 0);
+
+    handle.await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Result<()> {
     let deps = create_deps().await;
     let nb_of_blobs = 2;

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -1,4 +1,4 @@
-use sov_blob_sender::BlobExecutionStatus;
+use sov_blob_sender::{BlobExecutionStatus, BlobSenderShutdownError};
 use sov_blob_sender::{BlobInternalId, BlobSender, BlobToSend};
 use sov_blob_storage::{PreferredBatchData, PreferredProofData};
 use sov_db::ledger_db::LedgerDb;
@@ -25,6 +25,7 @@ use crate::{common::TxStatusBlobSenderHooks, TxStatusManager};
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
 pub struct PreferredBlobSender<Da: DaService> {
     inner: Option<BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>>,
+    shutdown_receiver: watch::Receiver<()>,
     nb_of_concurrent_batch_blob_submissions: Arc<AtomicUsize>,
     nb_of_concurrent_proof_blob_submissions: Arc<AtomicUsize>,
 }
@@ -43,10 +44,12 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_batch_blob_submissions = Arc::new(AtomicUsize::new(0));
         let nb_of_concurrent_proof_blob_submissions = Arc::new(AtomicUsize::new(0));
+        let shutdown_receiver = shutdown_sender.subscribe();
         match seq_role {
             SequencerRole::PgSyncReplica | SequencerRole::DaOnlyReplica => Ok((
                 Self {
                     inner: None,
+                    shutdown_receiver,
                     nb_of_concurrent_batch_blob_submissions,
                     nb_of_concurrent_proof_blob_submissions,
                 },
@@ -77,6 +80,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
                 Ok((
                     Self {
                         inner: Some(inner),
+                        shutdown_receiver,
                         nb_of_concurrent_batch_blob_submissions,
                         nb_of_concurrent_proof_blob_submissions,
                     },
@@ -101,7 +105,8 @@ impl<Da: DaService> PreferredBlobSender<Da> {
             blob_id, "Dispatching proof blob for publishing"
         );
 
-        inner.publish_proof_blob(proof_data.0, blob_id).await?;
+        let result = inner.publish_proof_blob(proof_data.0, blob_id).await;
+        self.handle_blob_publish_result(result)?;
 
         Ok(())
     }
@@ -114,9 +119,24 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         let blob_id = batch.blob_id;
         let data = batch_bytes(batch)?;
 
-        inner.publish_batch_blob(data, blob_id).await?;
+        let result = inner.publish_batch_blob(data, blob_id).await;
+        self.handle_blob_publish_result(result)?;
 
         Ok(())
+    }
+
+    fn handle_blob_publish_result(&self, result: anyhow::Result<()>) -> anyhow::Result<()> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(err)
+                if err.downcast_ref::<BlobSenderShutdownError>().is_some()
+                    && self.shutdown_receiver.has_changed().unwrap_or(true) =>
+            {
+                debug!("BlobSender rejected blob submission after shutdown started");
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     pub async fn publish_blobs_for_recovery(

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -668,6 +668,11 @@ where
         visible_slot_number_after_increase: VisibleSlotNumber,
         visible_increase: NonZero<u8>,
     ) -> Result<Option<SequenceNumber>, BatchCreationError> {
+        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            tracing::debug!("Shutdown signal received; skipping preferred batch start");
+            return Ok(None);
+        }
+
         if self.executor.has_in_progress_batch() {
             return Ok(None);
         }
@@ -1037,6 +1042,11 @@ where
         proof_bytes: PreferredProofDataBytes,
         sequence_number: SequenceNumber,
     ) {
+        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            tracing::debug!("Shutdown signal received; skipping proof blob publication");
+            return;
+        }
+
         // Put the proof blob into the sequencer cache, from which it will get pulled out and processed when the next batch is created.
         // The side effects task also persists it to postgres.
         self.executor_events_sender

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -106,7 +106,9 @@ where
 
             let aggregator_shutdown = self.shutdown_receiver.clone();
             let aggregator_handle = tokio::spawn(async move {
-                run_task_until_shutdown("aggregator", aggregator.run(), &aggregator_shutdown).await;
+                if let Err(e) = aggregator.run(aggregator_shutdown).await {
+                    tracing::error!(error = %e, "Aggregator task failed");
+                }
             });
 
             let intake = IntakeTask {
@@ -330,18 +332,37 @@ impl<Ps: ProverService> AggregatorTask<Ps>
 where
     Ps::DaService: DaService<Error = anyhow::Error>,
 {
-    async fn run(mut self) -> anyhow::Result<()> {
+    async fn run(
+        mut self,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    ) -> anyhow::Result<()> {
         loop {
-            let (metadata, window_size) = match self.metadata_rx.recv().await {
-                // Intake side dropped its sender (clean shutdown or intake error).
-                None => {
-                    tracing::debug!("Intake task closed metadata channel; aggregator exiting");
+            let (metadata, window_size) =
+                match future_or_shutdown(self.metadata_rx.recv(), &shutdown_receiver).await {
+                    FutureOrShutdownOutput::Shutdown => {
+                        tracing::debug!("Shutdown signal received; aggregator exiting");
+                        break;
+                    }
+                    // Intake side dropped its sender (clean shutdown or intake error).
+                    FutureOrShutdownOutput::Output(None) => {
+                        tracing::debug!("Intake task closed metadata channel; aggregator exiting");
+                        break;
+                    }
+                    FutureOrShutdownOutput::Output(Some(item)) => item,
+                };
+
+            let status = match future_or_shutdown(
+                self.proof_sender.proof_blob_sender_status(),
+                &shutdown_receiver,
+            )
+            .await
+            {
+                FutureOrShutdownOutput::Shutdown => {
+                    tracing::debug!("Shutdown signal received; aggregator exiting");
                     break;
                 }
-                Some(item) => item,
+                FutureOrShutdownOutput::Output(status) => status?,
             };
-
-            let status = self.proof_sender.proof_blob_sender_status().await?;
             if status.is_busy() {
                 tracing::error!(
                     in_flight = status.in_flight,
@@ -355,12 +376,22 @@ where
             }
 
             let proving_start = std::time::Instant::now();
-            let agg_proof = create_aggregate_proof_with_retries(
-                metadata,
-                &*self.prover_service,
-                &self.backoff_policy,
+            let agg_proof = match future_or_shutdown(
+                create_aggregate_proof_with_retries(
+                    metadata,
+                    &*self.prover_service,
+                    &self.backoff_policy,
+                ),
+                &shutdown_receiver,
             )
-            .await?;
+            .await
+            {
+                FutureOrShutdownOutput::Shutdown => {
+                    tracing::debug!("Shutdown signal received; aggregator exiting");
+                    break;
+                }
+                FutureOrShutdownOutput::Output(proof) => proof?,
+            };
             let aggregation_duration = proving_start.elapsed();
 
             sov_metrics::track_metrics(|tracker| {
@@ -374,9 +405,19 @@ where
                 "Sending aggregated proof to DA"
             );
 
-            self.proof_sender
-                .publish_proof_blob_with_metadata(agg_proof)
-                .await?;
+            match future_or_shutdown(
+                self.proof_sender
+                    .publish_proof_blob_with_metadata(agg_proof),
+                &shutdown_receiver,
+            )
+            .await
+            {
+                FutureOrShutdownOutput::Shutdown => {
+                    tracing::debug!("Shutdown signal received; aggregator exiting");
+                    break;
+                }
+                FutureOrShutdownOutput::Output(result) => result?,
+            }
 
             self.cursor.inc_next_height_to_receive_by(window_size);
         }


### PR DESCRIPTION
# Description

Previously blob sender returns `Ok(())` for blob that is not send if it happens during shutdown. Which is semantically wrong, because it never attempted to submit this blob.


This also resulted in following changes:

- `crates/full-node/sov-blob-sender/src/lib.rs:50`: added typed `BlobSenderShutdownError`; blob sender still rejects post-shutdown blobs, but callers can now distinguish graceful shutdown from real publish failures.
- `crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs:128`: preferred blob sender swallows only that typed shutdown error, and only after shutdown is observed.
- `crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs:335`: aggregator now exits on shutdown while waiting for metadata, checking sender status, proving, or publishing.
- `crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs:671`: preferred sequencer skips new batch start and proof publication once shutdown is observed.
 
---


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
New test is added


## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->