### PR TITLE
Fix warning about unused import from risc0 adatper in guest build

### DIFF
--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -117,14 +117,19 @@ impl ZkVerifier for Risc0Verifier {
         let receipt: risc0_zkvm::Receipt =
             sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
         receipt.verify(code_commitment.0)?;
-        Ok(sov_rollup_interface::common::strict_bincode_deserialize(&receipt.journal.bytes)?)
+        Ok(sov_rollup_interface::common::strict_bincode_deserialize(
+            &receipt.journal.bytes,
+        )?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
-        let receipt: risc0_zkvm::Receipt = sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
-        Ok(sov_rollup_interface::common::strict_bincode_deserialize(&receipt.journal.bytes)?)
+        let receipt: risc0_zkvm::Receipt =
+            sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        Ok(sov_rollup_interface::common::strict_bincode_deserialize(
+            &receipt.journal.bytes,
+        )?)
     }
 }
 

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -5,12 +5,9 @@
 //! Sovereign SDK rollups.
 use crypto::{Risc0PublicKey, Risc0Signature};
 use risc0_zkvm::sha::Digest;
-#[cfg(not(target_os = "zkvm"))]
-use risc0_zkvm::Receipt;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::common::strict_bincode_deserialize;
 use sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues;
 use sov_rollup_interface::zk::aggregated_proof::{CodeCommitmentDecodeError, CodeCommitmentHash};
 use sov_rollup_interface::zk::SerializedZkProof;
@@ -117,7 +114,8 @@ impl ZkVerifier for Risc0Verifier {
         serialized_proof: &SerializedZkProof,
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
-        let receipt: Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        let receipt: risc0_zkvm::Receipt =
+            sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
         receipt.verify(code_commitment.0)?;
         Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
@@ -125,7 +123,7 @@ impl ZkVerifier for Risc0Verifier {
     fn extract_public_data<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
-        let receipt: Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        let receipt: risc0_zkvm::Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
         Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
 }

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -117,14 +117,14 @@ impl ZkVerifier for Risc0Verifier {
         let receipt: risc0_zkvm::Receipt =
             sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
         receipt.verify(code_commitment.0)?;
-        Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
+        Ok(sov_rollup_interface::common::strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
-        let receipt: risc0_zkvm::Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
-        Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
+        let receipt: risc0_zkvm::Receipt = sov_rollup_interface::common::strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        Ok(sov_rollup_interface::common::strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
 }
 


### PR DESCRIPTION
# Description

```
sov-demo-prover-guest-celestia-risc0: warning: unused import: `sov_rollup_interface::common::strict_bincode_deserialize`
sov-demo-prover-guest-celestia-risc0:   --> /home/ubuntu/sovereign-sdk/crates/adapters/risc0/src/lib.rs:13:5
sov-demo-prover-guest-celestia-risc0:    |
sov-demo-prover-guest-celestia-risc0: 13 | use sov_rollup_interface::common::strict_bincode_deserialize;
sov-demo-prover-guest-celestia-risc0:    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sov-demo-prover-guest-celestia-risc0:    |
sov-demo-prover-guest-celestia-risc0:    = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
```

------

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/3004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->