### PR TITLE
Fix sov-sequencer README demo-rollup link

### DIFF
--- a/crates/full-node/sov-sequencer/README.md
+++ b/crates/full-node/sov-sequencer/README.md
@@ -4,7 +4,7 @@ Simple implementation of based sequencer generic over batch builder and DA servi
 
 ### Submit transactions
 
-Please see [`demo-rollup` README](../../examples/demo-rollup/README.md#how-to-submit-transactions).
+Please see [`demo-rollup` README](../../../examples/demo-rollup/README.md#how-to-submit-transactions).
 
 ### Publish blob
 


### PR DESCRIPTION
# Description

Fixes a broken relative link in `crates/full-node/sov-sequencer/README.md`.

The README points readers to the demo-rollup documentation for submitting transactions, but the relative path was one directory too shallow. This updates the link so it resolves to the existing demo-rollup README section.




- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs

Documentation-only fix.