### PR TITLE
Reject malformed decimal integer strings

### DIFF
--- a/typescript/packages/serializers/src/js/json-to-borsh.ts
+++ b/typescript/packages/serializers/src/js/json-to-borsh.ts
@@ -317,6 +317,9 @@ export class JsonToBorshConverter {
         if (integerType.includes("128") || integerType.includes("64")) {
           value = BigInt(context.value);
         } else {
+          if (!/^[+-]?\d+$/.test(context.value)) {
+            throw new Error("Invalid integer");
+          }
           const parsed = Number.parseInt(context.value, 10);
           if (isNaN(parsed)) {
             throw new Error("NaN");

--- a/typescript/packages/serializers/tests/js.test.ts
+++ b/typescript/packages/serializers/tests/js.test.ts
@@ -39,4 +39,16 @@ describe("js", () => {
       },
     );
   });
+
+  describe("integer parsing", () => {
+    it("rejects malformed decimal integer strings", () => {
+      expect(() => js.serialize({ Number: { U32: "12abc" } }, 0)).toThrow(
+        "Expected u32",
+      );
+    });
+
+    it("serializes canonical decimal integer strings", () => {
+      expect(() => js.serialize({ Number: { U32: "12" } }, 0)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
The JS serializer currently parses decimal strings for smaller integer types with `Number.parseInt`, so inputs such as `12abc` are accepted as `12`.

This adds a canonical decimal string check before parsing and covers the malformed string case while preserving normal decimal strings.