### PR TITLE
Fix accidental state breakage from EVM precompiles:

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -84,8 +84,14 @@ where
         let block = init_block(config);
 
         self.cfg.set(&chain_cfg, state)?;
-        self.enabled_custom_precompiles
-            .set(&config.enabled_custom_precompiles, state)?;
+        // Only write the value when non-empty to avoid state root breakage on older rollups that
+        // did not have precompiles set in genesis.
+        // A missing value is treated as an empty set on read so this is semantically identical to
+        // writing an empty set.
+        if !config.enabled_custom_precompiles.is_empty() {
+            self.enabled_custom_precompiles
+                .set(&config.enabled_custom_precompiles, state)?;
+        }
         self.head.set(&block, state)?;
 
         let block_env = create_block_env(

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -318,6 +318,15 @@ where
     where
         Reader: StateReader<User, Error = E>,
     {
+        // When the runtime has no compiled-in custom precompiles, the enabled set can never have
+        // any effect: a custom precompile is only ever activated if it is also present in
+        // `P::ADDRESSES` (see `SovPrecompileProvider::custom_precompile_enabled`). Skip the state
+        // read entirely in that case.
+        // This both avoids a tiny bit of extra gas usage for rollups not using custom precompiles,
+        // and provides backwards compatibility for existing pre-precompile rollups.
+        if P::ADDRESSES.is_empty() {
+            return Ok(BTreeSet::new());
+        }
         Ok(self
             .enabled_custom_precompiles
             .get(state)?


### PR DESCRIPTION
# Description

Verified that acceptance tests short run passes

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
