### PR TITLE
Celestia: authenticate `total_len`

### DIFF
--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -1191,6 +1191,39 @@ async fn verification_fails_if_not_all_blobs_are_proven() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn verification_fails_if_blob_total_len_is_forged() {
+    use crate::shares::BlobIterator;
+    use sov_rollup_interface::da::CountedBufReader;
+
+    let block = with_namespace_padding::filtered_block();
+    let rollup_params = with_namespace_padding::ROLLUP_PARAMS;
+
+    let mut relevant_blobs = extract_relevant_blobs(&block);
+    // The length that the DA shares actually prove for this blob.
+    let proven_len = relevant_blobs.batch_blobs[0].total_len();
+
+    // Build the inclusion proof from the honest blob first, then swap in a blob whose
+    // witness-derived `total_len()` disagrees with the proven sequence length. The verifier
+    // only authenticates the accumulator *content*, so without the cross-check a malicious
+    // prover could smuggle in an arbitrary `total_len()` (used downstream by sov-blob-storage
+    // for the malformed-blob slash decision, size limits, and deserialization gas charging).
+    let relevant_proofs = get_extraction_proof(&block, &relevant_blobs);
+    let forged_len = proven_len + 7;
+    relevant_blobs.batch_blobs[0].blob =
+        CountedBufReader::new(BlobIterator::with_forged_len(forged_len));
+
+    let verifier = CelestiaVerifier::new(rollup_params);
+    let error = verifier
+        .verify_relevant_tx_list(&block.header, &relevant_blobs, relevant_proofs)
+        .unwrap_err();
+
+    assert!(
+        error.to_string().contains("MismatchedBlobLength"),
+        "Expected the verifier to reject a forged total_len, got: {error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_blobs_from_padded_namespace() {
     let block: FilteredCelestiaBlock = with_namespace_padding::filtered_block();
     let relevant_blobs = extract_relevant_blobs(&block);

--- a/crates/adapters/celestia/src/shares.rs
+++ b/crates/adapters/celestia/src/shares.rs
@@ -212,6 +212,25 @@ impl Buf for BlobIterator {
     }
 }
 
+#[cfg(test)]
+impl BlobIterator {
+    /// Test-only constructor that reports `sequence_len` as the blob length while carrying no
+    /// share data. Wrapped in [`sov_rollup_interface::da::CountedBufReader::new`] (which starts
+    /// with an empty accumulator) it yields a blob whose `total_len()` is decoupled from the
+    /// length proven from the DA shares — i.e. a forged length, as a malicious prover could
+    /// supply via the witness. The share data is never read in that scenario, so the inner
+    /// shares are intentionally empty.
+    pub(crate) fn with_forged_len(sequence_len: usize) -> Self {
+        Self {
+            sequence_len,
+            consumed: 0,
+            current: Bytes::new(),
+            current_idx: 0,
+            blob: Blob(Vec::new()),
+        }
+    }
+}
+
 /// Goes over namespace and splits it into blobs.
 #[cfg(feature = "native")]
 #[derive(Debug)]

--- a/crates/adapters/celestia/src/types/error.rs
+++ b/crates/adapters/celestia/src/types/error.rs
@@ -58,6 +58,8 @@ pub enum BlobDataError {
     NonMatchingShare,
     #[error("Wrong sender")]
     WrongSender,
+    #[error("Blob claims length {actual} but proven sequence length is {expected}")]
+    MismatchedBlobLength { expected: usize, actual: usize },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/adapters/celestia/src/verifier/mod.rs
+++ b/crates/adapters/celestia/src/verifier/mod.rs
@@ -442,6 +442,20 @@ fn authenticate_blob_data(
     // Failure means a bug.
     debug_assert!(signer_checked, "Bug. Signer checking has been skipped");
     let sequence_length = sequence_length.expect("sequence length should be set by this point");
+
+    // `total_len()` is read from the untrusted witness and is never otherwise checked against
+    // the DA shares (only the accumulator *content* is authenticated, as a prefix). Pin it to
+    // the sequence length proven from the first share so downstream consumers in the STF (the
+    // size limits, deserialization gas charge, and the malformed-blob slash check in
+    // sov-blob-storage) cannot be fed a forged length.
+    let claimed_total_len = blob.blob.total_len();
+    if claimed_total_len != sequence_length as usize {
+        return Err(InvalidBlobData(BlobDataError::MismatchedBlobLength {
+            expected: sequence_length as usize,
+            actual: claimed_total_len,
+        }));
+    }
+
     let shares_occupied_total =
         shares_needed_for_bytes_with_signer(sequence_length as usize, has_signer);
     Ok(shares_occupied_total)

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -773,6 +773,41 @@ async fn txs_below_min_fee_are_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn duplicate_txs_are_rejected() {
+    let (test_rollup, admin) = create_test_rollup(
+        0,
+        TEST_MAX_BATCH_SIZE,
+        TEST_BLOB_PROCESSING_TIMEOUT,
+        MAX_BATCH_EXECUTION_TIME_MILLIS,
+        TEST_FINALIZATION_BLOCKS,
+        BlockProducingConfig::Manual,
+    )
+    .await;
+
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let client = test_rollup.api_client().clone();
+    let tx = tx_set_value(&admin.private_key, 0, 7);
+    let mut tx_mal = tx.clone();
+    tx_mal.data.push(1);
+    let _ok = client
+        .send_raw_tx_to_sequencer(&tx)
+        .await
+        .expect("Tx must have been accepted");
+
+    let error = client
+        .send_raw_tx_to_sequencer(&tx_mal)
+        .await
+        .expect_err("Tx must have been rejected for trailing bytes");
+    let err_message = error.to_string();
+    assert!(
+        err_message.contains("1 trailing bytes after transaction deserialization"),
+        "Full error message does not contain expect part: {err_message}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tx_ws_submission() {
     let (test_rollup, admin) = create_test_rollup(
         0,

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -193,13 +193,35 @@ pub fn encode<S: Spec, RT: Runtime<S> + Eip712AuthenticatorTrait<S>>(
     <RT as Eip712AuthenticatorTrait<S>>::encode_with_eip712_auth(raw_tx)
 }
 
+pub fn encode_malformed<S: Spec, RT: Runtime<S> + Eip712AuthenticatorTrait<S>>(
+    tx: Transaction<RT, S>,
+) -> FullyBakedTx {
+    let mut raw_tx = RawTx::new(borsh::to_vec(&tx).unwrap());
+    raw_tx.data.push(1);
+    <RT as Eip712AuthenticatorTrait<S>>::encode_with_eip712_auth(raw_tx)
+}
+
 fn execute_tx(
     runner: &mut TestRunner<RT, S>,
     tx: Transaction<RT, S>,
 ) -> TxEffect<
     impl TxReceiptContents<Successful = SuccessfulTxContents<S>, Skipped = SkippedTxContents<S>>,
 > {
-    let serialized_tx = encode(tx);
+    execute_tx_maybe_malformed(runner, tx, false)
+}
+
+fn execute_tx_maybe_malformed(
+    runner: &mut TestRunner<RT, S>,
+    tx: Transaction<RT, S>,
+    malformed: bool,
+) -> TxEffect<
+    impl TxReceiptContents<Successful = SuccessfulTxContents<S>, Skipped = SkippedTxContents<S>>,
+> {
+    let serialized_tx = if malformed {
+        encode_malformed(tx)
+    } else {
+        encode(tx)
+    };
     let txs: Vec<FullyBakedTx> = vec![serialized_tx];
     let blob = borsh::to_vec(&txs).unwrap();
     let blob = MockBlob::new_with_hash(blob, runner.config.sequencer_da_address);
@@ -224,6 +246,29 @@ fn correct_signature_is_accepted() {
     let TxEffect::Successful(SuccessfulTxContents { .. }) = receipt else {
         panic!("Expected transaction to succeed, got: {receipt:?}");
     };
+}
+
+#[test]
+fn duplicate_tx_is_rejected() {
+    let (mut runner, admin) = setup();
+    let call = encode_message::<_, RT>();
+    let tx = create_tx::<_, RT>(call, &admin);
+    let tx_clone = tx.clone();
+
+    let receipt = execute_tx(&mut runner, tx);
+    let TxEffect::Successful(SuccessfulTxContents { .. }) = receipt else {
+        panic!("Expected transaction to succeed, got: {receipt:?}");
+    };
+    let receipt = execute_tx_maybe_malformed(&mut runner, tx_clone, true);
+    let TxEffect::Skipped(SkippedTxContents { error, .. }) = receipt else {
+        panic!("Expected transaction to be skipped, got: {receipt:?}");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("148 trailing bytes after transaction deserialization"),
+        "Expected error to contain '148 trailing bytes after transaction deserialization', got: {error}"
+    );
 }
 
 #[test]

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -203,8 +203,9 @@ pub fn authenticate<
     let raw_tx_hash = calculate_hash_metered::<Accessor, S>(raw_tx, state)
         .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
 
+    let mut raw_tx_slice: &[u8] = raw_tx;
     let tx = match <Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec> as MeteredBorshDeserialize<S>>::deserialize(
-        &mut &raw_tx[..],
+        &mut raw_tx_slice,
         state,
     ) {
         Ok(ok) => ok,
@@ -221,6 +222,16 @@ pub fn authenticate<
             ));
         }
     };
+    if !raw_tx_slice.is_empty() {
+        return Err(AuthenticationError::FatalError(
+            FatalError::DeserializationFailed(format!(
+                "{} trailing bytes after transaction deserialization",
+                raw_tx.len()
+            )),
+            raw_tx_hash,
+        ));
+    }
+
     verify_and_decode_tx::<S, D, SP>(raw_tx_hash, tx, state)
 }
 

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -472,6 +472,17 @@ pub fn authenticate<
             }
         };
 
+    // Verify that the transaction is fully deserialized
+    if !raw_tx.is_empty() {
+        return Err(AuthenticationError::FatalError(
+            FatalError::DeserializationFailed(format!(
+                "{} trailing bytes after transaction deserialization",
+                raw_tx.len()
+            )),
+            raw_tx_hash,
+        ));
+    }
+
     verify_and_decode_tx_multi_hash::<S, D>(raw_tx_hash, tx, resolved_hashes, state)
 }
 


### PR DESCRIPTION
# Description

Add extra safe guards for `total_len`, defensive programming.

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
Added new tests

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->