### PR TITLE
ci: cache SP1 guest builds, rebalance cargo-hack partitions, drop dead env

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,7 +105,6 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
       SKIP_GUEST_BUILD: "1"
-      SP1_SKIP_PROGRAM_BUILD: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -146,6 +145,15 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Nested zkVM guest target dirs live outside the main `target/` that
+          # `cache: rust` covers; cache them explicitly so the SP1 guests are
+          # served from cache instead of rebuilt on every run.
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
+            crates/bench/sp1-microbenches/guest-sha256/target
+            crates/bench/sp1-microbenches/guest-ed25519/target
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -166,6 +174,12 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Cache the nested SP1 guest target dirs (outside the main `target/`)
+          # so they aren't rebuilt on every run.
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
       - name: rollup bench check
         env:
           SOV_BENCH_BLOCKS: 10
@@ -183,14 +197,13 @@ jobs:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=hack-all-targets-1-93-p${{ matrix.partition }}
     strategy:
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4, 5, 6]
     timeout-minutes: 120
     env:
       RUSTFLAGS: "-D warnings"
       SKIP_GUEST_BUILD: "1"
-      SP1_SKIP_PROGRAM_BUILD: "true"
       CARGO_HACK_PARTITION_N: ${{ matrix.partition }}
-      CARGO_HACK_PARTITION_M: 3
+      CARGO_HACK_PARTITION_M: 6
     steps:
       - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -214,14 +227,13 @@ jobs:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=hack-default-targets-1-93-p${{ matrix.partition }}
     strategy:
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4, 5, 6]
     timeout-minutes: 120
     env:
       RUSTFLAGS: "-D warnings"
       SKIP_GUEST_BUILD: "1"
-      SP1_SKIP_PROGRAM_BUILD: "true"
       CARGO_HACK_PARTITION_N: ${{ matrix.partition }}
-      CARGO_HACK_PARTITION_M: 3
+      CARGO_HACK_PARTITION_M: 6
     steps:
       - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -247,6 +259,17 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Nested zkVM guest target dirs live outside the main `target/` that
+          # `cache: rust` covers; cache them explicitly so the SP1 guests are
+          # served from cache instead of rebuilt on every run. (risc0 builds into
+          # `target/riscv-guest` under the main target; caching it is a follow-up
+          # pending CI validation.)
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
+            crates/bench/sp1-microbenches/guest-sha256/target
+            crates/bench/sp1-microbenches/guest-ed25519/target
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -261,7 +284,6 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
       SKIP_GUEST_BUILD: "1"
-      SP1_SKIP_PROGRAM_BUILD: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -281,7 +303,6 @@ jobs:
     timeout-minutes: 90
     env:
       SKIP_GUEST_BUILD: "1"
-      SP1_SKIP_PROGRAM_BUILD: "true"
       RUST_BACKTRACE: 1
       CARGO_BUILD_JOBS: 4
     steps:
@@ -434,6 +455,12 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Cache the nested SP1 guest target dirs (outside the main `target/`)
+          # so they aren't rebuilt on every run.
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
       - name: Compile README.md to Bash
         run: bashtestmd --input examples/demo-rollup/README_CELESTIA.md --output demo-rollup-readme.sh --tag test-ci
       - run: cat demo-rollup-readme.sh
@@ -452,6 +479,12 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Cache the nested SP1 guest target dirs (outside the main `target/`)
+          # so they aren't rebuilt on every run.
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -495,7 +528,6 @@ jobs:
       - check
     timeout-minutes: 60
     env:
-      SP1_SKIP_PROGRAM_BUILD: "true"
       SKIP_GUEST_BUILD: "1"
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
@@ -545,7 +577,6 @@ jobs:
       - check
     timeout-minutes: 60
     env:
-      SP1_SKIP_PROGRAM_BUILD: "true"
       SKIP_GUEST_BUILD: "1"
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
@@ -585,6 +616,10 @@ jobs:
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
+      # Mirror the real `check` job, which skips guest builds. Without this the
+      # timing job builds the SP1/RISC0 guests and over-reports check's compile
+      # time (and pollutes the shared check-1-93 cache with guest artifacts).
+      SKIP_GUEST_BUILD: "1"
     steps:
       - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -613,6 +648,14 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+          # Mirror nextest_all_features' guest cache so this timing job measures
+          # the same incremental state (and validates guest caching).
+          path: |
+            examples/demo-rollup/provers/sp1/guest-mock/target
+            examples/demo-rollup/provers/sp1/guest-celestia/target
+            examples/demo-rollup/provers/sp1/guest-aggregation-mock/target
+            crates/bench/sp1-microbenches/guest-sha256/target
+            crates/bench/sp1-microbenches/guest-ed25519/target
       - run: cargo switcheroo disable
         shell: bash
       - name: Build test binaries with timings (all features)


### PR DESCRIPTION
## Why

CI on `dev` runs **20–35 min** (median ≈ 24m over the last 12 successful runs). Profiling the critical path with the repo's own `timing_*` jobs shows it's gated by two jobs: `nextest_all_features` (~20m) and `cargo hack` partition‑3 (28–31m spikes).

**Where the compile time goes** (from `timing_nextest_all_features`, warm cache, 1880s cumulative recompile CPU):

| Unit | Time | Kind |
|------|------|------|
| `sp1` guest | **440s** | zkVM guest build script |
| `risc0` guest | **210s** | zkVM guest build script |
| `sp1-microbenches` guests | **209s** | zkVM guest build script |

The three guest builds are **~46% of recompile CPU**, and on the wall clock the single serial `sp1` build (~440s) ≈ the **entire** ~500s compile phase — everything else is small (<50s) and parallelizes away. They rebuild **every run** because the nested `guest-*/target` dirs live **outside** the main `target/` that `cache: rust` covers (the same gap the `check` job already patches with `path: ./crates/fuzz/target`).

## What this PR does

**3A — Cache the SP1 guest target dirs** on every guest‑building job (`nextest_all_features`, `timing_nextest_all_features`, `bench_check`, `rollup_tps_validation`, both `check-demo-rollup-bash-commands*`):
```yaml
path: |
  examples/demo-rollup/provers/sp1/guest-*/target
  crates/bench/sp1-microbenches/guest-*/target   # full-guest jobs only
```
Expected: test‑job compile floor drops from ~440s (sp1) toward ~210s (risc0 becomes the new floor) — roughly **‑4 min off the critical path**, more once risc0 is cached too.

**2A — Rebalance `cargo hack` 3 → 6 partitions.** The 407 feature‑powerset combos are split **by count, not cost**, so the expensive core crates (`sov-modules-api` 128 combos, `sov-state`, `sov-bank`, …) piled into partition 3 (28–31 min). Six partitions spread them (est. ~15–18 min worst partition).

**4 — Hygiene.**
- `timing_check` now sets `SKIP_GUEST_BUILD=1` so it mirrors the real `check` job — it was building guests (~408s) and **over‑reporting** check's compile time on the dashboard.
- Removed the dead `SP1_SKIP_PROGRAM_BUILD` env from all 7 jobs that set it: each also sets `SKIP_GUEST_BUILD=1`, which makes the sp1 build scripts return **before** `sp1_build` ever reads `SP1_SKIP_PROGRAM_BUILD`.

## Correctness / safety notes

- **`path:` is additive, not a replacement.** Verified in the action source (`src/action.ts`): `cache` → `--mode=rust` and `path` → `--path=…` are passed as **independent** args to `spacectl`. The `cache: rust` preset (main `target/`, `~/.cargo`) is untouched. Already relied upon by `check` (`+ crates/fuzz/target`) and `check-web3-js-sdk-integration` (`+ typescript/.turbo`).
- **Cache invalidation is correct.** `sp1_build::cargo_rerun_if_changed` already emits `rerun-if-changed` for each guest's `src/`/`bin/`/`build.rs`/`Cargo.toml`, the workspace `Cargo.lock`, and local path‑deps — so a guest change rebuilds and refreshes the cached target (no stale ELF). No guest `build.rs` change is needed.
- **risc0 caching is intentionally deferred.** It builds into `target/riscv-guest` (under the main target) and `risc0_build` 3.0.5 does **not** track guest sources, so caching it safely needs a `rerun-if-changed` guard in `provers/risc0/build.rs` — a focused follow‑up once this PR confirms the SP1 win.

## Validation

CI‑config‑only change (no Rust/source changes). Validated by the workflow's own `--timings` jobs across consecutive runs: on a cache hit, the `sp1`/`sp1-microbenches` build‑script units should **drop off** the `timing_nextest_all_features` recompiled‑units list and the compile phase should fall from ~500s toward ~200s. Notes:
- First run after merge: partition caches `p4/p5/p6` start cold (one‑time), and the new guest cache entries populate on the first guest build.
- Cache size: guest target dirs add ~1–2 GB per cache tag; guest sources change rarely so the cache stays stable (not churning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/3008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->