### PR TITLE
Introduce secondary shutdown controller for post-run background tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11821,6 +11821,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sov-metrics",
+ "sov-rollup-interface",
  "sp1-lib",
  "tokio",
  "tokio-metrics",

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -34,6 +34,7 @@ use sov_rollup_interface::da::{
 use sov_rollup_interface::node::da::{
     run_maybe_retryable_async_fn_with_retries, DaService, MaybeRetryable, SubmitBlobReceipt,
 };
+use sov_rollup_interface::node::SecondaryShutdownController;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -191,7 +192,7 @@ impl CelestiaService {
     pub async fn new(
         config: CelestiaConfig,
         chain_params: RollupParams,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> Self {
         tracing::info!(?config, "Initializing Celestia Adapter");
         let request_timeout = Duration::from_secs(config.request_timeout_secs.get());
@@ -226,7 +227,7 @@ impl CelestiaService {
                     bg_client,
                     signer,
                     tx_priority,
-                    shutdown_receiver,
+                    SecondaryShutdownController::clone(secondary_shutdown_controller),
                     stat_polling_period,
                     stat_request_timeout,
                 ));
@@ -702,7 +703,7 @@ async fn stat_collection_task(
     client: celestia_client::Client,
     signer: CelestiaAddress,
     priority: celestia_client::tx::TxPriority,
-    mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
     period: Duration,
     request_timeout: Duration,
 ) {
@@ -713,7 +714,7 @@ async fn stat_collection_task(
 
     loop {
         tokio::select! {
-            _ = shutdown_receiver.changed() => {
+            _ = secondary_shutdown_controller.changed() => {
                 tracing::info!("Shutting down celestia stat collection task");
                 return;
             }

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -714,7 +714,7 @@ async fn stat_collection_task(
 
     loop {
         tokio::select! {
-            _ = secondary_shutdown_controller.changed() => {
+            _ = secondary_shutdown_controller.wait_for_shutdown() => {
                 tracing::info!("Shutting down celestia stat collection task");
                 return;
             }

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -227,7 +227,7 @@ impl CelestiaService {
                     bg_client,
                     signer,
                     tx_priority,
-                    SecondaryShutdownController::clone(secondary_shutdown_controller),
+                    secondary_shutdown_controller.clone(),
                     stat_polling_period,
                     stat_request_timeout,
                 ));

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -18,6 +18,7 @@ use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaVerifier, RelevantBlobs};
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::da::SlotData;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use tokio::task::JoinSet;
 
 async fn collect_all_blobs_between(
@@ -263,8 +264,9 @@ async fn test_submit_blob_correct() -> anyhow::Result<()> {
     let rollup_params = ROLLUP_PARAMS_DEV;
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-    let da_service = CelestiaService::new(config, rollup_params, shutdown_rx).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service =
+        CelestiaService::new(config, rollup_params, &secondary_shutdown_controller).await;
     let signer = da_service
         .get_signer()
         .await
@@ -289,8 +291,9 @@ async fn test_submit_blob_correct() -> anyhow::Result<()> {
 async fn test_submit_proof_correct() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service =
+        CelestiaService::new(config, ROLLUP_PARAMS_DEV, &secondary_shutdown_controller).await;
 
     let zk_proof: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
     let signer = da_service
@@ -342,7 +345,7 @@ async fn test_multi_sender_multi_namespace_full_verification_roundtrip() -> anyh
         rollup_proof_namespace: Namespace::const_v0(*b"n99proof99"),
     };
 
-    let mut shutdown_senders = Vec::new();
+    let mut secondary_shutdown_controllers = Vec::new();
     let mut active_services = Vec::new();
     let mut active_signers = Vec::new();
 
@@ -353,9 +356,9 @@ async fn test_multi_sender_multi_namespace_full_verification_roundtrip() -> anyh
         let mut config = base_config.clone();
         config.signer_private_key = Some(signer_private_key);
 
-        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        shutdown_senders.push(shutdown_tx);
-        let service = CelestiaService::new(config, *params, shutdown_rx).await;
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
+        let service = CelestiaService::new(config, *params, &secondary_shutdown_controller).await;
+        secondary_shutdown_controllers.push(secondary_shutdown_controller);
         assert_eq!(
             service.get_signer().await,
             Some(expected_signer),
@@ -365,10 +368,14 @@ async fn test_multi_sender_multi_namespace_full_verification_roundtrip() -> anyh
         active_signers.push(expected_signer);
     }
 
-    let (unknown_shutdown_tx, unknown_shutdown_rx) = tokio::sync::watch::channel(());
-    shutdown_senders.push(unknown_shutdown_tx);
-    let unknown_service =
-        CelestiaService::new(base_config, unknown_rollup_params, unknown_shutdown_rx).await;
+    let unknown_secondary_shutdown_controller = SecondaryShutdownController::new();
+    let unknown_service = CelestiaService::new(
+        base_config,
+        unknown_rollup_params,
+        &unknown_secondary_shutdown_controller,
+    )
+    .await;
+    secondary_shutdown_controllers.push(unknown_secondary_shutdown_controller);
 
     let mut verification_services = active_services.clone();
     verification_services.push(unknown_service);
@@ -611,9 +618,17 @@ async fn test_raw_v0_and_v1_blobs_across_namespaces() -> anyhow::Result<()> {
     };
 
     // CelestiaService for reading/verifying (uses key 0).
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-    let _ = sov_metrics::init_metrics_tracker(&MonitoringConfig::standard(), shutdown_rx.clone());
-    let da_service = CelestiaService::new(base_config.clone(), rollup_params, shutdown_rx).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let _ = sov_metrics::init_metrics_tracker(
+        &MonitoringConfig::standard(),
+        &secondary_shutdown_controller,
+    );
+    let da_service = CelestiaService::new(
+        base_config.clone(),
+        rollup_params,
+        &secondary_shutdown_controller,
+    )
+    .await;
     let verifier = CelestiaVerifier::new(rollup_params);
 
     // Build 6 raw clients with different signers (keys 1–6).
@@ -793,9 +808,10 @@ fn bytes_for_shares_accounts_for_signer_overhead() {
 async fn test_submit_blob_application_level_error() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
+    let da_service =
+        CelestiaService::new(config, ROLLUP_PARAMS_DEV, &secondary_shutdown_controller).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 
@@ -815,9 +831,10 @@ async fn test_submit_blob_application_level_error() -> anyhow::Result<()> {
 async fn test_submit_blob_internal_server_error() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
+    let da_service =
+        CelestiaService::new(config, ROLLUP_PARAMS_DEV, &secondary_shutdown_controller).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 
@@ -840,9 +857,10 @@ async fn test_submit_blob_internal_server_error() -> anyhow::Result<()> {
 async fn test_submit_blob_response_timeout() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
+    let da_service =
+        CelestiaService::new(config, ROLLUP_PARAMS_DEV, &secondary_shutdown_controller).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -13,6 +13,7 @@ use crate::{CelestiaConfig, CelestiaService, VerifyOnFetchMode};
 use anyhow::{anyhow, Context};
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use sov_test_utils::docker::prepull_image_best_effort;
 use testcontainers::core::{ExecCommand, Host, Mount, WaitFor};
 use testcontainers::runners::AsyncRunner;
@@ -311,9 +312,13 @@ async fn test_service_starts() -> anyhow::Result<()> {
 
     let config = dev_node.get_config().await?;
     tracing::info!("CONFIG: {:?}", config);
-    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-    let da_service =
-        CelestiaService::new(config, crate::test_helper::ROLLUP_PARAMS_DEV, shutdown_rx).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service = CelestiaService::new(
+        config,
+        crate::test_helper::ROLLUP_PARAMS_DEV,
+        &secondary_shutdown_controller,
+    )
+    .await;
     let signer = da_service.get_signer().await;
     assert_eq!(signer, Some(dev_node.get_signer_address(0).await?));
     let header_1 = da_service.get_head_block_header().await?;

--- a/crates/adapters/mock-da/benches/concurrent_access.rs
+++ b/crates/adapters/mock-da/benches/concurrent_access.rs
@@ -141,7 +141,7 @@ fn bench_storable_mock_da_service(c: &mut Criterion) {
 
     group.finish();
 
-    let _ = secondary_shutdown_controller.shutdown();
+    secondary_shutdown_controller.shutdown();
     sender.send(()).unwrap();
     rt.block_on(async {
         for handle in handles {

--- a/crates/adapters/mock-da/benches/concurrent_access.rs
+++ b/crates/adapters/mock-da/benches/concurrent_access.rs
@@ -5,7 +5,9 @@ use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaConfig;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{
+    future_or_shutdown, FutureOrShutdownOutput, SecondaryShutdownController,
+};
 
 const BLOCK_TIME_MS: u64 = 50;
 const READERS_COUNT: usize = 10;
@@ -25,6 +27,7 @@ fn bench_storable_mock_da_service(c: &mut Criterion) {
 
     let (sender, mut receiver) = tokio::sync::watch::channel(());
     receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let path = temp.path().join("mock-da.sqlite");
 
@@ -43,7 +46,7 @@ fn bench_storable_mock_da_service(c: &mut Criterion) {
                 randomization: None,
                 failure_behavior: Default::default(),
             },
-            receiver.clone(),
+            &secondary_shutdown_controller,
         )
         .await;
 
@@ -138,6 +141,7 @@ fn bench_storable_mock_da_service(c: &mut Criterion) {
 
     group.finish();
 
+    let _ = secondary_shutdown_controller.shutdown();
     sender.send(()).unwrap();
     rt.block_on(async {
         for handle in handles {

--- a/crates/adapters/mock-da/src/bin/mock-da-server.rs
+++ b/crates/adapters/mock-da/src/bin/mock-da-server.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::EnvFilter;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{MockAddress, MockDaConfig};
+use sov_rollup_interface::node::SecondaryShutdownController;
 
 // Start with cargo run --features="native"
 #[derive(Parser, Debug)]
@@ -58,8 +59,9 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("  Database: {}", cli.db);
     tracing::info!("  Block producing: {:?}", config.block_producing);
 
-    let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
-    let da_service = StorableMockDaService::from_config(config, shutdown_receiver).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service =
+        StorableMockDaService::from_config(config, &secondary_shutdown_controller).await;
     // Start the HTTP server
     let addr = start_server(da_service, &cli.host, cli.port).await?;
 
@@ -69,6 +71,6 @@ async fn main() -> anyhow::Result<()> {
     // Wait for shutdown signal
     tokio::signal::ctrl_c().await?;
     tracing::info!("Shutting down mock-da server...");
-    shutdown_sender.send(())?;
+    secondary_shutdown_controller.shutdown()?;
     Ok(())
 }

--- a/crates/adapters/mock-da/src/bin/mock-da-server.rs
+++ b/crates/adapters/mock-da/src/bin/mock-da-server.rs
@@ -71,6 +71,6 @@ async fn main() -> anyhow::Result<()> {
     // Wait for shutdown signal
     tokio::signal::ctrl_c().await?;
     tracing::info!("Shutting down mock-da server...");
-    secondary_shutdown_controller.shutdown()?;
+    secondary_shutdown_controller.shutdown();
     Ok(())
 }

--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait};
 use sov_rollup_interface::node::da::{DaService, SlotData, SubmitBlobReceipt};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -51,7 +51,7 @@ impl BlockProducingConfig {
     /// Spawns periodic block producing. Useful for testing or custom setup.
     fn spawn_block_producing_if_needed(
         &self,
-        shutdown_receiver: watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
         da_layer: Arc<RwLock<StorableMockDaLayer>>,
     ) -> Option<JoinHandle<()>> {
         let BlockProducingConfig::Periodic { block_time_ms } = self else {
@@ -60,12 +60,15 @@ impl BlockProducingConfig {
 
         let block_time = Duration::from_millis(*block_time_ms);
         let span = tracing::info_span!("periodic_batch_producer");
+        let secondary_shutdown_controller =
+            SecondaryShutdownController::clone(secondary_shutdown_controller);
 
         Some(tokio::spawn(
             async move {
                 tracing::debug!(interval = ?block_time, "Spawning a task for periodic producing");
                 loop {
-                    match future_or_shutdown(tokio::time::sleep(block_time), &shutdown_receiver)
+                    match secondary_shutdown_controller
+                        .future_or_shutdown_secondary(tokio::time::sleep(block_time))
                         .await
                     {
                         FutureOrShutdownOutput::Shutdown => {
@@ -288,7 +291,10 @@ impl StorableMockDaService {
     }
 
     /// Creates new in memory [`StorableMockDaService`] from [`MockDaConfig`].
-    pub async fn from_config(config: MockDaConfig, shutdown_receiver: watch::Receiver<()>) -> Self {
+    pub async fn from_config(
+        config: MockDaConfig,
+        secondary_shutdown_controller: &SecondaryShutdownController,
+    ) -> Self {
         let da_layer = match config.da_layer.as_ref() {
             None => {
                 let mut da_layer = StorableMockDaLayer::new_from_connection(
@@ -310,7 +316,7 @@ impl StorableMockDaService {
         };
         let handle = config
             .block_producing
-            .spawn_block_producing_if_needed(shutdown_receiver, da_layer.clone());
+            .spawn_block_producing_if_needed(secondary_shutdown_controller, da_layer.clone());
         Self::construct(
             config.sender_address,
             da_layer,
@@ -661,11 +667,10 @@ mod tests {
             block_time_ms: block_time.as_millis() as u64,
         };
 
-        let (shutdown_sender, mut shutdown_receiver) = tokio::sync::watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
 
-        let producing_handle =
-            block_producing.spawn_block_producing_if_needed(shutdown_receiver, da_layer.clone());
+        let producing_handle = block_producing
+            .spawn_block_producing_if_needed(&secondary_shutdown_controller, da_layer.clone());
 
         let services_count = 20;
         let blobs_per_service = 50;
@@ -713,7 +718,7 @@ mod tests {
             StorableMockDaService::new(MockAddress::new([1; 32]), da_layer, block_producing).await;
         check_consistency(&da_service, services_count * blobs_per_service).await?;
 
-        shutdown_sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         drop(da_service);
         producing_handle.unwrap().await?;
 

--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -68,7 +68,7 @@ impl BlockProducingConfig {
                 tracing::debug!(interval = ?block_time, "Spawning a task for periodic producing");
                 loop {
                     match secondary_shutdown_controller
-                        .future_or_shutdown_secondary(tokio::time::sleep(block_time))
+                        .future_or_shutdown(tokio::time::sleep(block_time))
                         .await
                     {
                         FutureOrShutdownOutput::Shutdown => {
@@ -718,7 +718,7 @@ mod tests {
             StorableMockDaService::new(MockAddress::new([1; 32]), da_layer, block_producing).await;
         check_consistency(&da_service, services_count * blobs_per_service).await?;
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         drop(da_service);
         producing_handle.unwrap().await?;
 

--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -60,8 +60,7 @@ impl BlockProducingConfig {
 
         let block_time = Duration::from_millis(*block_time_ms);
         let span = tracing::info_span!("periodic_batch_producer");
-        let secondary_shutdown_controller =
-            SecondaryShutdownController::clone(secondary_shutdown_controller);
+        let secondary_shutdown_controller = secondary_shutdown_controller.clone();
 
         Some(tokio::spawn(
             async move {

--- a/crates/adapters/mock-da/src/storable/mod.rs
+++ b/crates/adapters/mock-da/src/storable/mod.rs
@@ -22,6 +22,7 @@ mod tests {
     use proptest::prelude::*;
     use sov_rollup_interface::da::{BlobReaderTrait, Time};
     use sov_rollup_interface::node::da::DaService;
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use tokio::sync::RwLock;
 
     use crate::storable::layer::StorableMockDaLayer;
@@ -44,10 +45,10 @@ mod tests {
         let blocks = 5;
         let start = Time::now();
 
-        let (_shutdown_sender, mut shutdown_receiver) = tokio::sync::watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
 
-        let da_service = StorableMockDaService::from_config(config, shutdown_receiver).await;
+        let da_service =
+            StorableMockDaService::from_config(config, &secondary_shutdown_controller).await;
         let da_service_reader = da_service.clone();
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);

--- a/crates/full-node/sov-metrics/Cargo.toml
+++ b/crates/full-node/sov-metrics/Cargo.toml
@@ -24,7 +24,7 @@ derive_more = { workspace = true, features = ["deref_mut", "deref"], optional = 
 derive-new = { workspace = true }
 tokio-metrics = { workspace = true, optional = true }
 hex = { workspace = true }
-sov-rollup-interface = { workspace = true, features = ["native"], optional = true }
+sov-rollup-interface = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [

--- a/crates/full-node/sov-metrics/Cargo.toml
+++ b/crates/full-node/sov-metrics/Cargo.toml
@@ -24,6 +24,7 @@ derive_more = { workspace = true, features = ["deref_mut", "deref"], optional = 
 derive-new = { workspace = true }
 tokio-metrics = { workspace = true, optional = true }
 hex = { workspace = true }
+sov-rollup-interface = { workspace = true, features = ["native"], optional = true }
 
 anyhow = { workspace = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [
@@ -52,14 +53,16 @@ risc0 = [
 ]
 sp1 = ["dep:sp1-lib", "dep:bincode"]
 native = [
-    "dep:tokio",
-    "dep:schemars",
-    "dep:tracing",
-    "dep:bincode",
-    "dep:http",
-    "dep:derivative",
-    "dep:schemars",
-    "dep:derive_more",
-    "dep:tokio-metrics",
-    "sov-metrics/native"
+	"dep:tokio",
+	"dep:schemars",
+	"dep:tracing",
+	"dep:bincode",
+	"dep:http",
+	"dep:derivative",
+	"dep:schemars",
+	"dep:derive_more",
+	"dep:tokio-metrics",
+	"dep:sov-rollup-interface",
+	"sov-metrics/native",
+	"sov-rollup-interface?/native"
 ]

--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -211,9 +211,9 @@ mod tests {
         metrics_publisher_task, receive_with_timeout, spawn_metrics_udp_receiver,
     };
     use crate::influxdb::tracker::timestamp;
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use std::io::Write;
     use std::str::FromStr;
-    use tokio::sync::watch;
 
     #[test]
     fn escaped_field_value_preserves_plain_input() {
@@ -262,13 +262,13 @@ mod tests {
         };
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);
-        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
+            metrics_publisher_task(receiver, &monitoring_config, secondary_shutdown_controller)
+                .await;
         });
 
         let tracker = MetricsTracker { sender };
@@ -363,12 +363,12 @@ mod tests {
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
-        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
+            metrics_publisher_task(receiver, &monitoring_config, secondary_shutdown_controller)
+                .await;
         });
 
         let tracker = MetricsTracker { sender };

--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -1,10 +1,9 @@
 //! Tasks responsible for actual metrics submission.
 
-use std::future::Future;
 use std::net::SocketAddr;
 
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController};
 use tokio::io::AsyncWriteExt;
-use tokio::sync::watch;
 
 use crate::influxdb::config::{MonitoringConfig, Transport};
 use crate::influxdb::tracker::DroppedMetrics;
@@ -12,25 +11,6 @@ use crate::influxdb::SubmittableMetric;
 use crate::{Metric, TelegrafSocketConfig};
 
 const SHUTDOWN_DRAINING_LIMIT: std::time::Duration = std::time::Duration::from_secs(1);
-
-enum FutureOrShutdownOutput<O> {
-    Output(O),
-    Shutdown,
-}
-
-async fn future_or_shutdown<T>(
-    inner: T,
-    shutdown: &watch::Receiver<()>,
-) -> FutureOrShutdownOutput<T::Output>
-where
-    T: Future,
-{
-    let mut shutdown = shutdown.clone();
-    tokio::select! {
-        res = inner => FutureOrShutdownOutput::Output(res),
-        _ = shutdown.changed() => FutureOrShutdownOutput::Shutdown,
-    }
-}
 
 enum PublisherTransport {
     Tcp(tokio::net::TcpStream),
@@ -103,7 +83,7 @@ impl MetricsPublisher {
 pub(crate) async fn metrics_publisher_task(
     mut metrics_receiver: tokio::sync::mpsc::Receiver<SubmittableMetric>,
     config: &MonitoringConfig,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
 ) {
     tracing::trace!(?config, "Starting metrics publisher task");
     let max_buffer_size = config.get_max_datagram_size() as usize;
@@ -152,7 +132,7 @@ pub(crate) async fn metrics_publisher_task(
                                 .await;
 
             }
-            result = future_or_shutdown(metrics_receiver.recv(), &shutdown_receiver) => {
+            result = secondary_shutdown_controller.future_or_shutdown_secondary(metrics_receiver.recv()) => {
                 match result {
                     FutureOrShutdownOutput::Output(Some(measurement)) => {
                         #[cfg(feature = "gas-constant-estimation")]
@@ -272,8 +252,8 @@ mod tests {
     use crate::influxdb::config::TelegrafSocketConfig;
     use crate::influxdb::RpcAggregationConfig;
     use crate::influxdb::{Metric, SubmittableMetricKind};
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use tokio::io::AsyncReadExt;
-    use tokio::sync::watch;
 
     #[derive(Clone, Debug)]
     struct SampleMetric(Vec<u8>);
@@ -303,8 +283,7 @@ mod tests {
         let first_chunk = 2;
         let second_chunk = 3;
         let max_udp_size = sample_metric_string_with_timestamp.len() * (first_chunk + second_chunk);
-        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
 
         let total_send = first_chunk + second_chunk;
 
@@ -319,7 +298,8 @@ mod tests {
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
+            metrics_publisher_task(receiver, &monitoring_config, secondary_shutdown_controller)
+                .await;
         });
 
         for _ in 0..first_chunk {
@@ -418,14 +398,14 @@ mod tests {
             rpc_aggregation: RpcAggregationConfig::standard(),
         };
 
-        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(1);
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
+            metrics_publisher_task(receiver, &monitoring_config, secondary_shutdown_controller)
+                .await;
         });
 
         sender

--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -132,7 +132,7 @@ pub(crate) async fn metrics_publisher_task(
                                 .await;
 
             }
-            result = secondary_shutdown_controller.future_or_shutdown_secondary(metrics_receiver.recv()) => {
+            result = secondary_shutdown_controller.future_or_shutdown(metrics_receiver.recv()) => {
                 match result {
                     FutureOrShutdownOutput::Output(Some(measurement)) => {
                         #[cfg(feature = "gas-constant-estimation")]

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -10,19 +10,27 @@ use crate::influxdb::{
     SubmittableMetricKind, DROPPED_METRICS_COUNT,
 };
 use crate::{MetricsTracker, MonitoringConfig};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController};
 
 pub(crate) static METRICS_TRACKER: OnceLock<MetricsTracker> = OnceLock::new();
 
 /// Spawns task that published metrics in the background.
 pub fn init_metrics_tracker(
     config: &MonitoringConfig,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
 ) -> Option<tokio::task::JoinHandle<()>> {
     let (sender, receiver) = tokio::sync::mpsc::channel(config.get_max_pending_metrics() as usize);
     let config_for_task = config.clone();
+    let secondary_shutdown_controller =
+        SecondaryShutdownController::clone(secondary_shutdown_controller);
     if METRICS_TRACKER.get().is_none() {
         let handle = tokio::spawn(async move {
-            publisher::metrics_publisher_task(receiver, &config_for_task, shutdown_receiver).await;
+            publisher::metrics_publisher_task(
+                receiver,
+                &config_for_task,
+                secondary_shutdown_controller,
+            )
+            .await;
         });
         tracing::debug!(?config, "Metrics tracker initialized");
         match OnceLock::set(&METRICS_TRACKER, MetricsTracker { sender }) {
@@ -807,10 +815,12 @@ impl Metric for tokio_metrics::RuntimeMetrics {
 /// Spawns a task to monitor tokio runtime metrics and submit them to the metrics tracker.
 pub fn spawn_tokio_runtime_metrics_task(
     metrics_interval: std::time::Duration,
-    mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
 ) -> tokio::task::JoinHandle<()> {
     let handle = tokio::runtime::Handle::current();
     let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
+    let secondary_shutdown_controller =
+        SecondaryShutdownController::clone(secondary_shutdown_controller);
 
     // print runtime metrics every metrics_interval
     tokio::spawn(async move {
@@ -818,11 +828,12 @@ pub fn spawn_tokio_runtime_metrics_task(
             crate::track_metrics(|tracker| {
                 tracker.submit(interval);
             });
-            tokio::select! {
-                _ = tokio::time::sleep(metrics_interval) => {},
-                _ = shutdown_receiver.changed() => {
-                    break;
-                }
+            match secondary_shutdown_controller
+                .future_or_shutdown_secondary(tokio::time::sleep(metrics_interval))
+                .await
+            {
+                FutureOrShutdownOutput::Output(_) => {}
+                FutureOrShutdownOutput::Shutdown => break,
             }
         }
     })

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -21,8 +21,7 @@ pub fn init_metrics_tracker(
 ) -> Option<tokio::task::JoinHandle<()>> {
     let (sender, receiver) = tokio::sync::mpsc::channel(config.get_max_pending_metrics() as usize);
     let config_for_task = config.clone();
-    let secondary_shutdown_controller =
-        SecondaryShutdownController::clone(secondary_shutdown_controller);
+    let secondary_shutdown_controller = secondary_shutdown_controller.clone();
     if METRICS_TRACKER.get().is_none() {
         let handle = tokio::spawn(async move {
             publisher::metrics_publisher_task(
@@ -819,8 +818,7 @@ pub fn spawn_tokio_runtime_metrics_task(
 ) -> tokio::task::JoinHandle<()> {
     let handle = tokio::runtime::Handle::current();
     let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
-    let secondary_shutdown_controller =
-        SecondaryShutdownController::clone(secondary_shutdown_controller);
+    let secondary_shutdown_controller = secondary_shutdown_controller.clone();
 
     // print runtime metrics every metrics_interval
     tokio::spawn(async move {

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -829,7 +829,7 @@ pub fn spawn_tokio_runtime_metrics_task(
                 tracker.submit(interval);
             });
             match secondary_shutdown_controller
-                .future_or_shutdown_secondary(tokio::time::sleep(metrics_interval))
+                .future_or_shutdown(tokio::time::sleep(metrics_interval))
                 .await
             {
                 FutureOrShutdownOutput::Output(_) => {}

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -39,7 +39,7 @@
 
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController};
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -83,7 +83,7 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
     #[allow(missing_docs)]
     pub async fn new(
         da_service: Arc<Da>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
         polling_interval: std::time::Duration,
     ) -> anyhow::Result<Self> {
         let last_finalized_header = da_service
@@ -98,6 +98,8 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
 
         let recent_headers_for_writer = headers_cache.clone();
         let da_service_for_finalized_fetcher = da_service.clone();
+        let secondary_shutdown_controller =
+            SecondaryShutdownController::clone(secondary_shutdown_controller);
 
         let finalized_header_handler = tokio::task::spawn(async move {
             background_header_fetch_task(
@@ -105,7 +107,7 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
                 finalized_sender,
                 recent_headers_for_writer,
                 polling_interval,
-                shutdown_receiver,
+                secondary_shutdown_controller.clone(),
             )
             .await;
         });
@@ -257,7 +259,7 @@ async fn background_header_fetch_task<Da: DaService>(
     finalized_sender: tokio::sync::watch::Sender<<Da::Spec as DaSpec>::BlockHeader>,
     recent_headers: Arc<FinalizedDaHeadersCacheContainer<Da>>,
     polling_interval: std::time::Duration,
-    shutdown_rx: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
 ) {
     let mut interval = tokio::time::interval(polling_interval);
     tracing::info!(?interval, "Starting background fetcher task");
@@ -265,14 +267,18 @@ async fn background_header_fetch_task<Da: DaService>(
 
     loop {
         // Wait for the next tick or shutdown
-        match future_or_shutdown(interval.tick(), &shutdown_rx).await {
+        match secondary_shutdown_controller
+            .future_or_shutdown_secondary(interval.tick())
+            .await
+        {
             FutureOrShutdownOutput::Shutdown => {
                 tracing::info!("DA header provider received shutdown signal");
                 break;
             }
             FutureOrShutdownOutput::Output(_) => {
                 // Fetch finalized header
-                match future_or_shutdown(da_service.get_last_finalized_block_header(), &shutdown_rx)
+                match secondary_shutdown_controller
+                    .future_or_shutdown_secondary(da_service.get_last_finalized_block_header())
                     .await
                 {
                     FutureOrShutdownOutput::Shutdown => {
@@ -316,11 +322,11 @@ mod tests {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(300),
         )
         .await?;
@@ -336,7 +342,7 @@ mod tests {
         assert_eq!(cached_header.height(), 6);
         da_service.send_transaction(&[3; 32]).await.await??;
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         Ok(())
     }
 
@@ -348,11 +354,11 @@ mod tests {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -365,7 +371,7 @@ mod tests {
         let header_9 = cache.get_block_header_at(9).await?;
         assert_eq!(header_9.height(), 9);
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         Ok(())
     }
 
@@ -378,11 +384,11 @@ mod tests {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -401,7 +407,7 @@ mod tests {
             "Cache size {cache_size} exceeds MAX_RECENT_HEADERS {MAX_RECENT_HEADERS}"
         );
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         Ok(())
     }
 
@@ -411,11 +417,11 @@ mod tests {
 
         da_service.send_transaction(&[1; 32]).await.await??;
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -423,7 +429,7 @@ mod tests {
         // Task should be running
         assert!(!cache.finalized_headers_task.is_finished());
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
 
         // Wait a bit for the task to finish
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -441,11 +447,11 @@ mod tests {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -454,7 +460,7 @@ mod tests {
         let header_0 = cache.get_block_header_at(0).await?;
         assert_eq!(header_0.height(), 0);
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         Ok(())
     }
 
@@ -466,11 +472,11 @@ mod tests {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -495,7 +501,7 @@ mod tests {
         assert_eq!(cached.height(), 3);
         assert_eq!(cached.hash(), header.hash());
 
-        sender.send(())?;
+        secondary_shutdown_controller.shutdown()?;
         Ok(())
     }
 
@@ -505,11 +511,11 @@ mod tests {
 
         da_service.send_transaction(&[1; 32]).await.await??;
 
-        let (sender, receiver) = tokio::sync::watch::channel(());
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let da_service = Arc::new(da_service);
         let cache = DaServiceWithCachedFinalizedHeaders::new(
             da_service.clone(),
-            receiver,
+            &secondary_shutdown_controller,
             Duration::from_millis(100),
         )
         .await?;
@@ -527,7 +533,7 @@ mod tests {
             "Expected error when background task is stopped"
         );
 
-        let _ = sender.send(());
+        let _ = secondary_shutdown_controller.shutdown();
         Ok(())
     }
 

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -268,7 +268,7 @@ async fn background_header_fetch_task<Da: DaService>(
     loop {
         // Wait for the next tick or shutdown
         match secondary_shutdown_controller
-            .future_or_shutdown_secondary(interval.tick())
+            .future_or_shutdown(interval.tick())
             .await
         {
             FutureOrShutdownOutput::Shutdown => {
@@ -278,7 +278,7 @@ async fn background_header_fetch_task<Da: DaService>(
             FutureOrShutdownOutput::Output(_) => {
                 // Fetch finalized header
                 match secondary_shutdown_controller
-                    .future_or_shutdown_secondary(da_service.get_last_finalized_block_header())
+                    .future_or_shutdown(da_service.get_last_finalized_block_header())
                     .await
                 {
                     FutureOrShutdownOutput::Shutdown => {
@@ -342,7 +342,7 @@ mod tests {
         assert_eq!(cached_header.height(), 6);
         da_service.send_transaction(&[3; 32]).await.await??;
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 
@@ -371,7 +371,7 @@ mod tests {
         let header_9 = cache.get_block_header_at(9).await?;
         assert_eq!(header_9.height(), 9);
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 
@@ -407,7 +407,7 @@ mod tests {
             "Cache size {cache_size} exceeds MAX_RECENT_HEADERS {MAX_RECENT_HEADERS}"
         );
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 
@@ -429,7 +429,7 @@ mod tests {
         // Task should be running
         assert!(!cache.finalized_headers_task.is_finished());
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
 
         // Wait a bit for the task to finish
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -460,7 +460,7 @@ mod tests {
         let header_0 = cache.get_block_header_at(0).await?;
         assert_eq!(header_0.height(), 0);
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 
@@ -501,7 +501,7 @@ mod tests {
         assert_eq!(cached.height(), 3);
         assert_eq!(cached.hash(), header.hash());
 
-        secondary_shutdown_controller.shutdown()?;
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 
@@ -533,7 +533,7 @@ mod tests {
             "Expected error when background task is stopped"
         );
 
-        let _ = secondary_shutdown_controller.shutdown();
+        secondary_shutdown_controller.shutdown();
         Ok(())
     }
 

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -98,8 +98,7 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
 
         let recent_headers_for_writer = headers_cache.clone();
         let da_service_for_finalized_fetcher = da_service.clone();
-        let secondary_shutdown_controller =
-            SecondaryShutdownController::clone(secondary_shutdown_controller);
+        let secondary_shutdown_controller = secondary_shutdown_controller.clone();
 
         let finalized_header_handler = tokio::task::spawn(async move {
             background_header_fetch_task(

--- a/crates/full-node/sov-stf-runner/src/http/rpc_metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/http/rpc_metrics.rs
@@ -419,9 +419,9 @@ mod tests {
             tokio_runtime_metrics_interval_millis: 500,
             rpc_aggregation: RpcAggregationConfig::standard(),
         };
-        let (_shutdown_sender, mut shutdown_receiver) = tokio::sync::watch::channel(());
-        shutdown_receiver.mark_unchanged();
-        sov_metrics::init_metrics_tracker(&monitoring_config, shutdown_receiver);
+        let secondary_shutdown_controller =
+            sov_rollup_interface::node::SecondaryShutdownController::new();
+        sov_metrics::init_metrics_tracker(&monitoring_config, &secondary_shutdown_controller);
 
         let aggregator = Arc::new(RpcStatsAggregator::new(
             RpcAggregationConfig::standard(),

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -80,6 +80,6 @@ pub async fn start_operator_workflow_in_background(
 ) -> JoinHandle<()> {
     let secondary_shutdown_controller = secondary_shutdown_controller.clone();
     tokio::spawn(async move {
-        let _ = secondary_shutdown_controller.changed().await;
+        let _ = secondary_shutdown_controller.wait_for_shutdown().await;
     })
 }

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -11,10 +11,10 @@ use op_manager::attestations::AttestationsManager;
 pub use prover_service::*;
 use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use sov_rollup_interface::optimistic::BondingProofService;
 use sov_rollup_interface::stf::ProofSender;
 pub use stf_info_manager::*;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
 pub use zk_manager::*;
 
@@ -28,7 +28,7 @@ pub async fn start_zk_workflow_in_background<Ps>(
     proof_sender: Box<dyn ProofSender>,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
     da_sync_state: Arc<DaSyncState>,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
     shutdown_sender: tokio::sync::watch::Sender<()>,
     start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<JoinHandle<()>>
@@ -44,7 +44,7 @@ where
         proof_sender,
         stf_info_receiver,
         da_sync_state,
-        shutdown_receiver,
+        secondary_shutdown_controller,
         shutdown_sender,
         start_fresh_outer_proof_on_resync,
     )
@@ -56,7 +56,7 @@ where
 pub async fn start_op_workflow_in_background<Ps, Bps>(
     bonding_proof_service: Bps,
     proof_sender: Box<dyn ProofSender>,
-    shutdown_receiver: watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
     st_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
 ) -> anyhow::Result<JoinHandle<()>>
 where
@@ -68,7 +68,7 @@ where
         st_info_receiver,
         bonding_proof_service,
         proof_sender,
-        shutdown_receiver,
+        secondary_shutdown_controller,
     )
     .post_attestation_to_da_in_background()
     .await)
@@ -76,9 +76,10 @@ where
 
 /// Starts the operator workflow in the background.
 pub async fn start_operator_workflow_in_background(
-    mut shutdown_receiver: watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
 ) -> JoinHandle<()> {
+    let secondary_shutdown_controller = secondary_shutdown_controller.clone();
     tokio::spawn(async move {
-        let _ = shutdown_receiver.changed().await;
+        let _ = secondary_shutdown_controller.changed().await;
     })
 }

--- a/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
@@ -2,7 +2,7 @@ use borsh::BorshSerialize;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController};
 use sov_rollup_interface::optimistic::{Attestation, BondingProofService, SerializedAttestation};
 use sov_rollup_interface::stf::ProofSender;
 use tokio::task::JoinHandle;
@@ -14,7 +14,7 @@ pub struct AttestationsManager<StateRoot, Witness, Da: DaSpec, Bps: BondingProof
     stf_info_receiver: Receiver<StateRoot, Witness, Da>,
     bonding_proof_service: Bps,
     proof_sender: Box<dyn ProofSender>,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
 }
 
 impl<StateRoot, Witness, Da, Bps> AttestationsManager<StateRoot, Witness, Da, Bps>
@@ -29,13 +29,15 @@ where
         stf_info_receiver: Receiver<StateRoot, Witness, Da>,
         bonding_proof_service: Bps,
         proof_sender: Box<dyn ProofSender>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> Self {
         Self {
             stf_info_receiver,
             bonding_proof_service,
             proof_sender,
-            shutdown_receiver,
+            secondary_shutdown_controller: SecondaryShutdownController::clone(
+                secondary_shutdown_controller,
+            ),
         }
     }
 
@@ -50,7 +52,9 @@ where
 
     async fn post_attestation_to_da(mut self) -> anyhow::Result<()> {
         loop {
-            match future_or_shutdown(self.stf_info_receiver.read_next(), &self.shutdown_receiver)
+            match self
+                .secondary_shutdown_controller
+                .future_or_shutdown_secondary(self.stf_info_receiver.read_next())
                 .await
             {
                 FutureOrShutdownOutput::Shutdown => {

--- a/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
@@ -35,9 +35,7 @@ where
             stf_info_receiver,
             bonding_proof_service,
             proof_sender,
-            secondary_shutdown_controller: SecondaryShutdownController::clone(
-                secondary_shutdown_controller,
-            ),
+            secondary_shutdown_controller: secondary_shutdown_controller.clone(),
         }
     }
 
@@ -54,7 +52,7 @@ where
         loop {
             match self
                 .secondary_shutdown_controller
-                .future_or_shutdown_secondary(self.stf_info_receiver.read_next())
+                .future_or_shutdown(self.stf_info_receiver.read_next())
                 .await
             {
                 FutureOrShutdownOutput::Shutdown => {

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -147,10 +147,7 @@ async fn run_task_until_shutdown<T>(
     task: impl std::future::Future<Output = anyhow::Result<T>>,
     secondary_shutdown_controller: &SecondaryShutdownController,
 ) {
-    match secondary_shutdown_controller
-        .future_or_shutdown(task)
-        .await
-    {
+    match secondary_shutdown_controller.future_or_shutdown(task).await {
         FutureOrShutdownOutput::Shutdown => {
             tracing::info!(task_name, "Shutting down task...");
         }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -5,7 +5,7 @@ use backon::{BackoffBuilder, ExponentialBuilder};
 use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput, SyncStatus};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController, SyncStatus};
 use sov_rollup_interface::stf::ProofSender;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use tokio::sync::mpsc;
@@ -35,7 +35,7 @@ pub struct ZkProofManager<Ps: ProverService> {
     backoff_policy: ExponentialBuilder,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
     da_sync_state: Arc<DaSyncState>,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
     shutdown_sender: tokio::sync::watch::Sender<()>,
     start_fresh_outer_proof_on_resync: bool,
 }
@@ -54,7 +54,7 @@ where
         proof_sender: Box<dyn ProofSender>,
         stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
         da_sync_state: Arc<DaSyncState>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
         shutdown_sender: tokio::sync::watch::Sender<()>,
         start_fresh_outer_proof_on_resync: bool,
     ) -> Self {
@@ -71,7 +71,9 @@ where
                 .with_max_times(BACKOFF_POLICY_MAX_NUM_RETRIES),
             stf_info_receiver,
             da_sync_state,
-            shutdown_receiver,
+            secondary_shutdown_controller: SecondaryShutdownController::clone(
+                secondary_shutdown_controller,
+            ),
             shutdown_sender,
             start_fresh_outer_proof_on_resync,
         }
@@ -104,9 +106,14 @@ where
                 shutdown_sender: self.shutdown_sender,
             };
 
-            let aggregator_shutdown = self.shutdown_receiver.clone();
+            let aggregator_shutdown_controller = self.secondary_shutdown_controller.clone();
             let aggregator_handle = tokio::spawn(async move {
-                run_task_until_shutdown("aggregator", aggregator.run(), &aggregator_shutdown).await;
+                run_task_until_shutdown(
+                    "aggregator",
+                    aggregator.run(),
+                    &aggregator_shutdown_controller,
+                )
+                .await;
             });
 
             let intake = IntakeTask {
@@ -124,7 +131,7 @@ where
             run_task_until_shutdown(
                 "aggregated proof intake",
                 intake.run(),
-                &self.shutdown_receiver,
+                &self.secondary_shutdown_controller,
             )
             .await;
 
@@ -140,9 +147,12 @@ where
 async fn run_task_until_shutdown<T>(
     task_name: &str,
     task: impl std::future::Future<Output = anyhow::Result<T>>,
-    shutdown_receiver: &tokio::sync::watch::Receiver<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
 ) {
-    match future_or_shutdown(task, shutdown_receiver).await {
+    match secondary_shutdown_controller
+        .future_or_shutdown_secondary(task)
+        .await
+    {
         FutureOrShutdownOutput::Shutdown => {
             tracing::info!(task_name, "Shutting down task...");
         }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -71,9 +71,7 @@ where
                 .with_max_times(BACKOFF_POLICY_MAX_NUM_RETRIES),
             stf_info_receiver,
             da_sync_state,
-            secondary_shutdown_controller: SecondaryShutdownController::clone(
-                secondary_shutdown_controller,
-            ),
+            secondary_shutdown_controller: secondary_shutdown_controller.clone(),
             shutdown_sender,
             start_fresh_outer_proof_on_resync,
         }
@@ -150,7 +148,7 @@ async fn run_task_until_shutdown<T>(
     secondary_shutdown_controller: &SecondaryShutdownController,
 ) {
     match secondary_shutdown_controller
-        .future_or_shutdown_secondary(task)
+        .future_or_shutdown(task)
         .await
     {
         FutureOrShutdownOutput::Shutdown => {

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -21,7 +21,7 @@ use sov_modules_api::provable_height_tracker::InfiniteHeight;
 use sov_rollup_interface::common::{HexHash, RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
 use sov_rollup_interface::stf::GenesisParams;
 use sov_rollup_interface::stf::{
     ApplySlotOutput, BatchReceipt, ExecutionContext, StateTransitionFunction,
@@ -156,7 +156,7 @@ async fn test_empty_state_manager_returns_last_finalized_height() -> anyhow::Res
         );
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
 
     Ok(())
 }
@@ -213,7 +213,7 @@ async fn test_instant_finality() -> anyhow::Result<()> {
         );
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
 
     Ok(())
 }
@@ -288,7 +288,7 @@ async fn rejected_aggregated_proofs_are_not_published_as_latest() -> anyhow::Res
         stf_info.aggregated_proofs
     );
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
 
     Ok(())
 }
@@ -412,7 +412,7 @@ async fn test_reorg_happened_correct_block_returned() -> anyhow::Result<()> {
         }
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
 
     Ok(())
 }
@@ -502,7 +502,7 @@ async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> a
             .await?
             .get()
     );
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -658,7 +658,7 @@ async fn test_progressing_with_shuffle(
         finalized_hashes.insert(last_finalized_header.hash());
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -732,8 +732,7 @@ async fn test_with_frequent_periodic_batch_production() -> anyhow::Result<()> {
     let tempdir = tempfile::tempdir()?;
 
     let finality = 50;
-    let (sender, mut receiver) = tokio::sync::watch::channel(());
-    receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let da_service = StorableMockDaService::from_config(
         MockDaConfig {
@@ -750,7 +749,7 @@ async fn test_with_frequent_periodic_batch_production() -> anyhow::Result<()> {
             }),
             failure_behavior: Default::default(),
         },
-        receiver,
+        &secondary_shutdown_controller,
     )
     .await;
 
@@ -828,8 +827,8 @@ async fn test_with_frequent_periodic_batch_production() -> anyhow::Result<()> {
         height = returned_block.header().height() + 1;
     }
 
-    shutdown_sender_2.send(())?;
-    sender.send(())?;
+    shutdown_sender_2.shutdown()?;
+    secondary_shutdown_controller.shutdown()?;
     Ok(())
 }
 
@@ -947,7 +946,7 @@ async fn test_chain_progress_between_prepare_storage_and_save_changes(
         height = returned_block.header().height() + 1;
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
 
     Ok(())
 }
@@ -1125,7 +1124,7 @@ async fn test_change_in_finalized_header() {
         .await
         .unwrap();
 
-    shutdown_sender.send(()).unwrap();
+    shutdown_sender.shutdown().unwrap();
 }
 
 // On empty internal state, if we pass a block that is not adjacent to
@@ -1224,11 +1223,7 @@ async fn setup_storage_manager(
 async fn setup_state_manager<Da>(
     storage_path: &std::path::Path,
     da_service: Da,
-) -> anyhow::Result<(
-    TestStateManager<Da>,
-    StateRoot,
-    tokio::sync::watch::Sender<()>,
-)>
+) -> anyhow::Result<(TestStateManager<Da>, StateRoot, SecondaryShutdownController)>
 where
     Da: DaService<Error = anyhow::Error, Spec = MockDaSpec>,
 {
@@ -1245,15 +1240,14 @@ where
         target_da_height: AtomicU64::new(u64::MAX),
         sync_status_sender,
     });
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());
-    shutdown_rx.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let update_info = query_state_update_info(&ledger_db, stf_state, sync_state.as_ref()).await?;
     let state_channel = StateChannel::new(update_info);
 
     let da_header_provider = DaServiceWithCachedFinalizedHeaders::new(
         Arc::new(da_service),
-        shutdown_rx,
+        &secondary_shutdown_controller,
         DA_POLLING_INTERVAL,
     )
     .await?;
@@ -1272,7 +1266,11 @@ where
     );
     state_manager.startup().await?;
 
-    Ok((state_manager, initial_state_root, shutdown_tx))
+    Ok((
+        state_manager,
+        initial_state_root,
+        secondary_shutdown_controller,
+    ))
 }
 
 // Writes to user space concatenation of block height bytes and block hash.
@@ -1648,7 +1646,7 @@ async fn test_progressing_with_rewind_below_finalized(
         da_service.send_transaction(&blob_data).await.await??;
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -1749,7 +1747,7 @@ async fn test_binary_search_handles_da_error() -> anyhow::Result<()> {
         Err(e) => panic!("Should succeed after clearing failure, got: {e}"),
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -1862,7 +1860,7 @@ async fn test_reorg_during_binary_search() -> anyhow::Result<()> {
     // Internal consistency should still hold
     check_internal_consistency(&state_manager, finality as usize);
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -1916,7 +1914,7 @@ async fn test_ledger_consistency_after_processing() -> anyhow::Result<()> {
         );
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }
 
@@ -1997,6 +1995,6 @@ async fn test_finalized_height_monotonic() -> anyhow::Result<()> {
         }
     }
 
-    shutdown_sender.send(())?;
+    shutdown_sender.shutdown()?;
     Ok(())
 }

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -156,7 +156,7 @@ async fn test_empty_state_manager_returns_last_finalized_height() -> anyhow::Res
         );
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
 
     Ok(())
 }
@@ -213,7 +213,7 @@ async fn test_instant_finality() -> anyhow::Result<()> {
         );
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
 
     Ok(())
 }
@@ -288,7 +288,7 @@ async fn rejected_aggregated_proofs_are_not_published_as_latest() -> anyhow::Res
         stf_info.aggregated_proofs
     );
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
 
     Ok(())
 }
@@ -412,7 +412,7 @@ async fn test_reorg_happened_correct_block_returned() -> anyhow::Result<()> {
         }
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
 
     Ok(())
 }
@@ -502,7 +502,7 @@ async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> a
             .await?
             .get()
     );
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -658,7 +658,7 @@ async fn test_progressing_with_shuffle(
         finalized_hashes.insert(last_finalized_header.hash());
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -827,8 +827,8 @@ async fn test_with_frequent_periodic_batch_production() -> anyhow::Result<()> {
         height = returned_block.header().height() + 1;
     }
 
-    shutdown_sender_2.shutdown()?;
-    secondary_shutdown_controller.shutdown()?;
+    shutdown_sender_2.shutdown();
+    secondary_shutdown_controller.shutdown();
     Ok(())
 }
 
@@ -946,7 +946,7 @@ async fn test_chain_progress_between_prepare_storage_and_save_changes(
         height = returned_block.header().height() + 1;
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
 
     Ok(())
 }
@@ -1124,7 +1124,7 @@ async fn test_change_in_finalized_header() {
         .await
         .unwrap();
 
-    shutdown_sender.shutdown().unwrap();
+    shutdown_sender.shutdown();
 }
 
 // On empty internal state, if we pass a block that is not adjacent to
@@ -1646,7 +1646,7 @@ async fn test_progressing_with_rewind_below_finalized(
         da_service.send_transaction(&blob_data).await.await??;
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -1747,7 +1747,7 @@ async fn test_binary_search_handles_da_error() -> anyhow::Result<()> {
         Err(e) => panic!("Should succeed after clearing failure, got: {e}"),
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -1860,7 +1860,7 @@ async fn test_reorg_during_binary_search() -> anyhow::Result<()> {
     // Internal consistency should still hold
     check_internal_consistency(&state_manager, finality as usize);
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -1914,7 +1914,7 @@ async fn test_ledger_consistency_after_processing() -> anyhow::Result<()> {
         );
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }
 
@@ -1995,6 +1995,6 @@ async fn test_finalized_height_monotonic() -> anyhow::Result<()> {
         }
     }
 
-    shutdown_sender.shutdown()?;
+    shutdown_sender.shutdown();
     Ok(())
 }

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -114,9 +114,9 @@ impl TestNode {
         // receivers left. A failed send just means everything already shut down,
         // which is the outcome we want here.
         let _ = self.shutdown_sender.send(());
-        // Similarly, `shutdown()` returns an error when no secondary receivers
-        // remain subscribed; that only means the background tasks already exited.
-        let _ = self.secondary_shutdown_controller.shutdown();
+        // The secondary controller holds its own receiver, so `shutdown()` always
+        // succeeds; it simply signals any background tasks that are still running.
+        self.secondary_shutdown_controller.shutdown();
         let _ = self.tasks.join_all().await;
     }
 }

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -25,7 +25,7 @@ use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::ledger_api::{AggregatedProofResponse, LedgerStateProvider};
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
@@ -63,6 +63,7 @@ pub struct TestNode {
     // Just to remove warnings from logs
     _sync_status_receiver: watch::Receiver<SyncStatus>,
     shutdown_sender: watch::Sender<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
 }
 
 impl TestNode {
@@ -108,7 +109,14 @@ impl TestNode {
     }
 
     pub async fn stop(self) {
-        self.shutdown_sender.send(()).unwrap();
+        // With a `stop_at_rollup_height`, the runner stops and is dropped before
+        // `stop()` is called, so the primary shutdown channel may already have no
+        // receivers left. A failed send just means everything already shut down,
+        // which is the outcome we want here.
+        let _ = self.shutdown_sender.send(());
+        // Similarly, `shutdown()` returns an error when no secondary receivers
+        // remain subscribed; that only means the background tasks already exited.
+        let _ = self.secondary_shutdown_controller.shutdown();
         let _ = self.tasks.join_all().await;
     }
 }
@@ -205,20 +213,21 @@ pub async fn initialize_runner_with_stop_at(
     let mut tasks = JoinSet::new();
     let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
     shutdown_receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let da_service_with_cache = DaServiceWithCachedFinalizedHeaders::new(
         da_service.clone(),
-        shutdown_receiver.clone(),
+        &secondary_shutdown_controller,
         TEST_MOCK_DA_POLLING_INTERVAL,
     )
     .await
     .unwrap();
 
-    let receiver_for_metrics = shutdown_receiver.clone();
     let monitoring_config = rollup_config.monitoring.clone();
+    let metrics_shutdown_controller = secondary_shutdown_controller.clone();
     tasks.spawn(async move {
         if let Some(handle) =
-            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+            sov_metrics::init_metrics_tracker(&monitoring_config, &metrics_shutdown_controller)
         {
             handle.await.expect("Metrics task errored");
         } else {
@@ -323,7 +332,7 @@ pub async fn initialize_runner_with_stop_at(
             }),
             stf_info_receiver,
             runner.da_sync_state(),
-            shutdown_receiver.clone(),
+            &secondary_shutdown_controller,
             shutdown_sender.clone(),
             false,
         )
@@ -350,6 +359,7 @@ pub async fn initialize_runner_with_stop_at(
             _outer_vm: outer_vm,
             tasks,
             shutdown_sender,
+            secondary_shutdown_controller,
             _sync_status_receiver,
         },
     )

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -21,7 +21,7 @@ use sov_modules_api::{FullyBakedTx, StateTransitionFunction};
 use sov_rollup_full_node_interface::StateChannel;
 use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::node::da::{DaService, SlotData};
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_state::{ArrayWitness, NativeStorage, Storage, StorageRoot};
 use sov_stf_runner::StateTransitionRunner;
@@ -48,9 +48,10 @@ async fn test_runner_with_background_da_service(
 ) -> anyhow::Result<()> {
     let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
     shutdown_receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let da_service =
-        StorableMockDaService::from_config(da_config.clone(), shutdown_receiver.clone()).await;
+        StorableMockDaService::from_config(da_config.clone(), &secondary_shutdown_controller).await;
     let da_service = Arc::new(da_service);
     let tempdir = tempfile::tempdir()?;
     let rollup_config = crate::helpers::runner_init::rollup_config_with_da::<StorableMockDaService>(
@@ -61,7 +62,7 @@ async fn test_runner_with_background_da_service(
 
     let da_service_with_cache = DaServiceWithCachedFinalizedHeaders::new(
         da_service.clone(),
-        shutdown_receiver.clone(),
+        &secondary_shutdown_controller,
         TEST_MOCK_DA_POLLING_INTERVAL,
     )
     .await?;
@@ -97,8 +98,10 @@ async fn test_runner_with_background_da_service(
     let (prev_state_root, _genesis_state_root) =
         init_variant.initialize(&stf, &mut storage_manager).await?;
 
-    let _ =
-        sov_metrics::init_metrics_tracker(&MonitoringConfig::standard(), shutdown_receiver.clone());
+    let _ = sov_metrics::init_metrics_tracker(
+        &MonitoringConfig::standard(),
+        &secondary_shutdown_controller,
+    );
 
     let axum_socket_addr = rollup_config.runner.http_config.socket_address()?;
     let axum_tcp = TcpListener::bind(axum_socket_addr).await.unwrap();
@@ -176,6 +179,7 @@ async fn test_runner_with_background_da_service(
     }
 
     shutdown_sender.send(())?;
+    secondary_shutdown_controller.shutdown()?;
     runner_task
         .await?
         .context("Runner did not completed with success")?;

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -179,7 +179,7 @@ async fn test_runner_with_background_da_service(
     }
 
     shutdown_sender.send(())?;
-    secondary_shutdown_controller.shutdown()?;
+    secondary_shutdown_controller.shutdown();
     runner_task
         .await?
         .context("Runner did not completed with success")?;

--- a/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
@@ -1,8 +1,8 @@
 use sov_metrics::{init_metrics_tracker, MonitoringConfig, TelegrafSocketConfig};
 use sov_modules_api::{Gas, GasMeter};
 use sov_modules_macros::track_gas_constants_usage;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use tokio::net::UdpSocket;
-use tokio::sync::watch;
 use tokio::time::timeout;
 
 type S = sov_test_utils::TestSpec;
@@ -38,8 +38,7 @@ async fn test_metrics_macro() {
         .await
         .expect("Impossible to bind to port");
 
-    let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-    shutdown_receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     init_metrics_tracker(
         &MonitoringConfig {
@@ -49,7 +48,7 @@ async fn test_metrics_macro() {
             tokio_runtime_metrics_interval_millis: 500,
             rpc_aggregation: sov_metrics::RpcAggregationConfig::standard(),
         },
-        shutdown_receiver,
+        &secondary_shutdown_controller,
     );
 
     let input = &mut 10;
@@ -105,8 +104,7 @@ async fn test_metrics_macro_without_input() {
         .await
         .expect("Impossible to bind to port");
 
-    let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
-    shutdown_receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     init_metrics_tracker(
         &MonitoringConfig {
@@ -116,7 +114,7 @@ async fn test_metrics_macro_without_input() {
             tokio_runtime_metrics_interval_millis: 500,
             rpc_aggregation: sov_metrics::RpcAggregationConfig::standard(),
         },
-        shutdown_receiver,
+        &secondary_shutdown_controller,
     );
 
     test_metrics_without_input();

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -27,7 +27,7 @@ use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::{DaService, SlotData};
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::ProvableHeightTracker;
 use sov_sequencer::preferred::PreferredSequencer;
@@ -146,7 +146,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: watch::Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> Self::DaService;
 
     /// Creates an instance of [`ProverService`].
@@ -380,29 +380,26 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
         let (main_shutdown_sender, mut main_shutdown_receiver) = tokio::sync::watch::channel(());
         main_shutdown_receiver.mark_unchanged();
-        let (secondary_shutdown_sender, mut secondary_shutdown_receiver) =
-            tokio::sync::watch::channel(());
-        secondary_shutdown_receiver.mark_unchanged();
+        let secondary_shutdown_controller = SecondaryShutdownController::new();
         let mut background_handles = vec![];
 
-        let receiver_for_metrics = secondary_shutdown_receiver.clone();
         let monitoring_config = rollup_config.monitoring.clone();
         if let Some(metrics_handle) =
-            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics.clone())
+            sov_metrics::init_metrics_tracker(&monitoring_config, &secondary_shutdown_controller)
         {
             background_handles.push(metrics_handle);
             background_handles.push(sov_metrics::spawn_tokio_runtime_metrics_task(
                 std::time::Duration::from_millis(
                     monitoring_config.tokio_runtime_metrics_interval_millis,
                 ),
-                receiver_for_metrics,
+                &secondary_shutdown_controller,
             ));
         } else {
             tracing::warn!("Metrics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
         };
 
         let da_service = self
-            .create_da_service(&rollup_config, secondary_shutdown_receiver.clone())
+            .create_da_service(&rollup_config, &secondary_shutdown_controller)
             .await;
         let da_service_handle = da_service.take_background_join_handle().await;
         if let Some(handle) = da_service_handle {
@@ -417,7 +414,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     Err(error) => {
                         cleanup_failed_startup_before_sequencer(
                             &main_shutdown_sender,
-                            &secondary_shutdown_sender,
+                            &secondary_shutdown_controller,
                             &mut background_handles,
                         )
                         .await;
@@ -432,7 +429,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let da_service_with_cache = startup_step!(
             DaServiceWithCachedFinalizedHeaders::new(
                 da_service.clone(),
-                secondary_shutdown_receiver.clone(),
+                &secondary_shutdown_controller,
                 da_polling_interval,
             )
             .await
@@ -653,7 +650,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 Err(error) => {
                     cleanup_failed_startup(
                         &main_shutdown_sender,
-                        &secondary_shutdown_sender,
+                        &secondary_shutdown_controller,
                         &mut background_handles,
                         &mut sequencer,
                     )
@@ -694,7 +691,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             Err(error) => {
                 cleanup_failed_startup(
                     &main_shutdown_sender,
-                    &secondary_shutdown_sender,
+                    &secondary_shutdown_controller,
                     &mut background_handles,
                     &mut sequencer,
                 )
@@ -713,7 +710,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         let _ = runner.shutdown_before_run().await;
                         cleanup_failed_startup(
                             &main_shutdown_sender,
-                            &secondary_shutdown_sender,
+                            &secondary_shutdown_controller,
                             &mut background_handles,
                             &mut sequencer,
                         )
@@ -738,7 +735,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     start_op_workflow_in_background::<Self::ProverService, _>(
                         bonding_proof_service,
                         proof_sender,
-                        secondary_shutdown_receiver,
+                        &secondary_shutdown_controller,
                         stf_info_receiver,
                     )
                     .await
@@ -752,14 +749,14 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         proof_sender,
                         stf_info_receiver,
                         runner.da_sync_state(),
-                        secondary_shutdown_receiver,
+                        &secondary_shutdown_controller,
                         main_shutdown_sender.clone(),
                         start_fresh_outer_proof_on_resync,
                     )
                     .await
                 }
                 OperatingMode::Operator => {
-                    Ok(start_operator_workflow_in_background(secondary_shutdown_receiver).await)
+                    Ok(start_operator_workflow_in_background(&secondary_shutdown_controller).await)
                 }
             };
             let workflow_task_handle = match workflow_task_handle_result {
@@ -768,7 +765,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     let _ = runner.shutdown_before_run().await;
                     cleanup_failed_startup(
                         &main_shutdown_sender,
-                        &secondary_shutdown_sender,
+                        &secondary_shutdown_controller,
                         &mut background_handles,
                         &mut sequencer,
                     )
@@ -797,7 +794,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 let _ = runner.shutdown_before_run().await;
                 cleanup_failed_startup(
                     &main_shutdown_sender,
-                    &secondary_shutdown_sender,
+                    &secondary_shutdown_controller,
                     &mut background_handles,
                     &mut sequencer,
                 )
@@ -819,7 +816,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             runner,
             endpoints,
             shutdown_sender: main_shutdown_sender,
-            secondary_shutdown_sender,
+            secondary_shutdown_controller,
             background_handles,
             genesis_slot_number: genesis_da_height,
             rpc_aggregation_config: monitoring_config.rpc_aggregation.clone(),
@@ -849,12 +846,12 @@ fn validate_operating_mode_config(
 
 async fn cleanup_failed_startup<S: Spec>(
     main_shutdown_sender: &watch::Sender<()>,
-    secondary_shutdown_sender: &watch::Sender<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
     background_handles: &mut Vec<JoinHandle<()>>,
     sequencer: &mut SequencerCreationReceipt<S>,
 ) {
     let _ = main_shutdown_sender.send(());
-    let _ = secondary_shutdown_sender.send(());
+    let _ = secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
     let sequencer_background_handles = std::mem::take(&mut sequencer.background_handles);
@@ -870,11 +867,11 @@ async fn cleanup_failed_startup<S: Spec>(
 
 async fn cleanup_failed_startup_before_sequencer(
     main_shutdown_sender: &watch::Sender<()>,
-    secondary_shutdown_sender: &watch::Sender<()>,
+    secondary_shutdown_controller: &SecondaryShutdownController,
     background_handles: &mut Vec<JoinHandle<()>>,
 ) {
     let _ = main_shutdown_sender.send(());
-    let _ = secondary_shutdown_sender.send(());
+    let _ = secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
 
@@ -959,7 +956,7 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
     pub genesis_slot_number: u64,
 
     // Trigger after the runner has finished.
-    secondary_shutdown_sender: tokio::sync::watch::Sender<()>,
+    secondary_shutdown_controller: SecondaryShutdownController,
 
     background_handles: Vec<tokio::task::JoinHandle<()>>,
 
@@ -996,7 +993,7 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
             );
         }
 
-        if self.secondary_shutdown_sender.send(()).is_err() {
+        if self.secondary_shutdown_controller.shutdown().is_err() {
             tracing::info!(
                 "Failed to send secondary shutdown signal because all receivers have been dropped"
             );

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -851,7 +851,7 @@ async fn cleanup_failed_startup<S: Spec>(
     sequencer: &mut SequencerCreationReceipt<S>,
 ) {
     let _ = main_shutdown_sender.send(());
-    let _ = secondary_shutdown_controller.shutdown();
+    secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
     let sequencer_background_handles = std::mem::take(&mut sequencer.background_handles);
@@ -871,7 +871,7 @@ async fn cleanup_failed_startup_before_sequencer(
     background_handles: &mut Vec<JoinHandle<()>>,
 ) {
     let _ = main_shutdown_sender.send(());
-    let _ = secondary_shutdown_controller.shutdown();
+    secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
 
@@ -993,11 +993,7 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
             );
         }
 
-        if self.secondary_shutdown_controller.shutdown().is_err() {
-            tracing::info!(
-                "Failed to send secondary shutdown signal because all receivers have been dropped"
-            );
-        }
+        self.secondary_shutdown_controller.shutdown();
 
         // blocks until background handles have shutdown
         monitoring_task.await??;

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -124,10 +124,10 @@ where
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
         self.inner
-            .create_da_service(rollup_config, shutdown_receiver)
+            .create_da_service(rollup_config, secondary_shutdown_controller)
             .await
     }
 

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -7,10 +7,12 @@
 pub mod da;
 mod da_sync_state;
 pub mod ledger_api;
+mod secondary_shutdown;
 
 use std::future::Future;
 
 pub use da_sync_state::SyncStatus;
+pub use secondary_shutdown::SecondaryShutdownController;
 use tokio::select;
 use tokio::sync::watch;
 

--- a/crates/rollup-interface/src/node/secondary_shutdown.rs
+++ b/crates/rollup-interface/src/node/secondary_shutdown.rs
@@ -26,10 +26,7 @@ impl SecondaryShutdownController {
     }
 
     /// Runs a future until it completes or the secondary shutdown signal fires.
-    pub async fn future_or_shutdown<T>(
-        &self,
-        inner: T,
-    ) -> FutureOrShutdownOutput<T::Output>
+    pub async fn future_or_shutdown<T>(&self, inner: T) -> FutureOrShutdownOutput<T::Output>
     where
         T: Future,
     {

--- a/crates/rollup-interface/src/node/secondary_shutdown.rs
+++ b/crates/rollup-interface/src/node/secondary_shutdown.rs
@@ -1,0 +1,49 @@
+use std::future::Future;
+
+use tokio::sync::watch;
+
+use super::{future_or_shutdown, FutureOrShutdownOutput};
+
+/// Controls the secondary shutdown channel used after the main runner exits.
+#[derive(Clone)]
+pub struct SecondaryShutdownController {
+    sender: watch::Sender<()>,
+    receiver: watch::Receiver<()>,
+}
+
+impl SecondaryShutdownController {
+    /// Creates a new secondary shutdown controller.
+    pub fn new() -> Self {
+        let (sender, mut receiver) = watch::channel(());
+        receiver.mark_unchanged();
+        Self { sender, receiver }
+    }
+
+    /// Waits until a secondary shutdown notification is sent.
+    pub async fn changed(&self) -> Result<(), watch::error::RecvError> {
+        let mut shutdown_receiver = self.receiver.clone();
+        shutdown_receiver.changed().await
+    }
+
+    /// Runs a future until it completes or the secondary shutdown signal fires.
+    pub async fn future_or_shutdown_secondary<T>(
+        &self,
+        inner: T,
+    ) -> FutureOrShutdownOutput<T::Output>
+    where
+        T: Future,
+    {
+        future_or_shutdown(inner, &self.receiver).await
+    }
+
+    /// Sends a secondary shutdown notification.
+    pub fn shutdown(&self) -> Result<(), watch::error::SendError<()>> {
+        self.sender.send(())
+    }
+}
+
+impl Default for SecondaryShutdownController {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/rollup-interface/src/node/secondary_shutdown.rs
+++ b/crates/rollup-interface/src/node/secondary_shutdown.rs
@@ -20,7 +20,7 @@ impl SecondaryShutdownController {
     }
 
     /// Waits until a secondary shutdown notification is sent.
-    pub async fn changed(&self) -> Result<(), watch::error::RecvError> {
+    pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
         let mut shutdown_receiver = self.receiver.clone();
         shutdown_receiver.changed().await
     }

--- a/crates/rollup-interface/src/node/secondary_shutdown.rs
+++ b/crates/rollup-interface/src/node/secondary_shutdown.rs
@@ -26,7 +26,7 @@ impl SecondaryShutdownController {
     }
 
     /// Runs a future until it completes or the secondary shutdown signal fires.
-    pub async fn future_or_shutdown_secondary<T>(
+    pub async fn future_or_shutdown<T>(
         &self,
         inner: T,
     ) -> FutureOrShutdownOutput<T::Output>
@@ -37,8 +37,12 @@ impl SecondaryShutdownController {
     }
 
     /// Sends a secondary shutdown notification.
-    pub fn shutdown(&self) -> Result<(), watch::error::SendError<()>> {
-        self.sender.send(())
+    pub fn shutdown(&self) {
+        // The controller keeps its own receiver alive for as long as it exists,
+        // so there is always at least one receiver and `send` cannot fail here.
+        self.sender
+            .send(())
+            .expect("secondary shutdown channel always has a live receiver");
     }
 }
 

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -213,9 +213,10 @@ where
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
-        StorableMockDaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+        StorableMockDaService::from_config(rollup_config.da.clone(), secondary_shutdown_controller)
+            .await
     }
 
     async fn create_prover_service(

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -113,7 +113,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
         CelestiaService::new(
             rollup_config.da.clone(),
@@ -121,7 +121,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
                 rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
                 rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
             },
-            shutdown_receiver,
+            secondary_shutdown_controller,
         )
         .await
     }

--- a/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
+++ b/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
@@ -50,6 +50,6 @@ async fn main() -> anyhow::Result<()> {
     .await;
 
     sov_celestia_adapter::checker::check_da_service(&da_service, args.rounds).await?;
-    let _ = secondary_shutdown_controller.shutdown();
+    secondary_shutdown_controller.shutdown();
     Ok(())
 }

--- a/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
+++ b/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
@@ -5,6 +5,7 @@ use sov_celestia_adapter::verifier::RollupParams;
 use sov_celestia_adapter::CelestiaService;
 use sov_demo_rollup::{ROLLUP_BATCH_NAMESPACE, ROLLUP_PROOF_NAMESPACE};
 use sov_modules_rollup_blueprint::logging::initialize_logging;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use sov_stf_runner::{from_toml_path, RollupConfig};
 
 /// Simple program description
@@ -37,19 +38,18 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Rollup config: {:?}", rollup_config);
 
-    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());
-    shutdown_rx.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
     let da_service = CelestiaService::new(
         rollup_config.da.clone(),
         RollupParams {
             rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
             rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
         },
-        shutdown_rx,
+        &secondary_shutdown_controller,
     )
     .await;
 
     sov_celestia_adapter::checker::check_da_service(&da_service, args.rounds).await?;
-    shutdown_tx.send(())?;
+    let _ = secondary_shutdown_controller.shutdown();
     Ok(())
 }

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -134,7 +134,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        _secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
         StorableMockDaClient::from_config(rollup_config.da.clone())
             .expect("Failed to create da service")

--- a/examples/demo-rollup/src/external_mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_sp1_rollup.rs
@@ -128,7 +128,7 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        _secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
         StorableMockDaClient::from_config(rollup_config.da.clone())
             .expect("Failed to create da service")

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -135,9 +135,10 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
-        StorableMockDaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+        StorableMockDaService::from_config(rollup_config.da.clone(), secondary_shutdown_controller)
+            .await
     }
 
     async fn create_prover_service(

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -128,9 +128,10 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
-        StorableMockDaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+        StorableMockDaService::from_config(rollup_config.da.clone(), secondary_shutdown_controller)
+            .await
     }
 
     async fn create_prover_service(

--- a/examples/demo-rollup/tests/external_mock_da.rs
+++ b/examples/demo-rollup/tests/external_mock_da.rs
@@ -8,18 +8,18 @@ use std::net::SocketAddr;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaConfig};
-use tokio::sync::watch;
+use sov_rollup_interface::node::SecondaryShutdownController;
 
 /// Mock-DA sequencer address. Must match
 /// `examples/test-data/genesis/integration-tests/sequencer_registry.json`,
 /// otherwise batches are rejected.
 pub const TEST_SEQ_DA_ADDRESS: MockAddress = MockAddress::new([0; 32]);
 
-/// Resources owned by [`start_external_mock_da`]. Dropping `shutdown` stops
-/// the DA service's background tasks.
+/// Resources owned by [`start_external_mock_da`]. Call `shutdown.shutdown()` to
+/// stop the DA service's background tasks.
 pub struct ExternalDa {
     pub service: StorableMockDaService,
-    pub shutdown: watch::Sender<()>,
+    pub shutdown: SecondaryShutdownController,
     pub addr: SocketAddr,
 }
 
@@ -28,10 +28,10 @@ pub struct ExternalDa {
 pub async fn start_external_mock_da(
     block_producing: BlockProducingConfig,
 ) -> anyhow::Result<ExternalDa> {
-    let (shutdown, shutdown_receiver) = watch::channel(());
+    let shutdown = SecondaryShutdownController::new();
     let mut config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
     config.block_producing = block_producing;
-    let service = StorableMockDaService::from_config(config, shutdown_receiver).await;
+    let service = StorableMockDaService::from_config(config, &shutdown).await;
     let addr = start_server(service.clone(), "127.0.0.1", 0).await?;
     Ok(ExternalDa {
         service,

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -286,7 +286,7 @@ impl NodeDiscoveryTestSetup {
 
     async fn shutdown(self) {
         self.cluster_info_service.shutdown();
-        let _ = self.da_shutdown.shutdown();
+        self.da_shutdown.shutdown();
     }
 
     async fn wait_for_cluster_change(&mut self) -> ClusterInfo {

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -35,6 +35,7 @@ use sov_proxy_utils::ClusterInfo;
 use sov_proxy_utils::ClusterInfoService;
 use sov_proxy_utils::RootHashCheck;
 use sov_proxy_utils::RootHashConsistency;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use sov_sequencer::preferred::ConfiguredNodeRole;
 use sov_sequencer::preferred::RecoveryStrategy;
 use sov_sequencer::SequencerRole;
@@ -48,7 +49,6 @@ use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::watch;
 use tokio::time::Duration;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;
@@ -222,7 +222,7 @@ struct NodeDiscoveryTestSetup {
     postgres: Arc<PostgresData>,
     da_service: StorableMockDaService,
     da_addr: SocketAddr,
-    da_shutdown: watch::Sender<()>,
+    da_shutdown: SecondaryShutdownController,
     cluster_info_service: ClusterInfoService,
 }
 
@@ -286,7 +286,7 @@ impl NodeDiscoveryTestSetup {
 
     async fn shutdown(self) {
         self.cluster_info_service.shutdown();
-        let _ = self.da_shutdown.send(());
+        let _ = self.da_shutdown.shutdown();
     }
 
     async fn wait_for_cluster_change(&mut self) -> ClusterInfo {

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -63,7 +63,7 @@ async fn test_replica_receives_txs_from_da() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.shutdown();
+    da_shutdown.shutdown();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -63,7 +63,7 @@ async fn test_replica_receives_txs_from_da() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.send(());
+    let _ = da_shutdown.shutdown();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -244,7 +244,7 @@ async fn test_replica_start_stop() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.shutdown();
+    da_shutdown.shutdown();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -329,5 +329,5 @@ async fn test_replica_start_stop_many_times() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.shutdown();
+    da_shutdown.shutdown();
 }

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -244,7 +244,7 @@ async fn test_replica_start_stop() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.send(());
+    let _ = da_shutdown.shutdown();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -329,5 +329,5 @@ async fn test_replica_start_stop_many_times() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.send(());
+    let _ = da_shutdown.shutdown();
 }

--- a/examples/demo-rollup/tests/replica/toxi_proxy_helper.rs
+++ b/examples/demo-rollup/tests/replica/toxi_proxy_helper.rs
@@ -4,7 +4,7 @@ use sov_test_utils::sov_toxi_proxi_image::ToxiProxySetup;
 
 pub(crate) struct NodeTestSetup {
     postgres: Arc<PostgresData>,
-    da_shutdown: watch::Sender<()>,
+    da_shutdown: SecondaryShutdownController,
     da_addr: SocketAddr,
     toxiproxy_setup: ToxiProxySetup,
     direct_postgres_connection_string: String,
@@ -99,7 +99,7 @@ impl NodeTestSetup {
     pub(crate) async fn shutdown(self, leader: TestRollup<Rollup>, replica: TestRollup<Rollup>) {
         let _ = replica.shutdown().await;
         let _ = leader.shutdown().await;
-        let _ = self.da_shutdown.send(());
+        let _ = self.da_shutdown.shutdown();
         self.toxiproxy_setup.shutdown();
     }
 

--- a/examples/demo-rollup/tests/replica/toxi_proxy_helper.rs
+++ b/examples/demo-rollup/tests/replica/toxi_proxy_helper.rs
@@ -99,7 +99,7 @@ impl NodeTestSetup {
     pub(crate) async fn shutdown(self, leader: TestRollup<Rollup>, replica: TestRollup<Rollup>) {
         let _ = replica.shutdown().await;
         let _ = leader.shutdown().await;
-        let _ = self.da_shutdown.shutdown();
+        self.da_shutdown.shutdown();
         self.toxiproxy_setup.shutdown();
     }
 

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -18,6 +18,7 @@ use sov_modules_api::CryptoSpec;
 use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
+use sov_rollup_interface::node::SecondaryShutdownController;
 use sov_sequencer::SeqConfigExtension;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::{RollupBuilder, StoragePath, TestRollup};
@@ -128,9 +129,9 @@ async fn test_start_stop_with_crash(
     mock_da_config.block_producing = BlockProducingConfig::Periodic {
         block_time_ms: 1_000,
     };
-    let (shutdown_sender, mut shutdown_receiver) = tokio::sync::watch::channel(());
-    shutdown_receiver.mark_unchanged();
-    let da_service = StorableMockDaService::from_config(mock_da_config, shutdown_receiver).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service =
+        StorableMockDaService::from_config(mock_da_config, &secondary_shutdown_controller).await;
     let da_layer = da_service.da_layer();
 
     let key_and_address = read_private_key::<MockRollupSpec<Native>>("tx_signer_private_key.json");
@@ -222,7 +223,7 @@ async fn test_start_stop_with_crash(
         test_rollup.shutdown().await?;
     }
 
-    shutdown_sender.send(())?;
+    secondary_shutdown_controller.shutdown()?;
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -223,7 +223,7 @@ async fn test_start_stop_with_crash(
         test_rollup.shutdown().await?;
     }
 
-    secondary_shutdown_controller.shutdown()?;
+    secondary_shutdown_controller.shutdown();
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/restart/proofs.rs
+++ b/examples/demo-rollup/tests/restart/proofs.rs
@@ -110,5 +110,5 @@ async fn test_aggregated_proofs_after_restart_external_da() {
     wait_for_aggregated_proofs(&test_rollup, 9).await;
 
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.send(());
+    let _ = da_shutdown.shutdown();
 }

--- a/examples/demo-rollup/tests/restart/proofs.rs
+++ b/examples/demo-rollup/tests/restart/proofs.rs
@@ -110,5 +110,5 @@ async fn test_aggregated_proofs_after_restart_external_da() {
     wait_for_aggregated_proofs(&test_rollup, 9).await;
 
     let _ = test_rollup.shutdown().await;
-    let _ = da_shutdown.shutdown();
+    da_shutdown.shutdown();
 }


### PR DESCRIPTION
# Description

  This PR hides secondary shutdown signaling behind `SecondaryShutdownController` and threads it through DA services, proof workflows, metrics, and rollup blueprint setup.

  Changes:
  - Adds `SecondaryShutdownController` in sov-rollup-interface.
  - Updates Celestia and mock DA background tasks to use the controller.
  - Updates OP/ZK/operator proof workflows to use secondary shutdown through the controller.
  - Updates metrics publisher initialization to use the shared shutdown controller.
  - Propagates sov-rollup-interface/native through sov-metrics.
  - Adjusts tests and demo rollups for the new shutdown API.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
