### PR TITLE
feat: support dropping optional values in jshon-to-borsh translation

### DIFF
--- a/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
@@ -250,7 +250,7 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
             let json_value = if let Some(value) = json_fields.remove(&field_serde.name) {
                 value
             } else {
-		// allow null values to be missing from the input
+                // allow null values to be missing from the input
                 if !matches!(inner_type, Ty::Option { .. }) {
                     return Err(EncodeError::MissingType {
                         name: format!("{}.{}", s.type_name, field.display_name),

--- a/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
@@ -245,13 +245,19 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
 
         for (field, field_serde) in s.fields.iter().zip(serde_metadata.fields_or_variants) {
             // TODO: ensure skip is handled correctly
-            let json_value =
-                json_fields
-                    .remove(&field_serde.name)
-                    .ok_or(EncodeError::MissingType {
-                        name: format!("{}.{}", s.type_name, field.display_name),
-                    })?;
+
             let inner_type = schema.resolve_or_err(&field.value)?;
+            let json_value = if let Some(value) = json_fields.remove(&field_serde.name) {
+                value
+            } else {
+		// allow null values to be missing from the input
+                if !matches!(inner_type, Ty::Option { .. }) {
+                    return Err(EncodeError::MissingType {
+                        name: format!("{}.{}", s.type_name, field.display_name),
+                    });
+                }
+                Value::Null
+            };
             context.value = json_value;
             context.current_link = field.value.clone();
             // TODO: adjust `Context` so it can return references to views over the full JSON,


### PR DESCRIPTION
# Description

We have CallMessages with a lot of optional values that clutter ledger signing. This allows us to drop all the null values from the JSON to be signed.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
