### PR TITLE
Add explicit instructions to agents.md to audit for breaking changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,18 @@ This codebase will outlive you. Avoid shortcuts that create long-term debt.
 - Focus on business logic, correctness and code quality which has the highest business impact. Ignore untracked files.
 - Ignore uncommitted changes in Cargo.toml, if it removes `default-members`. This is expected pattern with `cargo switcheroo`
 
+### Scanning for state breakage
+
+A **state break** is when the same inputs produce a different state root — an unintentional hard fork that desyncs existing chains. It is distinct from a **chain-hash break** (a change to the runtime schema's identity), which is expected when a message format changes and is absorbed via `CHAIN_HASH_OVERRIDES`. A change can — and should — be chain-hash-breaking *without* being state-breaking. Scan any change touching state layout, execution paths, or serialized types for these:
+
+- **Eager genesis initialization.** Writing a new `#[state]` value at genesis adds a key to the tree, changing the genesis (and empty-batch) state root for *every* chain. Only write when non-default, and make a missing value read back as the default (`get(...).unwrap_or_default()`).
+- **New metered reads/writes in execution paths.** State accesses are gas-metered, and gas feeds the fee deducted (and written) from the payer. A single extra (or one less!) `StateValue::get` on a transaction or hook path changes gas → fees → balances → state root if it's ever exercised. Be careful on the entire execution path: both changes to existing CallMessage handlers in a module, as well as any state access changes across the STF transaction processing pipeline.
+- **Serialization layout of replayed or stored types.** Transactions are replayed from DA during resync, and state items are hashed into the state root; so any type either reachable from `CallMessage` / `RuntimeCall`, or stored in the rollup state, must keep a stable, byte-perfect serialized layout. For both binary codecs used here (borsh for messages, BCS for state), **only** appending enum variants is safe (preserves existing discriminants); you must NOT add, remove, reorder, or retype *struct or tuple* fields, nor insert/reorder enum variants. Genesis-config types decoded from JSON using serde_json are exempt when the new field is `#[serde(default)]`, because `serde_json`'s format is self-describing.
+- **State item ordering.** `#[state]` field prefixes are positional within a module: appending a new field is safe, but inserting or reordering shifts the storage keys of all following fields. Module discriminants are pinned in `constants.toml`.
+
+These rules exist to protect *deployed* state and *historical* messages. The release boundary is the `nightly` branch (unless the user says otherwise): commits already in `dev` but not yet in `nightly` are unreleased and safe to change in state-breaking ways. In exceptional cases the user may also confirm that some type or commit is known to not have been used in production yet. Test-only modules are also safe to change.
+When in doubt about whether something is deployed, ask the user; by default assume anything in a `nightly` branch is released.
+
 # Agent working agreement
 
 ## Default operating mode: Minimal Patch Mode


### PR DESCRIPTION
# Description

We have well-known heuristics for what changes will break existing rollups/state, and how to avoid them when modifying execution and modules. Encode this knowledge in agents.md so that agents can avoid writing breaking code and can scan for it in review, helping pre-empt nightly promotion failures.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
