### PR TITLE
 Add primary shutdown controller for rollup services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12200,6 +12200,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sov-rest-utils",
+ "sov-rollup-interface",
  "test-strategy",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/bench/sp1-microbenches/guest-ed25519/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-ed25519/Cargo.lock
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",

--- a/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -18,9 +18,9 @@ use sov_modules_api::{DaSpec, EventModuleName, RuntimeEventResponse};
 use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::node::da::{DaService, SubmitBlobReceipt};
 use sov_rollup_interface::node::ledger_api::{LedgerStateProvider, QueryMode};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, PrimaryShutdownController};
 use sov_rollup_interface::stf::BlobDiscardReason;
-use tokio::sync::{broadcast, oneshot, watch, Mutex};
+use tokio::sync::{broadcast, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::{interval, sleep};
 use tracing::{debug, error, info, trace};
@@ -80,8 +80,7 @@ pub struct BlobSender<Da: DaService, H, FM: FinalizationManager> {
     db: Arc<BlobSenderDb>,
     hooks: Arc<H>,
     in_flight_blobs: Arc<Mutex<HashMap<BlobInternalId, InFlightBlob<Da::Spec>>>>,
-    shutdown_receiver: watch::Receiver<()>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     da: Da,
     finalization_manager: FM,
     nb_of_concurrent_batch_blob_submissions: Arc<AtomicUsize>,
@@ -103,7 +102,7 @@ where
         finalization_manager: FM,
         storage_path: &Path,
         hooks: H,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         blob_processing_timeout: Duration,
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
         completed_blobs_to_send: Vec<(BlobToSend, BlobInternalId)>,
@@ -115,7 +114,7 @@ where
             finalization_manager,
             storage_path,
             hooks,
-            shutdown_sender,
+            primary_shutdown,
             blob_processing_timeout,
             blob_sender_channel,
             LEDGER_POLL_INTERVAL,
@@ -131,7 +130,7 @@ where
         finalization_manager: FM,
         storage_path: &Path,
         hooks: H,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         blob_processing_timeout: Duration,
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
         ledger_pool_interval: Duration,
@@ -139,7 +138,6 @@ where
         nb_of_concurrent_batch_blob_submissions: Arc<AtomicUsize>,
         nb_of_concurrent_proof_blob_submissions: Arc<AtomicUsize>,
     ) -> anyhow::Result<(Self, JoinHandle<()>)> {
-        let shutdown_receiver = shutdown_sender.subscribe();
         let db = Arc::new(BlobSenderDb::new(storage_path).await?);
 
         let mut all_blobs = db.get_all::<Da::Spec>().await?;
@@ -165,8 +163,7 @@ where
             db,
             hooks,
             in_flight_blobs: in_flight_blobs.clone(),
-            shutdown_receiver: shutdown_receiver.clone(),
-            shutdown_sender,
+            primary_shutdown: primary_shutdown.clone(),
             da,
             finalization_manager,
             nb_of_concurrent_batch_blob_submissions,
@@ -177,7 +174,7 @@ where
             blobs_to_send_after_restart: Some(all_blobs),
         };
 
-        let handle = Self::main_task(in_flight_blobs, shutdown_receiver).await;
+        let handle = Self::main_task(in_flight_blobs, primary_shutdown).await;
 
         Ok((sender, handle))
     }
@@ -289,7 +286,7 @@ where
         blob_id: BlobInternalId,
         latest_known_processing_state: BlobExecutionStatus<Da::Spec>,
     ) -> anyhow::Result<()> {
-        if self.shutdown_receiver.has_changed()? {
+        if self.primary_shutdown.is_triggered() {
             info!("BlobSender: shutdown signal received, skipping blob submission");
             return Ok(());
         }
@@ -325,10 +322,10 @@ where
             blob_processing_timeout: self.blob_processing_timeout,
             ledger_pool_interval: self.ledger_pool_interval,
             blob_sender_channel: self.blob_sender_channel.clone(),
-            shutdown_sender: self.shutdown_sender.clone(),
+            primary_shutdown: self.primary_shutdown.clone(),
         };
 
-        let shutdown_receiver = self.shutdown_receiver.clone();
+        let primary_shutdown = self.primary_shutdown.clone();
 
         task_state.inc_nb_of_concurrent_blob_submissions(is_batch);
         let handle = tokio::task::spawn({
@@ -342,7 +339,7 @@ where
                     blob_id,
                     latest_known_processing_state,
                 );
-                let res = future_or_shutdown(fut, &shutdown_receiver).await;
+                let res = primary_shutdown.future_or_shutdown(fut).await;
 
                 match res {
                     FutureOrShutdownOutput::Output(()) => {}
@@ -377,16 +374,16 @@ where
 
     async fn main_task(
         in_flight_blobs: Arc<Mutex<HashMap<BlobInternalId, InFlightBlob<Da::Spec>>>>,
-        mut shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut metrics_interval = interval(Duration::from_secs(10));
             loop {
-                let fut = future_or_shutdown(metrics_interval.tick(), &shutdown_receiver);
+                let fut = primary_shutdown.future_or_shutdown(metrics_interval.tick());
 
                 match fut.await {
                     FutureOrShutdownOutput::Shutdown => {
-                        if let Err(err) = shutdown_receiver.changed().await {
+                        if let Err(err) = primary_shutdown.wait_for_shutdown().await {
                             error!(%err, "BlobSender: The shutdown sender was dropped, shutting down anyway");
                         }
                     }
@@ -500,7 +497,7 @@ struct TaskState<Da: DaService, FM: FinalizationManager> {
     blob_processing_timeout: Duration,
     ledger_pool_interval: Duration,
     blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
@@ -633,7 +630,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         .is_err()
                     {
                         // If we can't save the state, we shut down.
-                        let _ = self.shutdown_sender.send(());
+                        self.primary_shutdown.shutdown();
                         return;
                     }
 
@@ -654,7 +651,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 ?blob_status,
                                 "BlobSender: unable to send blob. Shutting down."
                             );
-                            let _ = self.shutdown_sender.send(());
+                            self.primary_shutdown.shutdown();
                             return;
                         }
                     }
@@ -670,7 +667,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         .is_err()
                     {
                         // If we can't save the state, we shut down.
-                        let _ = self.shutdown_sender.send(());
+                        self.primary_shutdown.shutdown();
                         return;
                     }
 
@@ -695,7 +692,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                     %blob_hash,
                                     "Shutting down the rollup. Blob processing wasn't completed on time."
                                 );
-                                let _ = self.shutdown_sender.send(());
+                                self.primary_shutdown.shutdown();
                                 return;
                             }
 
@@ -721,7 +718,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             // Error is logged inside the method
                             Err(_) => {
                                 // If we can't check the finality status, we shut down.
-                                let _ = self.shutdown_sender.send(());
+                                self.primary_shutdown.shutdown();
                                 return;
                             }
                         };
@@ -756,7 +753,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         .is_err()
                     {
                         // If we can't save the state, we shut down.
-                        let _ = self.shutdown_sender.send(());
+                        self.primary_shutdown.shutdown();
                         return;
                     }
 
@@ -772,7 +769,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             Ok(finality_status) => finality_status,
                             Err(_) => {
                                 // If we can't check the finality status, we shut down.
-                                let _ = self.shutdown_sender.send(());
+                                self.primary_shutdown.shutdown();
                                 return;
                             }
                         };

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -221,6 +221,14 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
         handle.await.unwrap();
     }
 
+    // Simulate a process restart: rebuild the deps with a fresh shutdown controller
+    // (the old one is permanently triggered after the shutdown above), while keeping
+    // the same DA and storage so the persisted in-progress blob survives the restart.
+    let deps = Deps {
+        primary_shutdown: PrimaryShutdownController::new(),
+        ..deps
+    };
+
     // After restart, the blob sender, resubmits the previous blob on the first call to `publish_batch_blob`.
     {
         let (status_sender, mut status_receiver) = broadcast::channel(100);

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -13,11 +13,12 @@ use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::HexHash;
 use sov_rollup_interface::da::BlobReaderTrait;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobDiscardReason;
 use sov_test_utils::logging::LogCollector;
 use std::sync::atomic::AtomicUsize;
 use tempfile::TempDir;
-use tokio::sync::{broadcast, watch, RwLock};
+use tokio::sync::{broadcast, RwLock};
 use tokio::task::JoinHandle;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
@@ -181,7 +182,7 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
 
     // Wait for the blob task to start.
     status_reciever.recv().await.unwrap();
-    deps.shutdown_sender.send(()).unwrap();
+    deps.primary_shutdown.shutdown();
     handle.await.unwrap();
 
     let mut records = collector.records();
@@ -216,7 +217,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
                 .await?;
             data
         };
-        deps.shutdown_sender.send(()).unwrap();
+        deps.primary_shutdown.shutdown();
         handle.await.unwrap();
     }
 
@@ -277,7 +278,7 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     subscriber.init();
 
     let deps = create_deps().await;
-    let mut shutdown_receiver = deps.shutdown_sender.subscribe();
+    let primary_shutdown = deps.primary_shutdown.clone();
 
     let (mut blob_sender, blob_sender_handle) = create_blob_sender(
         Duration::from_secs(1),
@@ -295,8 +296,8 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
 
     // Blob publication fails due to the absence of DA blocks.
     // After MAX_NB_OF_BLOB_SUBMISSION_RETRIES attempts, BlobSender should request shutdown.
-    shutdown_receiver
-        .changed()
+    primary_shutdown
+        .wait_for_shutdown()
         .await
         .expect("The BlobSender should request shutdown after failing to process blobs.");
 
@@ -503,22 +504,20 @@ async fn proofs_in_flight_do_not_block_batch_gate() -> anyhow::Result<()> {
 
 struct Deps {
     _da_dir: TempDir,
-    shutdown_sender: watch::Sender<()>,
-    _shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     da: StorableMockDaService,
     storage_dir: TempDir,
 }
 
 async fn create_deps() -> Deps {
     let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, shutdown_receiver) = watch::channel(());
+    let primary_shutdown = PrimaryShutdownController::new();
     let da = create_da(&da_dir).await;
     let storage_dir = tempfile::tempdir().unwrap();
 
     Deps {
         _da_dir: da_dir,
-        shutdown_sender,
-        _shutdown_receiver: shutdown_receiver,
+        primary_shutdown,
         da,
         storage_dir,
     }
@@ -557,7 +556,7 @@ async fn create_blob_sender(
         finalization_manager,
         deps.storage_dir.path(),
         hooks,
-        deps.shutdown_sender.clone(),
+        deps.primary_shutdown.clone(),
         blob_processing_timeout,
         blob_status_sender,
         Duration::from_millis(1000),

--- a/crates/full-node/sov-ethereum/Cargo.toml
+++ b/crates/full-node/sov-ethereum/Cargo.toml
@@ -27,6 +27,7 @@ sov-sequencer = { workspace = true }
 sov-eth-dev-signer = { workspace = true }
 sov-metrics = { workspace = true, features = ["native"] }
 sov-rest-utils = { workspace = true }
+sov-rollup-interface = { workspace = true, features = ["native"] }
 
 borsh = { workspace = true }
 serde = { workspace = true }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -178,7 +178,7 @@ where
         let mut block = self.get_block(pending_block.block_number() - 1, &mut state)?;
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-        let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
+        let primary_shutdown = self.ethereum.primary_shutdown.clone();
 
         loop {
             tokio::select! {
@@ -201,7 +201,7 @@ where
                         self.send_matching_logs(&receipt, &block, &filter, time).await?;
                     }
                 }
-                _ = shutdown_receiver.changed() => {
+                _ = primary_shutdown.wait_for_shutdown() => {
                     tracing::info!("Shutdown signal received, terminating logs subscription gracefully");
                     break;
                 }
@@ -237,7 +237,7 @@ where
         );
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-        let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
+        let primary_shutdown = self.ethereum.primary_shutdown.clone();
         let mut last_send_time = std::time::Instant::now();
         let has_waker_task = Arc::new(AtomicBool::new(false));
         let (wakeup_sender, mut wakeup_receiver) = tokio::sync::watch::channel(());
@@ -307,7 +307,7 @@ where
                         }
                     }
                 }
-                _ = shutdown_receiver.changed() => {
+                _ = primary_shutdown.wait_for_shutdown() => {
                     tracing::info!("Shutdown signal received, terminating blocks subscription gracefully");
                     break;
                 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -8,6 +8,7 @@ pub use sov_eth_dev_signer::Signers;
 pub use sov_evm::EthereumAuthenticator;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::{ApiStateAccessor, DaSpec, SequencerType, Spec};
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rpc_eth_types::{internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code};
 use sov_sequencer::{SeqConfigExtension, Sequencer};
 use std::future::ready;
@@ -25,7 +26,7 @@ pub struct EthRpcConfig<S: Spec> {
     pub sequencer_da_address: <S::Da as DaSpec>::Address,
     pub sequencer_type: SequencerType,
     /// Shutdown signal receiver for graceful termination
-    pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    pub primary_shutdown: PrimaryShutdownController,
 }
 
 const LIMIT_EXCEEDED_CODE: i32 = -32005;
@@ -48,7 +49,7 @@ where
         sequencer_rollup_address,
         sequencer_da_address,
         sequencer_type,
-        shutdown_receiver,
+        primary_shutdown,
     } = eth_rpc_config;
 
     let mut rpc = RpcModule::new(Ethereum {
@@ -59,7 +60,7 @@ where
         sequencer_rollup_address,
         sequencer_da_address,
         sequencer_type,
-        shutdown_receiver,
+        primary_shutdown,
     });
 
     register_rpc_methods::<S, Seq>(&mut rpc).expect("Failed to register sequencer RPC methods");
@@ -164,7 +165,7 @@ struct Ethereum<S: Spec, Seq: Sequencer<Spec = S>> {
     sequencer_rollup_address: S::Address,
     sequencer_da_address: <S::Da as DaSpec>::Address,
     sequencer_type: SequencerType,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<S, Seq> Ethereum<S, Seq>

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_tx.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_tx.rs
@@ -22,7 +22,7 @@ async fn evm_tx_test(finalization_blocks: u32) -> anyhow::Result<()> {
     sanity_checks(&test_client).await;
     execute_evm_tests(&test_client, &test_rollup).await.unwrap();
 
-    test_rollup.shutdown_sender.send(()).unwrap();
+    test_rollup.primary_shutdown.shutdown();
     Ok(())
 }
 

--- a/crates/full-node/sov-ethereum/tests/integration/runtime.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/runtime.rs
@@ -73,7 +73,7 @@ where
     fn create<Seq>(
         sequencer: Seq,
         rollup_config: &RollupConfig<S::Address, StorableMockDaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_rollup_interface::da::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -102,7 +102,7 @@ where
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type,
-            shutdown_receiver,
+            primary_shutdown,
         };
 
         Ok(NodeEndpoints {

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -32,8 +32,8 @@ use sov_rollup_interface::node::ledger_api::{
     FinalityStatus, IncludeChildren, ItemOrHash, LedgerStateProvider, QueryMode, SlotIdAndOffset,
     SlotIdentifier, SlotResponse, TxIdAndOffset, TxIdentifier, TxResponse,
 };
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::TxReceiptContents;
-use tokio::sync::watch;
 
 type PathMap = Path<HashMap<String, NumberOrHash>>;
 
@@ -88,7 +88,7 @@ pub struct LedgerRoutes<T, B, Tx, E> {
 #[derive(Clone)]
 pub struct LedgerState<T: LedgerStateProvider + Clone + Send + Sync + 'static> {
     pub ledger: T,
-    pub shutdown_receiver: watch::Receiver<()>,
+    pub primary_shutdown: PrimaryShutdownController,
 }
 
 impl<T, B, TxReceipt, E> LedgerRoutes<T, B, TxReceipt, E>
@@ -109,11 +109,11 @@ where
     /// Returns an [`axum::Router`] that exposes ledger data.
     pub fn axum_router(
         ledger: T,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> axum::Router<LedgerState<T>> {
         let state = LedgerState {
             ledger,
-            shutdown_receiver,
+            primary_shutdown,
         };
         let routes = axum::Router::<LedgerState<T>>::new()
             .route(
@@ -732,7 +732,8 @@ where
                 })
                 .boxed();
 
-            serve_generic_ws_subscription(socket, subscription, state.shutdown_receiver).await;
+            serve_generic_ws_subscription(socket, subscription, state.primary_shutdown.clone())
+                .await;
         })
     }
 
@@ -750,7 +751,8 @@ where
                     WsLedgerError::AggregatedProofConvertFailed
                 })
             });
-            serve_generic_ws_subscription(socket, subscription, state.shutdown_receiver).await;
+            serve_generic_ws_subscription(socket, subscription, state.primary_shutdown.clone())
+                .await;
         })
     }
 
@@ -787,7 +789,8 @@ where
                 })
                 .boxed();
 
-            serve_generic_ws_subscription(socket, subscription, state.shutdown_receiver).await;
+            serve_generic_ws_subscription(socket, subscription, state.primary_shutdown.clone())
+                .await;
         })
     }
 
@@ -883,7 +886,7 @@ where
                 .flatten()
                 .boxed();
 
-            serve_generic_ws_subscription(socket, subscription, state.shutdown_receiver).await;
+            serve_generic_ws_subscription(socket, subscription, state.primary_shutdown.clone()).await;
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -25,9 +25,9 @@ use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::ledger_api::{ItemOrHash, LedgerStateProvider, QueryMode};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, PrimaryShutdownController};
 use thiserror::Error;
-use tokio::sync::{broadcast, watch, Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio::time::timeout;
 use tracing::{info, trace};
 
@@ -399,7 +399,7 @@ pub enum StateUpdateError {
 /// Polls for the next state update, handling shutdown, timeout, and debug flags
 pub async fn poll_state_update<S: Spec>(
     state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-    shutdown_receiver: &watch::Receiver<()>,
+    primary_shutdown: &PrimaryShutdownController,
     task_name: &'static str,
 ) -> Result<StateUpdateInfo<S::Storage>, StateUpdateError> {
     loop {
@@ -408,7 +408,7 @@ pub async fn poll_state_update<S: Spec>(
             state_update_receiver.changed(),
         );
 
-        let fut = future_or_shutdown(changed_with_timeout, shutdown_receiver);
+        let fut = primary_shutdown.future_or_shutdown(changed_with_timeout);
         let FutureOrShutdownOutput::Output(timeout_result) = fut.await else {
             return Err(StateUpdateError::Shutdown);
         };
@@ -442,7 +442,7 @@ pub async fn poll_state_update<S: Spec>(
 /// Automagically handles shutdown and error checking for you.
 pub async fn react_to_state_updates<S, Fut>(
     mut state_update_receiver: StateUpdateReceiver<S::Storage>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     task_name: &'static str,
     mut closure: impl FnMut(StateUpdateInfo<S::Storage>) -> Fut,
 ) where
@@ -451,7 +451,7 @@ pub async fn react_to_state_updates<S, Fut>(
 {
     loop {
         let poll_result =
-            poll_state_update::<S>(&mut state_update_receiver, &shutdown_receiver, task_name).await;
+            poll_state_update::<S>(&mut state_update_receiver, &primary_shutdown, task_name).await;
 
         match poll_result {
             Ok(info) => {
@@ -474,11 +474,11 @@ pub async fn react_to_state_updates<S, Fut>(
 pub async fn loop_call_update_state<Seq: Sequencer>(
     seq: Seq,
     state_update_receiver: StateUpdateReceiver<<Seq::Spec as Spec>::Storage>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 ) {
     react_to_state_updates::<Seq::Spec, _>(
         state_update_receiver,
-        shutdown_receiver,
+        primary_shutdown,
         "loop_call_update_state",
         |info| async {
             if cfg!(debug_assertions) {
@@ -500,7 +500,7 @@ pub async fn loop_call_update_state<Seq: Sequencer>(
 #[tracing::instrument(skip_all, level = "trace")]
 pub async fn loop_send_tx_notifications<S: Spec, Rt: RuntimeEventProcessor>(
     state_update_receiver: StateUpdateReceiver<S::Storage>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     ledger_db: &LedgerDb,
     txsm: &TxStatusManager<S::Da>,
 ) {
@@ -513,7 +513,7 @@ pub async fn loop_send_tx_notifications<S: Spec, Rt: RuntimeEventProcessor>(
         state_update_receiver.borrow().slot_number.next(),
     ));
 
-    react_to_state_updates::<S, _>(state_update_receiver, shutdown_receiver, "loop_send_tx_notifications", move |info| {
+    react_to_state_updates::<S, _>(state_update_receiver, primary_shutdown, "loop_send_tx_notifications", move |info| {
         let next_slot_to_process = next_slot_to_process.clone();
         async move {
             let storage_slot_number = info.slot_number;

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -22,12 +22,13 @@ use sov_modules_api::{CryptoSpec, HDTimestamp};
 use sov_modules_stf_blueprint::{BatchReceipt, StfBlueprint};
 use sov_rest_utils::{json_obj, ErrorObject};
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_state::sequencer_state::SequencerStateChanges;
 use sov_state::{StateRoot, Storage};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tracing::trace;
 use uuid::Uuid;
@@ -134,8 +135,7 @@ pub struct StartBlockData<S: Spec> {
 pub struct RollupBlockExecutorConfig<S: Spec> {
     pub da_address: <S::Da as DaSpec>::Address,
     pub shutdown_notifier: Sender<()>,
-    pub shutdown_receiver: watch::Receiver<()>,
-    pub shutdown_sender: watch::Sender<()>,
+    pub primary_shutdown: PrimaryShutdownController,
     pub state_root_request_sender: Sender<StateRootComputeRequest<S>>,
     pub forced_tx_batch_notifier: broadcast::Sender<ForcedTxBatchNotification>,
 }
@@ -149,8 +149,7 @@ where
 {
     pub checkpoint: StateCheckpoint<S>,
     seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
-    shutdown_receiver: watch::Receiver<()>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 
     rollup_block_task_state: Option<BackgroundTaskState<S>>,
     next_event_number: u64,
@@ -232,8 +231,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             da_address,
             shutdown_notifier,
             state_root_request_sender,
-            shutdown_receiver,
-            shutdown_sender,
+            primary_shutdown,
             forced_tx_batch_notifier,
         } = rollup_exec_config;
 
@@ -249,8 +247,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             state_roots: Default::default(),
             state_root_responses: Default::default(),
             id: Uuid::now_v7(),
-            shutdown_receiver,
-            shutdown_sender,
+            primary_shutdown,
             startup_transaction_cache_writer: tx_cache_writer,
             uncommitted_changes,
             forced_tx_batch_notifier,
@@ -264,7 +261,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
 
     #[tracing::instrument(skip_all, level = "trace")]
     pub async fn replace_state(&mut self, other: Self) {
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             tracing::info!("The sequencer is shutting down. Exiting replace_state");
             return;
         }
@@ -357,7 +354,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
 
         let Some(result) = task_state.result_receiver.recv().await else {
             tracing::error!("The rollup block executor task failed unexpectedly. Gracefully shutting down the sequencer.");
-            let _ = self.shutdown_sender.send(()); // We don't care if this fails, because that would mean the sequencer is already shutting down - which is exactly what we want.
+            self.primary_shutdown.shutdown(); // We don't care if this was already triggered, because that would mean the sequencer is already shutting down - which is exactly what we want.
             return Err(RollupBlockExecutorErrorWithBudget {
                 execution_time_micros: 0,
                 gas_used: <S as Spec>::Gas::zero(),
@@ -427,7 +424,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         )
         .await;
 
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             tracing::info!("The sequencer is shutting down. Exiting replay_batch");
             return Ok(());
         }
@@ -517,7 +514,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                         executor_output_hash = %output.accepted_tx.tx_hash,
                         "The executor returned a different tx hash than expected"
                     );
-                    exit_rollup(&self.shutdown_sender).await;
+                    exit_rollup(&self.primary_shutdown).await;
                     unreachable!()
                 }
                 output.execution_time_micros
@@ -529,7 +526,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                     "Transaction was soft-confirmed but failed to be re-applied; this is a bug, please report it",
                 );
 
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&self.primary_shutdown).await;
                 unreachable!()
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -206,7 +206,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         >,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let mut shutdown_receiver = exec_config.shutdown_receiver.clone();
+            let shutdown_receiver = exec_config.primary_shutdown.clone();
             let mut executor = RollupBlockExecutor::<_, Rt>::new(
                 &info,
                 exec_config,
@@ -272,7 +272,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                         }
 
                     }
-                   _ = shutdown_receiver.changed() => {
+                   _ = shutdown_receiver.wait_for_shutdown() => {
                         // Quit on shutdown.
                         return;
                    }

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -12,8 +12,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use sov_full_node_configs::sequencer::{ConfiguredNodeRole, PostgresConfig};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
-use tokio::sync::watch;
+use sov_rollup_interface::node::{FutureOrShutdownOutput, PrimaryShutdownController};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn, Instrument};
 
@@ -50,8 +49,7 @@ impl std::fmt::Display for LeadershipRole {
 pub struct HeartBeatTask {
     backend: PostgresBackend,
     node_id: String,
-    shutdown_sender: watch::Sender<()>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     postgres_config: PostgresConfig,
     heartbeat_interval: Duration,
 }
@@ -59,18 +57,16 @@ pub struct HeartBeatTask {
 impl HeartBeatTask {
     pub async fn new(
         postgres_config: PostgresConfig,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         bind_addr: SocketAddr,
         heartbeat_interval: Duration,
     ) -> Result<Self> {
         let backend = PostgresBackend::connect(&postgres_config, bind_addr).await?;
-        let shutdown_receiver = shutdown_sender.subscribe();
 
         Ok(Self {
             backend,
             node_id: postgres_config.node_id.clone(),
-            shutdown_sender,
-            shutdown_receiver,
+            primary_shutdown,
             postgres_config,
             heartbeat_interval,
         })
@@ -185,7 +181,7 @@ impl HeartBeatTask {
                     // makes the tick fire late, so `tick_elapsed` (below) overshoots
                     // the heartbeat interval.
                     let tick_start = Instant::now();
-                    match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
+                    match self.primary_shutdown.future_or_shutdown(interval.tick()).await {
                         FutureOrShutdownOutput::Shutdown => {
                             info!("Shutdown signal received, stopping heartbeat task");
                             // Only a replica deregisters; the leader is removed via the
@@ -248,7 +244,7 @@ impl HeartBeatTask {
                     node_id = %self.node_id,
                     "Leadership lost! Another node has taken over. Initiating graceful shutdown."
                 );
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&self.primary_shutdown).await;
             }
             Err(e) => {
                 error!(
@@ -256,7 +252,7 @@ impl HeartBeatTask {
                     error = ?e,
                     "Heartbeat error! Unable to communicate with database. Initiating graceful shutdown."
                 );
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&self.primary_shutdown).await;
             }
         }
     }
@@ -270,7 +266,7 @@ impl HeartBeatTask {
                     node_id = %self.node_id,
                     "Replica acquired leadership! Exiting to restart as leader."
                 );
-                let _ = self.shutdown_sender.send(());
+                self.primary_shutdown.shutdown();
                 true
             }
             Ok(LeadershipRole::Replica) => {
@@ -302,7 +298,7 @@ impl HeartBeatTask {
                 let mut interval = tokio::time::interval(self.heartbeat_interval);
 
                 loop {
-                    match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
+                    match self.primary_shutdown.future_or_shutdown(interval.tick()).await {
                         FutureOrShutdownOutput::Shutdown => {
                             info!(node_id = %self.node_id, "Shutdown signal received, stopping registration task.");
                             self.deregister_on_shutdown_best_effort().await;

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -28,12 +28,13 @@ use sov_modules_api::{
     FullyBakedTx, KernelStateAccessor, Runtime, Spec, StateCheckpoint, TxHash, VisibleSlotNumber,
 };
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::num::NonZero;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 
 use crate::common::WithCachedTxHashes;
 use crate::preferred::{exit_rollup, track_in_progress_batch_size};
@@ -227,20 +228,20 @@ pub struct BlobsCache {
     proofs_and_completed_batches: BTreeMap<SequenceNumber, ReadBlob>,
     in_progress_batch: Option<InProgressBatch>,
     event_stream: Option<mpsc::Sender<DbEvent>>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl BlobsCache {
     pub fn new(
         completed_blobs: BTreeMap<SequenceNumber, ReadBlob>,
         in_progress_batch: Option<InProgressBatch>,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> Self {
         Self {
             proofs_and_completed_batches: completed_blobs,
             in_progress_batch,
             event_stream: None,
-            shutdown_sender,
+            primary_shutdown,
         }
     }
 
@@ -359,7 +360,7 @@ impl BlobsCache {
     pub async fn insert_tx(&mut self, tx: FullyBakedTx, hash: TxHash) {
         let Some(batch) = self.in_progress_batch.as_mut() else {
             tracing::error!("No in-progress batch; this is a bug, please report it");
-            exit_rollup(&self.shutdown_sender).await;
+            exit_rollup(&self.primary_shutdown).await;
             unreachable!();
         };
         batch.txs.push(tx.clone());
@@ -408,7 +409,7 @@ impl BlobsCache {
             tracing::error!(
                 "There's already an in-progress batch; this is a bug, please report it"
             );
-            exit_rollup(&self.shutdown_sender).await;
+            exit_rollup(&self.primary_shutdown).await;
         };
         let blob_id = new_blob_id();
         self.in_progress_batch = Some(ReadBatch {
@@ -459,14 +460,14 @@ impl BlobsCache {
     pub async fn terminate_batch(&mut self) -> ReadBatch {
         let Some(in_progress_batch) = self.in_progress_batch.as_ref() else {
             tracing::error!("No in-progress batch; this is a bug, please report it");
-            exit_rollup(&self.shutdown_sender).await;
+            exit_rollup(&self.primary_shutdown).await;
             unreachable!();
         };
 
         let sequence_number = in_progress_batch.sequence_number;
         let Some(batch) = self.in_progress_batch.take() else {
             tracing::error!("No in-progress batch; this is a bug, please report it");
-            exit_rollup(&self.shutdown_sender).await;
+            exit_rollup(&self.primary_shutdown).await;
             unreachable!();
         };
 
@@ -538,12 +539,12 @@ impl SequencerRole {
 
 pub(crate) struct PreferredSequencerDb {
     backend: Option<Box<dyn DbBackend>>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl PreferredSequencerDb {
     pub(crate) async fn new(
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         storage_path: &Path,
         postgres_config: &Option<PostgresConfig>,
         bind_addr: SocketAddr,
@@ -596,7 +597,7 @@ impl PreferredSequencerDb {
         Ok((
             Self {
                 backend,
-                shutdown_sender,
+                primary_shutdown,
             },
             role,
         ))
@@ -629,7 +630,7 @@ impl PreferredSequencerDb {
                         BlobsCache::new(
                             completed_blobs,
                             in_progress_batch,
-                            self.shutdown_sender.clone(),
+                            self.primary_shutdown.clone(),
                         ),
                     ))
                 }
@@ -643,7 +644,7 @@ impl PreferredSequencerDb {
                         %operation,
                         "The primary has become a replica. Shutting down.",
                     );
-                    exit_rollup(&self.shutdown_sender).await;
+                    exit_rollup(&self.primary_shutdown).await;
                     unreachable!()
                 }
             }
@@ -653,7 +654,7 @@ impl PreferredSequencerDb {
                 BlobsCache::new(
                     Default::default(),
                     Option::None,
-                    self.shutdown_sender.clone(),
+                    self.primary_shutdown.clone(),
                 ),
             ))
         }
@@ -690,7 +691,7 @@ impl PreferredSequencerDb {
             Self::debug_assert_in_progress_batch_is_none(
                 "Cached in-progress batch state (None) didn't match backend db state",
                 backend,
-                &self.shutdown_sender,
+                &self.primary_shutdown,
             )
             .await;
 
@@ -729,7 +730,7 @@ impl PreferredSequencerDb {
                     %operation,
                     "The primary has become a replica. Shutting down.",
                 );
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&self.primary_shutdown).await;
                 unreachable!()
             }
         }
@@ -760,7 +761,7 @@ impl PreferredSequencerDb {
             Self::debug_assert_in_progress_batch_is_none(
                 "Backend didn't remove in-progress batch from database when ending rollup block",
                 backend,
-                &self.shutdown_sender,
+                &self.primary_shutdown,
             )
             .await;
         }
@@ -783,14 +784,14 @@ impl PreferredSequencerDb {
     async fn debug_assert_in_progress_batch_is_none(
         msg: &str,
         backend: &mut Box<dyn DbBackend>,
-        shutdown_sender: &watch::Sender<()>,
+        primary_shutdown: &PrimaryShutdownController,
     ) {
         if cfg!(debug_assertions) {
             match backend.read_in_progress_batch().await {
                 Ok(_) => {}
                 other => {
                     tracing::error!("{msg}: {other:?}");
-                    exit_rollup(shutdown_sender).await;
+                    exit_rollup(primary_shutdown).await;
                 }
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
@@ -25,9 +25,9 @@ async fn test_db_elected_resolution_returns_replica_when_leader_exists() {
 
     let storage_dir = tempfile::tempdir().unwrap();
     let bind_addr = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0));
-    let (shutdown_sender, _) = tokio::sync::watch::channel(());
+    let primary_shutdown = sov_rollup_interface::node::PrimaryShutdownController::new();
     let (_db, role) = crate::preferred::db::PreferredSequencerDb::new(
-        shutdown_sender,
+        primary_shutdown,
         storage_dir.path(),
         &Some(postgres_config),
         bind_addr,

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -5,8 +5,9 @@ use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::{Runtime, Spec, StateCheckpoint, TxChangeSet, VisibleSlotNumber};
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::common::AcceptedTx;
 use crate::metrics::{track_in_progress_batch_size, PreferredSequencerExecutorEventSendingMetrics};
@@ -22,19 +23,19 @@ const MAX_EXECUTOR_EVENT_QUEUE_DEPTH: usize = 1000;
 pub(crate) struct ExecutorEventsSender<S: Spec, Rt: Runtime<S>> {
     events_sender: mpsc::Sender<ExecutorEvent<S, Rt>>,
     cache: BlobsCache,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
     pub fn new(
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         cache: BlobsCache,
     ) -> (Self, mpsc::Receiver<ExecutorEvent<S, Rt>>) {
         let (sender, receiver) = mpsc::channel(MAX_EXECUTOR_EVENT_QUEUE_DEPTH);
         (
             Self {
                 events_sender: sender,
-                shutdown_sender,
+                primary_shutdown,
                 cache,
             },
             receiver,
@@ -43,7 +44,7 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
 
     async fn shutdown_on_error(&self) {
         tracing::error!("Failed to send executor event because the receiver was dropped. This indicates that the database is no longer available. Shutting down.");
-        exit_rollup(&self.shutdown_sender).await;
+        exit_rollup(&self.primary_shutdown).await;
     }
 
     /// Send an event tracking metrics on the queue depth and blocking time and shutting down on error.

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -55,11 +55,10 @@ where
         storage_path: &Path,
         ledger_db: LedgerDb,
         api_ledger_db: LedgerDb,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         stop_at_rollup_height: Option<RollupHeight>,
         bind_addr: SocketAddr,
     ) -> Result<(PreferredSequencer<S, Rt, Da>, Vec<JoinHandle<()>>)> {
-        let shutdown_receiver = shutdown_sender.subscribe();
         let latest_state_update = state_update_receiver.borrow().clone();
 
         let da_address = self
@@ -85,13 +84,13 @@ where
 
         let (api_state, checkpoint_sender) = Self::api_state(
             latest_state_update.storage.clone(),
-            shutdown_sender.subscribe(),
+            primary_shutdown.clone(),
         );
 
         let (blobs_sender_channel, _) = broadcast::channel(preferred_config.events_channel_size);
 
         let (db, seq_role) = PreferredSequencerDb::new(
-            shutdown_sender.clone(),
+            primary_shutdown.clone(),
             storage_path,
             &preferred_config.postgres_config,
             bind_addr,
@@ -108,7 +107,7 @@ where
             db_cache.all_proofs_and_completed_blobs().clone(),
             storage_path.into(),
             tx_status_manager.clone(),
-            shutdown_sender.clone(),
+            primary_shutdown.clone(),
             Duration::from_secs(config.blob_processing_timeout_secs),
             blobs_sender_channel.clone(),
             seq_role,
@@ -119,7 +118,7 @@ where
             blob_sender.highest_sequence_number_to_send_after_restart()?
         {
             if blob_sender_sequence_number >= next_sequence_number {
-                let _ = shutdown_sender.send(());
+                primary_shutdown.shutdown();
                 let preferred_db_highest_sequence_number = next_sequence_number
                     .checked_sub(1)
                     .map_or_else(|| "none".to_owned(), |seq| seq.to_string());
@@ -147,7 +146,7 @@ where
         );
 
         let (executor_events_sender, executor_events_receiver) =
-            ExecutorEventsSender::new(shutdown_sender.clone(), db_cache);
+            ExecutorEventsSender::new(primary_shutdown.clone(), db_cache);
 
         let in_flight_batch_blobs = blob_sender.nb_of_in_flight_batch_blobs();
         let in_flight_proof_blobs = blob_sender.nb_of_in_flight_proof_blobs();
@@ -157,8 +156,7 @@ where
             da_address,
             shutdown_notifier: block_executors_shutdown_notifier.clone(),
             state_root_request_sender: state_root_task.request_sender.clone(),
-            shutdown_receiver: shutdown_receiver.clone(),
-            shutdown_sender: shutdown_sender.clone(),
+            primary_shutdown: primary_shutdown.clone(),
             forced_tx_batch_notifier: forced_tx_batch_notifier.clone(),
         };
 
@@ -175,7 +173,7 @@ where
         }
 
         let (mut replica_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new(shutdown_sender.clone(), seq_role).await?;
+            ReplicaSyncTask::new(primary_shutdown.clone(), seq_role).await?;
 
         let tx_queue_id = Arc::new(AtomicU64::new(0));
         let batch_execution_time_limit_micros =
@@ -187,8 +185,7 @@ where
             batch_execution_time_limit_micros,
             config.clone(),
             self.max_concurrent_proof_blobs,
-            shutdown_receiver.clone(),
-            shutdown_sender.clone(),
+            primary_shutdown.clone(),
             executor_events_sender,
             next_sequence_number,
             in_flight_batch_blobs,
@@ -217,7 +214,7 @@ where
             executor_events_receiver,
             db,
             api_ledger_db,
-            shutdown_sender: shutdown_sender.clone(),
+            primary_shutdown: primary_shutdown.clone(),
             transaction_cache: cached_txs.write_handle(),
         }
         .spawn();
@@ -234,7 +231,7 @@ where
             preferred_config.maximum_future_nonce_delta,
             preferred_config.future_nonce_transaction_timeout_millis,
             forced_tx_batch_notifier.subscribe(),
-            shutdown_receiver.clone(),
+            primary_shutdown.clone(),
         );
         handles.push(nonce_buffer_task);
 
@@ -248,8 +245,7 @@ where
             _runtime: PhantomData,
             config: config.clone(),
             nonce_buffer_input,
-            shutdown_receiver: shutdown_receiver.clone(),
-            shutdown_sender: shutdown_sender.clone(),
+            primary_shutdown: primary_shutdown.clone(),
             tx_queue_id,
             stop_at_rollup_height,
             test_only_state_update_notification_receiver,
@@ -274,7 +270,7 @@ where
         if let Some(postgres_config) = &preferred_config.postgres_config {
             let heartbeat_task = HeartBeatTask::new(
                 postgres_config.clone(),
-                shutdown_sender.clone(),
+                primary_shutdown.clone(),
                 bind_addr,
                 postgres_config.leader_election.heartbeat_interval(),
             )
@@ -286,17 +282,17 @@ where
         handles.push(tokio::spawn(update_state_task(
             seq.clone(),
             state_update_receiver.clone(),
-            shutdown_receiver.clone(),
+            primary_shutdown.clone(),
         )));
 
         handles.push(tokio::spawn({
             let ledger_db = ledger_db.clone();
             let seq = seq.clone();
-            let shutdown_rx = shutdown_receiver.clone();
+            let primary_shutdown = primary_shutdown.clone();
             async move {
                 loop_send_tx_notifications::<S, Rt>(
                     state_update_receiver,
-                    shutdown_rx,
+                    primary_shutdown,
                     &ledger_db,
                     seq.tx_status_manager(),
                 )
@@ -338,7 +334,7 @@ where
 
     fn api_state(
         storage: S::Storage,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> (
         ApiState<S>,
         watch::Sender<Arc<ConcurrentStateCheckpoint<S>>>,
@@ -359,7 +355,7 @@ where
             checkpoint_receiver,
             runtime.kernel_with_slot_mapping(),
             None,
-            shutdown_receiver,
+            primary_shutdown,
         );
         (api_state, checkpoint_sender)
     }

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -59,6 +59,7 @@ use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootTask;
@@ -72,7 +73,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use sync_sequencer_state::*;
-use tokio::sync::{broadcast, watch};
+use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{error, info, trace};
@@ -125,9 +126,8 @@ where
     pub(crate) config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
     /// Used for intelligently buffering nonce-based TXs if they arrive out of order.
     nonce_buffer_input: NonceBufferInputSender<SequencerTxExecutionBackend<S, Rt>, S, Rt>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     transaction_cache: TransactionCache<S, Rt>,
-    shutdown_sender: watch::Sender<()>,
     // Used to track which txs need to be ignored after the sequencer had downtime (in the sense of giving out 503s)
     tx_queue_id: Arc<AtomicU64>,
     stop_at_rollup_height: Option<RollupHeight>,
@@ -157,7 +157,7 @@ where
         max_concurrent_proof_blobs: usize,
         ledger_db: LedgerDb,
         api_ledger_db: LedgerDb,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         stop_at_rollup_height: Option<RollupHeight>,
         bind_addr: SocketAddr,
     ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
@@ -167,7 +167,7 @@ where
                 storage_path,
                 ledger_db,
                 api_ledger_db,
-                shutdown_sender,
+                primary_shutdown,
                 stop_at_rollup_height,
                 bind_addr,
             )
@@ -210,7 +210,7 @@ where
     async fn recover_and_catch_up(
         &self,
         state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-        shutdown_receiver: &watch::Receiver<()>,
+        primary_shutdown: &PrimaryShutdownController,
         mut info: StateUpdateInfo<S::Storage>,
     ) -> anyhow::Result<()> {
         let mut rt = Rt::default();
@@ -240,7 +240,7 @@ where
                     }
                     info = poll_state_update::<S>(
                         state_update_receiver,
-                        shutdown_receiver,
+                        primary_shutdown,
                         "update_state_task",
                     )
                     .await?;
@@ -281,7 +281,7 @@ where
 
                 info = poll_state_update::<S>(
                     state_update_receiver,
-                    shutdown_receiver,
+                    primary_shutdown,
                     "update_state_task",
                 )
                 .await?;
@@ -324,7 +324,7 @@ where
     async fn wait_for_node_resync(
         &self,
         state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-        shutdown_receiver: &watch::Receiver<()>,
+        primary_shutdown: &PrimaryShutdownController,
         distance_to_tip: u64,
         current_info: StateUpdateInfo<S::Storage>,
     ) -> anyhow::Result<()> {
@@ -346,7 +346,7 @@ where
             // Else, poll a state update for the next iteration
             info = poll_state_update::<S>(
                 state_update_receiver,
-                shutdown_receiver,
+                primary_shutdown,
                 "update_state_task",
             )
             .await?;
@@ -357,12 +357,12 @@ where
     async fn wait_for_node_resync_with_allowed_slack(
         &self,
         state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-        shutdown_receiver: &watch::Receiver<()>,
+        primary_shutdown: &PrimaryShutdownController,
         current_info: StateUpdateInfo<S::Storage>,
     ) -> anyhow::Result<()> {
         self.wait_for_node_resync(
             state_update_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             // Catch up a bit extra to avoid immediately triggering another resync
             self.config.max_allowed_node_distance_behind.div_ceil(2),
             current_info,
@@ -373,10 +373,10 @@ where
     async fn wait_for_node_resync_to_tip(
         &self,
         state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-        shutdown_receiver: &watch::Receiver<()>,
+        primary_shutdown: &PrimaryShutdownController,
         current_info: StateUpdateInfo<S::Storage>,
     ) -> anyhow::Result<()> {
-        self.wait_for_node_resync(state_update_receiver, shutdown_receiver, 1, current_info)
+        self.wait_for_node_resync(state_update_receiver, primary_shutdown, 1, current_info)
             .await
     }
 
@@ -386,7 +386,7 @@ where
         baked_tx: FullyBakedTx,
         ip_addr: IpAddr,
     ) -> Result<AcceptedTx<<Self as Sequencer>::Confirmation>, ErrorObject> {
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             tracing::info!("The sequencer is shutting down. Cannot accept transactions");
             return Err(shut_down());
         }
@@ -571,7 +571,7 @@ fn raw_max_deferred_slots_delay(max_allowed_node_distance_behind: u64) -> u64 {
 async fn update_state_task<S, Rt, Da>(
     seq: PreferredSequencer<S, Rt, Da>,
     mut state_update_receiver: StateUpdateReceiver<S::Storage>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 ) where
     S: Spec,
     Rt: Runtime<S>,
@@ -579,7 +579,7 @@ async fn update_state_task<S, Rt, Da>(
 {
     loop {
         if let Err(e) =
-            update_state_task_inner(seq.clone(), &mut state_update_receiver, &shutdown_receiver)
+            update_state_task_inner(seq.clone(), &mut state_update_receiver, &primary_shutdown)
                 .await
         {
             // Thrown when polling for state updates is aborted due to a shutdown signal. Don't
@@ -594,7 +594,7 @@ async fn update_state_task<S, Rt, Da>(
                 error = ?e,
                 "Error in preferred sequencer update state task. Shutting down rollup."
             );
-            exit_rollup(&seq.shutdown_sender).await;
+            exit_rollup(&seq.primary_shutdown).await;
         }
     }
 }
@@ -645,7 +645,7 @@ fn should_skip_update_state(postgres_config: Option<&PostgresConfig>) -> bool {
 async fn update_state_task_inner<S, Rt, Da>(
     seq: PreferredSequencer<S, Rt, Da>,
     state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
-    shutdown_receiver: &watch::Receiver<()>,
+    primary_shutdown: &PrimaryShutdownController,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -653,7 +653,7 @@ where
     Da: DaService<Spec = S::Da>,
 {
     let info =
-        poll_state_update::<S>(state_update_receiver, shutdown_receiver, "update_state").await?;
+        poll_state_update::<S>(state_update_receiver, primary_shutdown, "update_state").await?;
 
     if cfg!(debug_assertions)
         && should_skip_update_state(seq.config.sequencer_kind_config.postgres_config.as_ref())
@@ -717,20 +717,20 @@ where
         }
 
         PreferredSeqOperation::WaitForNodeResyncToTip => {
-            seq.wait_for_node_resync_to_tip(state_update_receiver, shutdown_receiver, info)
+            seq.wait_for_node_resync_to_tip(state_update_receiver, primary_shutdown, info)
                 .await?;
         }
 
         PreferredSeqOperation::WaitForNodeResyncWithAllowedSlack => {
             seq.wait_for_node_resync_with_allowed_slack(
                 state_update_receiver,
-                shutdown_receiver,
+                primary_shutdown,
                 info,
             )
             .await?;
         }
         PreferredSeqOperation::RecoverAndCatchUp => {
-            seq.recover_and_catch_up(state_update_receiver, shutdown_receiver, info)
+            seq.recover_and_catch_up(state_update_receiver, primary_shutdown, info)
                 .await?;
         }
 
@@ -1119,22 +1119,20 @@ fn accepts_preferred_batches<B: BlobSelector>(_blob_selector: B) -> bool {
 
 #[track_caller]
 pub(crate) fn exit_rollup(
-    shutdown_sender: &watch::Sender<()>,
+    primary_shutdown: &PrimaryShutdownController,
 ) -> impl std::future::Future<Output = ()> {
     let location = std::panic::Location::caller();
-    exit_rollup_inner(shutdown_sender.clone(), location)
+    exit_rollup_inner(primary_shutdown.clone(), location)
 }
 
 async fn exit_rollup_inner(
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     location: &'static std::panic::Location<'static>,
 ) {
     // In the Kubernetes environment, logs are sometimes lost during shutdown.
     // This delay ensures logs have time to be flushed before the application exits.
     tracing::info!("Shutting down the rollup");
-    if shutdown_sender.send(()).is_err() {
-        tracing::error!(%location, "Failed to send shutdown signal");
-    }
+    primary_shutdown.shutdown();
     let sleep_time = Duration::from_secs(5);
     tracing::error!(%location, after = ?sleep_time, "Calling std::process::exit(1)");
     println!("Calling std::process::exit(1): {location}");

--- a/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
@@ -6,7 +6,7 @@ use sov_modules_api::{
 };
 use sov_rollup_interface::{
     crypto::CredentialId,
-    node::{future_or_shutdown, FutureOrShutdownOutput},
+    node::{FutureOrShutdownOutput, PrimaryShutdownController},
     TxHash,
 };
 use std::cmp::Ordering as CmpOrdering;
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::common::{AcceptedTx, ForcedTxBatchNotification};
@@ -269,13 +269,17 @@ struct TimeoutQueueTask<S: Spec, Rt: Runtime<S>> {
     /// The timeout duration for all transactions.
     timeout_duration: Duration,
     /// Shutdown notification.
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<S: Spec, Rt: Runtime<S>> TimeoutQueueTask<S, Rt> {
     async fn run(mut self) {
         loop {
-            let req = match future_or_shutdown(self.input.recv(), &self.shutdown_receiver).await {
+            let req = match self
+                .primary_shutdown
+                .future_or_shutdown(self.input.recv())
+                .await
+            {
                 FutureOrShutdownOutput::Shutdown | FutureOrShutdownOutput::Output(None) => return,
                 FutureOrShutdownOutput::Output(Some(req)) => req,
             };
@@ -284,7 +288,9 @@ impl<S: Spec, Rt: Runtime<S>> TimeoutQueueTask<S, Rt> {
 
             // Sleep until timeout is due
             if !remaining.is_zero() {
-                match future_or_shutdown(tokio::time::sleep(remaining), &self.shutdown_receiver)
+                match self
+                    .primary_shutdown
+                    .future_or_shutdown(tokio::time::sleep(remaining))
                     .await
                 {
                     FutureOrShutdownOutput::Shutdown => return,
@@ -384,7 +390,7 @@ impl<S: Spec, Rt: Runtime<S>> TxExecutionBackend<S, Rt> for SequencerTxExecution
 pub struct NonceBufferInputSender<E: TxExecutionBackend<S, Rt>, S: Spec, Rt: Runtime<S>> {
     buffer_sender_channel: mpsc::Sender<NonceBufferInput<S, Rt>>,
     execution_backend: E,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 pub struct NonceBufferTask<E: TxExecutionBackend<S, Rt>, S: Spec, Rt: Runtime<S>> {
@@ -538,7 +544,7 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
         }
     }
 
-    async fn run(&mut self, shutdown_receiver: &mut watch::Receiver<()>) {
+    async fn run(&mut self, primary_shutdown: &PrimaryShutdownController) {
         let mut input_closed = false;
         let mut wipe_closed = false;
         loop {
@@ -549,7 +555,7 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
                 // If shutdown and another branch are both ready, prioritize shutdown so queued
                 // messages are drained with shutdown semantics deterministically.
                 biased;
-                _ = shutdown_receiver.changed() => {
+                _ = primary_shutdown.wait_for_shutdown() => {
                     tracing::info!("Nonce buffer task shutting down. Rejecting queued transactions.");
                     self.drain_and_reject_all_txs(shutdown_reject_error::<S, Rt>);
                     return;
@@ -828,7 +834,7 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
         maximum_future_nonce_delta: u64,
         future_nonce_transaction_timeout_millis: u64,
         forced_tx_batch_receiver: broadcast::Receiver<ForcedTxBatchNotification>,
-        mut shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> (JoinHandle<()>, NonceBufferInputSender<E, S, Rt>) {
         let (buffer_sender_channel, buffer_input) = mpsc::channel(MAX_BUFFER_INPUT_QUEUE);
         let (timeout_sender, timeout_receiver) = mpsc::channel(MAX_BUFFERED_TXS);
@@ -837,13 +843,13 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
             input: timeout_receiver,
             output: buffer_sender_channel.clone(),
             timeout_duration: Duration::from_millis(future_nonce_transaction_timeout_millis),
-            shutdown_receiver: shutdown_receiver.clone(),
+            primary_shutdown: primary_shutdown.clone(),
         };
 
         let input_sender = NonceBufferInputSender {
             buffer_sender_channel,
             execution_backend: execution_backend.clone(),
-            shutdown_receiver: shutdown_receiver.clone(),
+            primary_shutdown: primary_shutdown.clone(),
         };
 
         let mut main_task = NonceBufferTask {
@@ -860,7 +866,7 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
 
         let handle = tokio::spawn(async move {
             tokio::select! {
-                _ = main_task.run(&mut shutdown_receiver) => {}
+                _ = main_task.run(&primary_shutdown) => {}
                 _ = timeout_task.run() => {}
             }
         });
@@ -872,7 +878,7 @@ impl<E: TxExecutionBackend<S, Rt> + Send + 'static, S: Spec, Rt: Runtime<S>>
     NonceBufferInputSender<E, S, Rt>
 {
     fn is_shutting_down(&self) -> bool {
-        self.shutdown_receiver.has_changed().unwrap_or(true)
+        self.primary_shutdown.is_triggered()
     }
 
     /// Send a message to the main input queue with metrics tracking.
@@ -1406,46 +1412,45 @@ mod tests {
         timeout_override: Option<u64>,
     ) -> (
         NonceBufferInputSender<MockTxExecutionBackend, TestSpec, TestRuntime>,
-        watch::Sender<()>,
+        PrimaryShutdownController,
     ) {
-        let (shutdown_sender, shutdown_receiver) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (_forced_tx_batch_notifier, forced_tx_batch_receiver) = broadcast::channel(1);
         let (_handle, sender) = NonceBufferTask::spawn(
             backend.clone(),
             DEFAULT_TEST_MAX_QUEUE_SIZE,
             timeout_override.unwrap_or(DEFAULT_TEST_QUEUE_TIMEOUT_MS),
             forced_tx_batch_receiver,
-            shutdown_receiver,
+            primary_shutdown.clone(),
         );
-        (sender, shutdown_sender)
+        (sender, primary_shutdown)
     }
 
     fn default_test_buffer_task() -> (
         MockTxExecutionBackend,
         NonceBufferInputSender<MockTxExecutionBackend, TestSpec, TestRuntime>,
-        watch::Sender<()>,
+        PrimaryShutdownController,
     ) {
         let backend = MockTxExecutionBackend::new();
-        let (sender, shutdown_sender) = test_buffer_task(&backend, None);
-        (backend, sender, shutdown_sender)
+        let (sender, primary_shutdown) = test_buffer_task(&backend, None);
+        (backend, sender, primary_shutdown)
     }
 
     type DrainTaskParts = (
         NonceBufferTask<MockTxExecutionBackend, TestSpec, TestRuntime>,
         mpsc::Sender<NonceBufferInput<TestSpec, TestRuntime>>,
-        watch::Sender<()>,
-        watch::Receiver<()>,
+        PrimaryShutdownController,
     );
 
     fn build_task_with_channels(backend: MockTxExecutionBackend) -> DrainTaskParts {
         let (buffer_sender_channel, buffer_input) = mpsc::channel(MAX_BUFFER_INPUT_QUEUE);
         let (timeout_sender, _timeout_receiver) = mpsc::channel(MAX_BUFFERED_TXS);
-        let (shutdown_sender, shutdown_receiver) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (_forced_tx_batch_notifier, forced_tx_batch_receiver) = broadcast::channel(1);
         let input_sender = NonceBufferInputSender {
             buffer_sender_channel: buffer_sender_channel.clone(),
             execution_backend: backend.clone(),
-            shutdown_receiver: shutdown_sender.subscribe(),
+            primary_shutdown: primary_shutdown.clone(),
         };
         let task = NonceBufferTask {
             buffers: Default::default(),
@@ -1458,12 +1463,7 @@ mod tests {
             timeout_metrics_batcher: MetricBatcher::new(METRICS_BATCH_SIZE),
             main_queue_depth_batcher: MetricBatcher::new(METRICS_BATCH_SIZE),
         };
-        (
-            task,
-            buffer_sender_channel,
-            shutdown_sender,
-            shutdown_receiver,
-        )
+        (task, buffer_sender_channel, primary_shutdown)
     }
 
     async fn push_new_tx_input(
@@ -2123,11 +2123,11 @@ mod tests {
     async fn test_shutdown_invalidates_buffer() {
         let backend =
             MockTxExecutionBackend::new().with_execution_delay(Duration::from_millis(200));
-        let (sender, shutdown_sender) = test_buffer_task(&backend, Some(2000)); // Long timeout
+        let (sender, primary_shutdown) = test_buffer_task(&backend, Some(2000)); // Long timeout
 
         let handles = submit_transactions(sender.clone(), (0..5).collect()).await;
         tokio::time::sleep(Duration::from_millis(450)).await;
-        let _ = shutdown_sender.send(());
+        primary_shutdown.shutdown();
         let results = collect_results(handles).await;
         let executed = backend.get_executed_nonces().len();
         assert!(
@@ -2145,8 +2145,7 @@ mod tests {
     #[tokio::test]
     async fn test_shutdown_drains_pending_messages() {
         let backend = MockTxExecutionBackend::new();
-        let (mut task, input_sender, shutdown_sender, mut shutdown_receiver) =
-            build_task_with_channels(backend);
+        let (mut task, input_sender, primary_shutdown) = build_task_with_channels(backend);
 
         let new_tx_receiver = push_new_tx_input(&input_sender, 1, [1; 32]).await;
         let (timed_out_receiver, credential_id, timed_out_hash) =
@@ -2176,10 +2175,10 @@ mod tests {
             .await
             .unwrap();
         drop(input_sender);
-        let _ = shutdown_sender.send(());
+        primary_shutdown.shutdown();
 
         let run_handle = tokio::spawn(async move {
-            task.run(&mut shutdown_receiver).await;
+            task.run(&primary_shutdown).await;
         });
         run_handle.await.unwrap();
 
@@ -2200,8 +2199,7 @@ mod tests {
     #[tokio::test]
     async fn test_wipe_drains_pending_messages() {
         let backend = MockTxExecutionBackend::new().with_tx_queue_id(1);
-        let (mut task, input_sender, shutdown_sender, mut shutdown_receiver) =
-            build_task_with_channels(backend);
+        let (mut task, input_sender, primary_shutdown) = build_task_with_channels(backend);
 
         let trigger_new_tx_receiver = push_new_tx_input(&input_sender, 0, [1; 32]).await;
         let queued_new_tx_receiver = push_new_tx_input(&input_sender, 1, [2; 32]).await;
@@ -2232,8 +2230,11 @@ mod tests {
             .await
             .unwrap();
 
-        let run_handle = tokio::spawn(async move {
-            task.run(&mut shutdown_receiver).await;
+        let run_handle = tokio::spawn({
+            let primary_shutdown = primary_shutdown.clone();
+            async move {
+                task.run(&primary_shutdown).await;
+            }
         });
 
         let trigger_result = tokio::time::timeout(Duration::from_secs(2), trigger_new_tx_receiver)
@@ -2269,7 +2270,7 @@ mod tests {
         )
         .await;
 
-        let _ = shutdown_sender.send(());
+        primary_shutdown.shutdown();
         run_handle.await.unwrap();
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -4,12 +4,12 @@ use sov_blob_storage::{PreferredBatchData, PreferredProofData};
 use sov_db::ledger_db::LedgerDb;
 use sov_modules_api::TxHash;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use std::{
     path::Path,
     sync::{atomic::AtomicUsize, Arc},
 };
 use tokio::sync::broadcast;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tracing::debug;
@@ -36,7 +36,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         all_completed_blobs: Vec<ReadBlob>,
         storage_path: Box<Path>,
         tx_status_manager: TxStatusManager<Da::Spec>,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         blob_processing_timeout: Duration,
         blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
         seq_role: SequencerRole,
@@ -65,7 +65,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
                     ledger_db,
                     storage_path.as_ref(),
                     TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
-                    shutdown_sender,
+                    primary_shutdown,
                     blob_processing_timeout,
                     Some(blobs_sender_channel),
                     blobs_to_send,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -6,8 +6,8 @@ use crate::preferred::replica::db_data::EventType;
 use crate::preferred::replica::db_data::EventsNotificationPayload;
 use crate::preferred::replica::db_data::ParsingError;
 use crate::SequencerNotReadyDetails;
-use sov_rollup_interface::node::future_or_shutdown;
 use sov_rollup_interface::node::FutureOrShutdownOutput;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
 use sqlx::Row;
@@ -97,7 +97,7 @@ impl EventReceiverStartNotifier {
 pub(crate) struct EventReceiver {
     connection_string: String,
     db_data_sender: tokio::sync::mpsc::Sender<DbData>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     query_pool: PgPool,
     page_size: usize,
     ready_to_process_db_events_recv: watch::Receiver<()>,
@@ -106,7 +106,7 @@ pub(crate) struct EventReceiver {
 impl EventReceiver {
     pub(crate) async fn new(
         connection_string: String,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         page_size: usize,
         ready_to_process_db_events_recv: watch::Receiver<()>,
     ) -> (Self, tokio::sync::mpsc::Receiver<DbData>) {
@@ -128,7 +128,7 @@ impl EventReceiver {
             Self {
                 connection_string,
                 db_data_sender,
-                shutdown_sender,
+                primary_shutdown,
                 query_pool,
                 page_size,
                 ready_to_process_db_events_recv,
@@ -139,7 +139,7 @@ impl EventReceiver {
 
     pub(crate) async fn spawn_db_data_fetcher(mut self) -> JoinHandle<()> {
         let mut nb_of_consecutive_db_errors = 0;
-        let shutdown_receiver = self.shutdown_sender.subscribe();
+        let shutdown_receiver = self.primary_shutdown.clone();
         let mut start_replica_task_receiver = self.ready_to_process_db_events_recv.clone();
 
         tokio::spawn(async move {
@@ -164,10 +164,11 @@ impl EventReceiver {
 
             debug!("Replica event receiver started.");
             loop {
-                let fut = future_or_shutdown(
-                    self.fetch_data(start_event_id, prev_event_type, &mut listener),
-                    &shutdown_receiver,
-                );
+                let fut = shutdown_receiver.future_or_shutdown(self.fetch_data(
+                    start_event_id,
+                    prev_event_type,
+                    &mut listener,
+                ));
 
                 let FutureOrShutdownOutput::Output(res) = fut.await else {
                     break;
@@ -190,7 +191,7 @@ impl EventReceiver {
                             EventReceiverError::DbError(err) => {
                                 error!(?err, ?start_event_id, "Failed to receive notifications from database. Shutting down replica.");
 
-                                if shutdown_receiver.has_changed().unwrap_or(true) {
+                                if shutdown_receiver.is_triggered() {
                                     break;
                                 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -4,8 +4,8 @@ use crate::preferred::replica::event_receiver::EventReceiver;
 use crate::preferred::replica::event_receiver::EventReceiverStartNotifier;
 use async_trait::async_trait;
 use sov_full_node_configs::sequencer::PostgresConfig;
-use sov_rollup_interface::node::future_or_shutdown;
 use sov_rollup_interface::node::FutureOrShutdownOutput;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -32,21 +32,21 @@ pub(crate) struct ReplicaTaskHandles {
 }
 
 pub(crate) struct ReplicaSyncTask {
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     page_size: usize,
     start_replica_task_receiver: watch::Receiver<()>,
 }
 
 impl ReplicaSyncTask {
     pub(crate) async fn new(
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         seq_role: SequencerRole,
     ) -> anyhow::Result<(Self, EventReceiverStartNotifier)> {
-        Self::new_with_page_size(shutdown_sender, PAGE_SIZE, seq_role).await
+        Self::new_with_page_size(primary_shutdown, PAGE_SIZE, seq_role).await
     }
 
     pub(crate) async fn new_with_page_size(
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         page_size: usize,
         seq_role: SequencerRole,
     ) -> anyhow::Result<(Self, EventReceiverStartNotifier)> {
@@ -54,7 +54,7 @@ impl ReplicaSyncTask {
             EventReceiverStartNotifier::new(seq_role);
         Ok((
             Self {
-                shutdown_sender,
+                primary_shutdown,
                 page_size,
                 start_replica_task_receiver,
             },
@@ -69,17 +69,17 @@ impl ReplicaSyncTask {
     ) -> ReplicaTaskHandles {
         let (event_receiver, db_data_receiver) = EventReceiver::new(
             postgres_config.postgres_connection_string.clone(),
-            self.shutdown_sender.clone(),
+            self.primary_shutdown.clone(),
             self.page_size,
             self.start_replica_task_receiver.clone(),
         )
         .await;
 
         let data_fetcher_handle = event_receiver.spawn_db_data_fetcher().await;
-        let shutdown_receiver = self.shutdown_sender.subscribe();
+        let primary_shutdown = self.primary_shutdown.clone();
 
         let sync_task_handle = tokio::spawn(async move {
-            Self::run_handler(handler, db_data_receiver, shutdown_receiver).await;
+            Self::run_handler(handler, db_data_receiver, primary_shutdown).await;
         });
 
         ReplicaTaskHandles {
@@ -91,16 +91,16 @@ impl ReplicaSyncTask {
     async fn run_handler<R: ReplicaEventHandler>(
         handler: R,
         mut db_data_receiver: tokio::sync::mpsc::Receiver<DbData>,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) {
         'outer: loop {
-            let fut = future_or_shutdown(db_data_receiver.recv(), &shutdown_receiver);
+            let fut = primary_shutdown.future_or_shutdown(db_data_receiver.recv());
             let FutureOrShutdownOutput::Output(Some(mut data)) = fut.await else {
                 break 'outer;
             };
 
             'inner: loop {
-                if shutdown_receiver.has_changed().unwrap_or(true) {
+                if primary_shutdown.is_triggered() {
                     break 'outer;
                 }
 
@@ -113,8 +113,7 @@ impl ReplicaSyncTask {
                     Err(DBDataRejected::ExecutorAhead(executor_seq_nr)) => {
                         // The executor is ahead of the db. Drain the queue and wait until we catch up.
                         loop {
-                            let fut =
-                                future_or_shutdown(db_data_receiver.recv(), &shutdown_receiver);
+                            let fut = primary_shutdown.future_or_shutdown(db_data_receiver.recv());
 
                             let FutureOrShutdownOutput::Output(Some(new_data)) = fut.await else {
                                 break 'outer;
@@ -157,8 +156,7 @@ impl ReplicaSyncTask {
                         // stop height, this will need to be taken into account for replicas.
                         tracing::info!("Replica reached stop height, stopping event processing. Draining db events until node shutdown.");
                         loop {
-                            let fut =
-                                future_or_shutdown(db_data_receiver.recv(), &shutdown_receiver);
+                            let fut = primary_shutdown.future_or_shutdown(db_data_receiver.recv());
                             match fut.await {
                                 FutureOrShutdownOutput::Shutdown
                                 | FutureOrShutdownOutput::Output(None) => {
@@ -424,9 +422,9 @@ mod tests {
             .await
             .unwrap();
 
-        let (shutdown_snd, _shutdown_rcv) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (mut sync_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new_with_page_size(shutdown_snd, 2, SequencerRole::PgSyncReplica)
+            ReplicaSyncTask::new_with_page_size(primary_shutdown, 2, SequencerRole::PgSyncReplica)
                 .await
                 .unwrap();
 
@@ -488,9 +486,9 @@ mod tests {
             .await
             .unwrap();
 
-        let (shutdown_snd, _shutdown_rcv) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (mut sync_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new_with_page_size(shutdown_snd, 8, SequencerRole::PgSyncReplica)
+            ReplicaSyncTask::new_with_page_size(primary_shutdown, 8, SequencerRole::PgSyncReplica)
                 .await
                 .unwrap();
 
@@ -544,7 +542,7 @@ mod tests {
     }
 
     async fn check_sync_task(test_cases: Vec<DbData>, expected: Vec<DbData>, exec_seq_nr: u64) {
-        let (_shutdown_snd, shutdown_rcv) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(100);
 
         for db_data in test_cases.clone() {
@@ -553,7 +551,7 @@ mod tests {
 
         let (test_handler, mut recv) = TestHandler::new(exec_seq_nr);
         tokio::task::spawn(async move {
-            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, shutdown_rcv).await;
+            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, primary_shutdown).await;
         });
 
         for exp in expected.into_iter() {
@@ -570,7 +568,7 @@ mod tests {
         let test_case = to_db_data(&test_case);
         let expected = test_case.clone();
 
-        let (_shutdown_snd, shutdown_rcv) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
         let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(100);
 
         for db_data in test_case.clone() {
@@ -581,7 +579,7 @@ mod tests {
         let test_handler_clone = test_handler.clone();
 
         tokio::task::spawn(async move {
-            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, shutdown_rcv).await;
+            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, primary_shutdown).await;
         });
 
         for exp in expected {

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use anyhow::Result;
 use sov_modules_api::{ConcurrentStateCheckpoint, Runtime, Spec, StateCheckpoint};
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
@@ -30,7 +31,7 @@ where
     pub db: PreferredSequencerDb,
     pub api_ledger_db: LedgerDb,
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
-    pub shutdown_sender: watch::Sender<()>,
+    pub primary_shutdown: PrimaryShutdownController,
     pub transaction_cache: TxResultWriter<S, Rt>,
 }
 
@@ -141,7 +142,7 @@ where
                 RecoveryStrategy::None => {
                     // Shut down
                     error!(RECOVERY_ERROR_MESSAGE_ON_NONE_STRATEGY);
-                    exit_rollup(&self.shutdown_sender).await;
+                    exit_rollup(&self.primary_shutdown).await;
                 }
             }
         } else {
@@ -331,7 +332,7 @@ where
                 if let Err(e) = self.handle_executor_event(&mut event_queue).await {
                     tracing::error!(error = ?e, "Error handling executor event");
                     // If we've already started shutting down, this might fail - but then we're happy.
-                    let _ = self.shutdown_sender.send(());
+                    self.primary_shutdown.shutdown();
                     break;
                 }
             }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -36,13 +36,14 @@ use sov_modules_api::{
     VisibleSlotNumber,
 };
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_state::{NativeStorage, Storage};
 use std::num::NonZero;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::oneshot;
 use tracing::{debug, info, warn};
 
 /// These two constants are used to calculate the comfortable batch size limit.
@@ -82,8 +83,7 @@ where
     pub(crate) seq_role: SequencerRole,
     pub(crate) seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
     pub(crate) max_concurrent_proof_blobs: usize,
-    pub(crate) shutdown_receiver: watch::Receiver<()>,
-    pub(crate) shutdown_sender: watch::Sender<()>,
+    pub(crate) primary_shutdown: PrimaryShutdownController,
 
     pub(crate) executor: RollupBlockExecutor<S, Rt>,
     /// The rollup height of the latest node checkpoint applied to this executor's storage.
@@ -509,7 +509,7 @@ where
         }
 
         // If the node is shutting down, we may not be able to terminate the batch. In that case, just return early.
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             info!("The sequencer is shutting down. Exiting trigger_batch_production.");
             return;
         }
@@ -766,7 +766,7 @@ where
         // Even if this method return early it uses 1 request slot.
         let request_used = ResourceUsed::new(1, 0, 0, <S as Spec>::Gas::zero());
 
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             tracing::info!("The sequencer is shutting down. Cannot accept transactions");
             return (Err(DoNewTxError::Shutdown), request_used);
         }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -31,6 +31,7 @@ use sov_modules_api::GasSpec;
 use sov_modules_api::VersionReader;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec};
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_state::Storage;
 use std::collections::BTreeMap;
@@ -39,7 +40,7 @@ use std::sync::Arc;
 use std::time::Duration;
 pub(crate) use sync_state::*;
 use tokio::sync::broadcast;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, oneshot};
 pub(crate) use updator::*;
 
 mod conditions_table;
@@ -172,8 +173,7 @@ pub(crate) fn create<S, Rt>(
     batch_execution_time_limit_micros: u64,
     seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
     max_concurrent_proof_blobs: usize,
-    shutdown_receiver: watch::Receiver<()>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     executor_events_sender: ExecutorEventsSender<S, Rt>,
     sequence_number_of_next_blob: SequenceNumber,
     in_flight_batch_blobs: Arc<AtomicUsize>,
@@ -223,8 +223,7 @@ where
         batch_size_tracker: BatchSizeTracker::new(seq_config.max_batch_size_bytes),
         seq_config: seq_config.clone(),
         max_concurrent_proof_blobs,
-        shutdown_receiver: shutdown_receiver.clone(),
-        shutdown_sender,
+        primary_shutdown: primary_shutdown.clone(),
         executor_events_sender,
         sequence_number_of_open_batch: None,
         next_unassigned_sequence_number: sequence_number_of_next_blob,
@@ -260,7 +259,7 @@ where
     let updator = SequencerStateUpdator {
         message_sender,
         channel_size,
-        shutdown_receiver,
+        primary_shutdown,
     };
     (state, updator)
 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -155,7 +155,7 @@ where
                                 return;
                             }
                             SequencerStateUpdatorError::Unexpected => {
-                                self.inner.shutdown_sender.send(()).unwrap();
+                                self.inner.primary_shutdown.shutdown();
                                 panic!("The sequencer experienced an unexpected error and cannot accept transactions! See logs for more details.");
                             }
                         }
@@ -729,7 +729,7 @@ where
             node_user_root = %HexString(node_user_root),
             "Sequencer user state root does not match the node user state root. This indicates a sequencer/node state divergence."
         );
-        crate::preferred::exit_rollup(&inner.shutdown_sender).await;
+        crate::preferred::exit_rollup(&inner.primary_shutdown).await;
     }
 
     async fn process_final_catchup(
@@ -751,7 +751,7 @@ where
         // Some events might come in while we're waiting to grab the lock.
         // Replay them.
         while let Ok(event) = db_event_subscription.try_recv() {
-            if inner.shutdown_receiver.has_changed().unwrap_or(true) {
+            if inner.primary_shutdown.is_triggered() {
                 tracing::info!("The sequencer is shutting down. Exiting replay_batch");
                 return Ok(data);
             }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
@@ -19,12 +19,13 @@ use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec};
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_state::Storage;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info};
 
 pub(crate) struct SequencerStateUpdator<S, Rt>
@@ -34,7 +35,7 @@ where
 {
     pub(crate) channel_size: Arc<AtomicU32>,
     pub(crate) message_sender: mpsc::Sender<Message<S, Rt>>,
-    pub(crate) shutdown_receiver: watch::Receiver<()>,
+    pub(crate) primary_shutdown: PrimaryShutdownController,
 }
 
 #[derive(Debug)]
@@ -240,7 +241,7 @@ where
         match recv.await {
             Ok(result) => Ok(result),
             Err(_) => {
-                if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                if self.primary_shutdown.is_triggered() {
                     info!("SequencerStateUpdator(force_close_current_batch) task exited, this is ok since the sequencer is shutting down.");
                     return Err(SequencerStateUpdatorError::Shutdown);
                 }
@@ -281,7 +282,7 @@ where
     async fn send(&self, message: Message<S, Rt>) -> Result<(), SequencerStateUpdatorError> {
         self.channel_size.fetch_add(1, Ordering::Relaxed);
         if self.message_sender.send(message).await.is_err() {
-            if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            if self.primary_shutdown.is_triggered() {
                 info!("SynchronizedSequencerState(send) task exited, this is ok since the sequencer is shutting down.");
                 return Err(SequencerStateUpdatorError::Shutdown);
             }
@@ -294,7 +295,7 @@ where
         if let Ok(ret) = recv.await {
             Ok(ret)
         } else {
-            if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            if self.primary_shutdown.is_triggered() {
                 info!("SynchronizedSequencerState(recv) task exited, this is ok since the sequencer is shutting down.");
                 return Err(SequencerStateUpdatorError::Shutdown);
             }

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -44,7 +44,7 @@ where
         // On shutdown exit early. This prevents duplicate subscriptions to the DB events channel, which would cause spurious warnings.
         // Note that we only need to detect whether a previous `replay_soft_confirmations_on_top_of_node_state` was aborted due to shutdown
         // *while its subscription was active*, so a single check at the start is sufficient.
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if self.primary_shutdown.is_triggered() {
             tracing::info!("The sequencer is shutting down. Exiting replay_soft_confirmations_on_top_of_node_state without completing replay.");
             return Ok(());
         }
@@ -147,7 +147,7 @@ where
                         executor
                             .replay_batch(&batch, proofs_to_replay, &node_state_root)
                             .await?;
-                        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                        if self.primary_shutdown.is_triggered() {
                             tracing::info!("The sequencer is shutting down. Exiting replay_soft_confirmations_on_top_of_node_state.");
                             return Ok(());
                         }
@@ -205,7 +205,7 @@ where
         // Just get close, then lock the sequencer. This will keep p99 reasonable while hopefully
         // minimizing the risk of extremely long catchup periods in `update_state`.
         while db_event_subscription.len() > 1 {
-            if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            if self.primary_shutdown.is_triggered() {
                 tracing::info!("The sequencer is shutting down. Exiting replay_batch");
                 return Ok(());
             }
@@ -275,7 +275,7 @@ where
             t.submit(metrics);
         });
 
-        if !self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if !self.primary_shutdown.is_triggered() {
             self.synchronized_state_updator
                 .prune_sequencer_db_msg("update_state::prune_sequencer_db")
                 .await
@@ -293,7 +293,7 @@ where
             .send_simple_state_update_msg(info)
             .await
             .map_err(|e| e.into_state_update_error())?;
-        if !self.shutdown_receiver.has_changed().unwrap_or(true) {
+        if !self.primary_shutdown.is_triggered() {
             self.synchronized_state_updator
                 .prune_sequencer_db_msg("update_state::prune_sequencer_db")
                 .await

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -28,8 +28,8 @@ use sov_rest_utils::{
 use sov_rest_utils::{get_client_ip, WsMessage};
 use sov_rollup_interface::da::{DaBlobHash, DaSpec};
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::TxHash;
-use tokio::sync::watch::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -131,15 +131,18 @@ impl CompressionQuery {
 #[derivative(Clone(bound = ""))]
 pub struct SequencerApis<Seq: Sequencer> {
     sequencer: Seq,
-    shutdown_receiver: Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<Seq: Sequencer> SequencerApis<Seq> {
     /// Creates a new Axum router for this sequencer.
-    pub fn rest_api_server(sequencer: Seq, shutdown_receiver: Receiver<()>) -> axum::Router<()> {
+    pub fn rest_api_server(
+        sequencer: Seq,
+        primary_shutdown: PrimaryShutdownController,
+    ) -> axum::Router<()> {
         let state = Self {
             sequencer,
-            shutdown_receiver,
+            primary_shutdown,
         };
 
         let router = axum::Router::new()
@@ -238,7 +241,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         let ws = ws.max_message_size(config_value!("MAX_TX_SIZE") * 2);
 
         Ok(ws.on_upgrade(move |mut socket| async move {
-            let mut shutdown_receiver = state.shutdown_receiver.clone();
+            let shutdown_receiver = state.primary_shutdown.clone();
             // Channel sends pre-serialized JSON strings to avoid double serialization
             let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<String>(10);
             // Use interval_at to delay the first ping until after a full interval of inactivity
@@ -383,7 +386,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                         awaiting_pong = Some(ping_data);
                         tracing::trace!("Sent ping to client");
                     }
-                    _ = shutdown_receiver.changed() => break,
+                    _ = shutdown_receiver.wait_for_shutdown() => break,
                 }
             }
 
@@ -456,7 +459,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 .await
                 .ok();
 
-            serve_generic_ws_subscription(socket, subscription, state.shutdown_receiver.clone())
+            serve_generic_ws_subscription(socket, subscription, state.primary_shutdown.clone())
                 .await;
         })
     }
@@ -562,7 +565,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             serve_generic_ws_subscription_with_config(
                 socket,
                 stream,
-                state.shutdown_receiver.clone(),
+                state.primary_shutdown.clone(),
                 config,
             )
             .await;
@@ -583,7 +586,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             serve_generic_ws_subscription_with_config(
                 socket,
                 stream,
-                state.shutdown_receiver.clone(),
+                state.primary_shutdown.clone(),
                 config,
             )
             .await;
@@ -618,7 +621,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             let stream = broadcast_to_subscription_stream(
                 state.sequencer.subscribe_blobs_from_blob_sender().await,
             );
-            serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
         })
     }
 
@@ -645,7 +648,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             let stream = broadcast_to_subscription_stream(
                 state.sequencer.subscribe_state_updates_unstable().await,
             );
-            serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
         })
     }
 
@@ -658,7 +661,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             let stream = broadcast_to_subscription_stream(
                 state.sequencer.subscribe_forced_tx_batches_unstable().await,
             );
-            serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
         })
     }
 

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -31,6 +31,7 @@ use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::BlobSenderStatus;
 use std::boxed::Box;
 use std::marker::PhantomData;
@@ -134,9 +135,8 @@ where
         max_concurrent_proof_blobs: usize,
         ledger_db: LedgerDb,
         api_ledger_db: LedgerDb,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
-        let shutdown_receiver = shutdown_sender.subscribe();
         let mut runtime = Rt::default();
         let kernel_with_slot_mapping = runtime.kernel_with_slot_mapping();
 
@@ -154,7 +154,7 @@ where
             checkpoint_receiver,
             kernel_with_slot_mapping,
             None,
-            shutdown_receiver.clone(),
+            primary_shutdown.clone(),
         );
 
         let txsm = TxStatusManager::default();
@@ -172,7 +172,7 @@ where
             ledger_db.clone(),
             storage_path,
             TxStatusBlobSenderHooks::new(txsm.clone()),
-            shutdown_sender,
+            primary_shutdown.clone(),
             Duration::from_secs(config.blob_processing_timeout_secs),
             None,
             Default::default(),
@@ -214,7 +214,7 @@ where
             loop_call_update_state(
                 seq.clone(),
                 state_update_receiver.clone(),
-                shutdown_receiver.clone(),
+                primary_shutdown.clone(),
             )
         }));
         handles.push(tokio::spawn({
@@ -223,7 +223,7 @@ where
             async move {
                 loop_send_tx_notifications::<S, Rt>(
                     state_update_receiver,
-                    shutdown_receiver,
+                    primary_shutdown,
                     &ledger_db,
                     seq.tx_status_manager(),
                 )

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -14,6 +14,7 @@ use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::TxHash;
 use std::marker::PhantomData;
 use std::net::IpAddr;
@@ -49,7 +50,7 @@ pub struct TestStatelessSequencer<R, S: Spec, Da: DaService> {
     tx_status_manager: TxStatusManager<S::Da>,
     _r: PhantomData<R>,
     state_sender: watch::Sender<Arc<ConcurrentStateCheckpoint<S>>>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     api_ledger_db: LedgerDb,
 }
 
@@ -67,9 +68,8 @@ where
         storage_path: &Path,
         config: &SequencerConfig<<S as Spec>::Address, ()>,
         ledger_db: LedgerDb,
-        shutdown_sender: watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
-        let shutdown_receiver = shutdown_sender.subscribe();
         let mut runtime = R::default();
         let storage = state_update_receiver.borrow().storage.clone();
         let inner = Mutex::new(Inner {
@@ -92,7 +92,7 @@ where
                     ledger_db.clone(),
                     storage_path,
                     TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
-                    shutdown_sender,
+                    primary_shutdown.clone(),
                     Duration::from_secs(config.blob_processing_timeout_secs),
                     None,
                     Default::default(),
@@ -105,7 +105,7 @@ where
             tx_status_manager,
             _r: Default::default(),
             state_sender,
-            shutdown_receiver: shutdown_receiver.clone(),
+            primary_shutdown: primary_shutdown.clone(),
             api_ledger_db: ledger_db.clone(),
         };
 
@@ -114,7 +114,7 @@ where
             loop_call_update_state(
                 seq.clone(),
                 state_update_receiver.clone(),
-                shutdown_receiver.clone(),
+                primary_shutdown.clone(),
             )
         }));
         handles.push(tokio::spawn({
@@ -123,7 +123,7 @@ where
             async move {
                 loop_send_tx_notifications::<S, R>(
                     state_update_receiver,
-                    shutdown_receiver,
+                    primary_shutdown,
                     &ledger_db,
                     seq.tx_status_manager(),
                 )
@@ -201,7 +201,7 @@ where
             self.state_sender.subscribe(),
             runtime.kernel_with_slot_mapping(),
             None,
-            self.shutdown_receiver.clone(),
+            self.primary_shutdown.clone(),
         )
     }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -322,7 +322,7 @@ async fn check_start_at(finalization_blocks: u32) {
         .unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
-    let mut shutdown_rec = test_rollup.shutdown_sender.subscribe();
+    let shutdown_rec = test_rollup.primary_shutdown.clone();
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
     let mut last_height = RollupHeight::new(0);
@@ -342,7 +342,7 @@ async fn check_start_at(finalization_blocks: u32) {
     assert_eq!(last_height, stop_at_height);
 
     // Let's wait for the shutdown.
-    shutdown_rec.changed().await.unwrap();
+    shutdown_rec.wait_for_shutdown().await.unwrap();
 
     pause_update_state::set(true);
 

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -11,7 +11,7 @@ use op_manager::attestations::AttestationsManager;
 pub use prover_service::*;
 use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::SecondaryShutdownController;
+use sov_rollup_interface::node::{PrimaryShutdownController, SecondaryShutdownController};
 use sov_rollup_interface::optimistic::BondingProofService;
 use sov_rollup_interface::stf::ProofSender;
 pub use stf_info_manager::*;
@@ -29,7 +29,7 @@ pub async fn start_zk_workflow_in_background<Ps>(
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
     da_sync_state: Arc<DaSyncState>,
     secondary_shutdown_controller: &SecondaryShutdownController,
-    shutdown_sender: tokio::sync::watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<JoinHandle<()>>
 where
@@ -45,7 +45,7 @@ where
         stf_info_receiver,
         da_sync_state,
         secondary_shutdown_controller,
-        shutdown_sender,
+        primary_shutdown,
         start_fresh_outer_proof_on_resync,
     )
     .post_aggregated_proof_to_da_in_background()

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -5,7 +5,9 @@ use backon::{BackoffBuilder, ExponentialBuilder};
 use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::{FutureOrShutdownOutput, SecondaryShutdownController, SyncStatus};
+use sov_rollup_interface::node::{
+    FutureOrShutdownOutput, PrimaryShutdownController, SecondaryShutdownController, SyncStatus,
+};
 use sov_rollup_interface::stf::ProofSender;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use tokio::sync::mpsc;
@@ -36,7 +38,7 @@ pub struct ZkProofManager<Ps: ProverService> {
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
     da_sync_state: Arc<DaSyncState>,
     secondary_shutdown_controller: SecondaryShutdownController,
-    shutdown_sender: tokio::sync::watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     start_fresh_outer_proof_on_resync: bool,
 }
 
@@ -55,7 +57,7 @@ where
         stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
         da_sync_state: Arc<DaSyncState>,
         secondary_shutdown_controller: &SecondaryShutdownController,
-        shutdown_sender: tokio::sync::watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         start_fresh_outer_proof_on_resync: bool,
     ) -> Self {
         Self {
@@ -72,7 +74,7 @@ where
             stf_info_receiver,
             da_sync_state,
             secondary_shutdown_controller: secondary_shutdown_controller.clone(),
-            shutdown_sender,
+            primary_shutdown,
             start_fresh_outer_proof_on_resync,
         }
     }
@@ -101,7 +103,7 @@ where
                 backoff_policy: self.backoff_policy,
                 metadata_rx,
                 cursor: cursor.clone(),
-                shutdown_sender: self.shutdown_sender,
+                primary_shutdown: self.primary_shutdown,
             };
 
             let aggregator_shutdown_controller = self.secondary_shutdown_controller.clone();
@@ -328,7 +330,7 @@ struct AggregatorTask<Ps: ProverService> {
     backoff_policy: ExponentialBuilder,
     metadata_rx: mpsc::Receiver<(AggregateProofMetadata<Ps>, u64)>,
     cursor: CursorHandle,
-    shutdown_sender: tokio::sync::watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<Ps: ProverService> AggregatorTask<Ps>
@@ -353,9 +355,7 @@ where
                     max_concurrent_proof_blobs = status.max_concurrent,
                     "The zk proof blob sender is busy, which means proofs are not being confirmed by the rollup on time. Triggering shutdown."
                 );
-                if self.shutdown_sender.send(()).is_err() {
-                    tracing::error!("Failed to send primary shutdown signal.");
-                }
+                self.primary_shutdown.shutdown();
                 break;
             }
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -16,7 +16,9 @@ use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::node::da::{DaService, SlotData};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput, SyncStatus};
+use sov_rollup_interface::node::{
+    future_or_shutdown, FutureOrShutdownOutput, PrimaryShutdownController, SyncStatus,
+};
 use sov_rollup_interface::stf::{
     ExecutionContext, PartialProofReceipt, ProofOutcome, ProofReceipt, ProofReceiptContents,
     StateTransitionFunction,
@@ -89,7 +91,7 @@ where
     stf_info_receiver: Option<Receiver<Stf::StateRoot, Stf::Witness, Da::Spec>>,
     sync_state: Arc<DaSyncState>,
     sync_fetcher: FinalizedBlocksBulkFetcher<Da>,
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     secondary_shutdown_sender: watch::Sender<()>,
     background_handles: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
     start_at_rollup_height: Option<RollupHeight>,
@@ -169,7 +171,7 @@ where
         state_channel: StateChannel<Sm::StfState>,
         prev_state_root: Stf::StateRoot,
         state_height_tracker: Box<dyn ProvableHeightTracker>,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         sync_state: Arc<DaSyncState>,
@@ -253,7 +255,7 @@ where
             sync_state,
             stf_info_receiver,
             sync_fetcher,
-            shutdown_receiver,
+            primary_shutdown,
             secondary_shutdown_sender,
             background_handles,
             start_at_rollup_height,
@@ -431,14 +433,14 @@ where
 
         let start_at_rollup_height = self.start_at_rollup_height;
         let stop_at_rollup_height = self.stop_at_rollup_height;
-        let shutdown_receiver = self.shutdown_receiver.clone();
+        let primary_shutdown = self.primary_shutdown.clone();
         loop {
             if self.stop_at_rollup_height.is_some() {
                 // Rollup is performing an upgrade procedure. We wait until the next_da_height is finalized.
                 let is_shutting_down = Self::wait_until_next_da_height_finalized_or_shutdown(
                     self,
                     next_da_height,
-                    &shutdown_receiver,
+                    &primary_shutdown,
                 )
                 .await?;
 
@@ -446,15 +448,13 @@ where
                     break;
                 }
             }
-            match future_or_shutdown(
-                self.process_next_slot(
+            match primary_shutdown
+                .future_or_shutdown(self.process_next_slot(
                     next_da_height,
                     &start_at_rollup_height,
                     &stop_at_rollup_height,
-                ),
-                &shutdown_receiver,
-            )
-            .await
+                ))
+                .await
             {
                 FutureOrShutdownOutput::Shutdown => break,
                 FutureOrShutdownOutput::Output(slot_result) => match slot_result? {
@@ -489,7 +489,7 @@ where
     async fn wait_until_next_da_height_finalized_or_shutdown(
         &self,
         next_da_height: u64,
-        shutdown_receiver: &watch::Receiver<()>,
+        primary_shutdown: &PrimaryShutdownController,
     ) -> anyhow::Result<bool> {
         loop {
             let finalized_height = self
@@ -498,11 +498,9 @@ where
                 .height();
             if next_da_height > finalized_height {
                 info!(%finalized_height, %next_da_height, "Waiting until next DA height is finalized");
-                match future_or_shutdown(
-                    tokio::time::sleep(self.da_polling_interval),
-                    shutdown_receiver,
-                )
-                .await
+                match primary_shutdown
+                    .future_or_shutdown(tokio::time::sleep(self.da_polling_interval))
+                    .await
                 {
                     FutureOrShutdownOutput::Shutdown => return Ok(true),
                     FutureOrShutdownOutput::Output(()) => continue,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -25,7 +25,9 @@ use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::ledger_api::{AggregatedProofResponse, LedgerStateProvider};
-use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
+use sov_rollup_interface::node::{
+    PrimaryShutdownController, SecondaryShutdownController, SyncStatus,
+};
 use sov_rollup_interface::stf::BlobSenderStatus;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
@@ -62,7 +64,7 @@ pub struct TestNode {
     tasks: JoinSet<()>,
     // Just to remove warnings from logs
     _sync_status_receiver: watch::Receiver<SyncStatus>,
-    shutdown_sender: watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     secondary_shutdown_controller: SecondaryShutdownController,
 }
 
@@ -113,7 +115,7 @@ impl TestNode {
         // `stop()` is called, so the primary shutdown channel may already have no
         // receivers left. A failed send just means everything already shut down,
         // which is the outcome we want here.
-        let _ = self.shutdown_sender.send(());
+        self.primary_shutdown.shutdown();
         // The secondary controller holds its own receiver, so `shutdown()` always
         // succeeds; it simply signals any background tasks that are still running.
         self.secondary_shutdown_controller.shutdown();
@@ -211,8 +213,7 @@ pub async fn initialize_runner_with_stop_at(
     let rollup_config = rollup_config(&da_service, path, aggregated_proof_block_jump);
 
     let mut tasks = JoinSet::new();
-    let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
-    shutdown_receiver.mark_unchanged();
+    let primary_shutdown = PrimaryShutdownController::new();
     let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let da_service_with_cache = DaServiceWithCachedFinalizedHeaders::new(
@@ -266,7 +267,7 @@ pub async fn initialize_runner_with_stop_at(
         let ledger_updates = ledger_db.clone();
         react_to_state_updates::<TestSpec, _>(
             state_update_recv,
-            shutdown_receiver.clone(),
+            primary_shutdown.clone(),
             "ledger_updates",
             move |info| {
                 let ledger_updates = ledger_updates.clone();
@@ -299,7 +300,7 @@ pub async fn initialize_runner_with_stop_at(
         state_channel,
         prev_state_root,
         Box::new(InfiniteHeight),
-        shutdown_receiver.clone(),
+        primary_shutdown.clone(),
         None,
         stop_at_rollup_height,
         da_sync_state,
@@ -333,7 +334,7 @@ pub async fn initialize_runner_with_stop_at(
             stf_info_receiver,
             runner.da_sync_state(),
             &secondary_shutdown_controller,
-            shutdown_sender.clone(),
+            primary_shutdown.clone(),
             false,
         )
         .await
@@ -358,7 +359,7 @@ pub async fn initialize_runner_with_stop_at(
             inner_vm,
             _outer_vm: outer_vm,
             tasks,
-            shutdown_sender,
+            primary_shutdown,
             secondary_shutdown_controller,
             _sync_status_receiver,
         },

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -21,7 +21,9 @@ use sov_modules_api::{FullyBakedTx, StateTransitionFunction};
 use sov_rollup_full_node_interface::StateChannel;
 use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::node::da::{DaService, SlotData};
-use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
+use sov_rollup_interface::node::{
+    PrimaryShutdownController, SecondaryShutdownController, SyncStatus,
+};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_state::{ArrayWitness, NativeStorage, Storage, StorageRoot};
 use sov_stf_runner::StateTransitionRunner;
@@ -30,7 +32,6 @@ use sov_test_utils::storage::SimpleStorageManager;
 use sov_test_utils::{TestStorage, TestStorageManager, TEST_MOCK_DA_POLLING_INTERVAL};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
-use tokio::sync::watch;
 
 type MockInitVariant = InitVariant<HashStf, MockDaService>;
 
@@ -46,8 +47,7 @@ async fn test_runner_with_background_da_service(
     target_height: u64,
     da_config: MockDaConfig,
 ) -> anyhow::Result<()> {
-    let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
-    shutdown_receiver.mark_unchanged();
+    let primary_shutdown = PrimaryShutdownController::new();
     let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let da_service =
@@ -117,7 +117,7 @@ async fn test_runner_with_background_da_service(
         state_channel,
         prev_state_root,
         Box::new(InfiniteHeight),
-        shutdown_receiver.clone(),
+        primary_shutdown.clone(),
         None,
         None,
         da_sync_state,
@@ -178,7 +178,7 @@ async fn test_runner_with_background_da_service(
         }
     }
 
-    shutdown_sender.send(())?;
+    primary_shutdown.shutdown();
     secondary_shutdown_controller.shutdown();
     runner_task
         .await?

--- a/crates/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -96,7 +96,7 @@ impl<S: Spec> ChainState<S> {
             sov_modules_api::rest::utils::serve_generic_ws_subscription(
                 socket,
                 stream,
-                state.shutdown_receiver(),
+                state.primary_shutdown(),
             )
             .await;
         })

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -33,6 +33,7 @@ use axum::routing::get;
 use serde::{Deserialize, Serialize};
 use sov_rest_utils::{json_obj, ErrorObject, Query};
 use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use tokio::sync::watch;
 use utoipa::openapi::OpenApi;
 
@@ -178,7 +179,7 @@ pub struct ApiState<S: Spec, T = ()> {
     requested_height: Option<HeightParam>,
     /// Signals node shutdown so long-lived handlers (e.g. WebSocket subscriptions)
     /// can terminate gracefully.
-    shutdown_receiver: watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 }
 
 impl<S: Spec, T> ApiState<S, T> {
@@ -189,14 +190,14 @@ impl<S: Spec, T> ApiState<S, T> {
         checkpoint_receiver: watch::Receiver<Arc<ConcurrentStateCheckpoint<S>>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         requested_height: Option<HeightParam>,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> Self {
         Self {
             inner,
             checkpoint_receiver,
             kernel,
             requested_height,
-            shutdown_receiver,
+            primary_shutdown,
         }
     }
 
@@ -207,7 +208,7 @@ impl<S: Spec, T> ApiState<S, T> {
             checkpoint_receiver: self.checkpoint_receiver,
             kernel: self.kernel,
             requested_height: self.requested_height,
-            shutdown_receiver: self.shutdown_receiver,
+            primary_shutdown: self.primary_shutdown,
         }
     }
 
@@ -292,10 +293,10 @@ impl<S: Spec, T> ApiState<S, T> {
         self.checkpoint_receiver.clone()
     }
 
-    /// Returns a receiver that is notified on node shutdown. Long-lived handlers
-    /// (e.g. WebSocket subscriptions) should select on it to terminate gracefully.
-    pub fn shutdown_receiver(&self) -> watch::Receiver<()> {
-        self.shutdown_receiver.clone()
+    /// Returns the primary shutdown controller. Long-lived handlers (e.g. WebSocket
+    /// subscriptions) should select on it to terminate gracefully on node shutdown.
+    pub fn primary_shutdown(&self) -> PrimaryShutdownController {
+        self.primary_shutdown.clone()
     }
 }
 

--- a/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
@@ -139,13 +139,12 @@ async fn rest_api_routes() {
             StateCheckpoint::new(storage, &MockKernel::<TestSpec>::default()),
         )));
     let runtime = MyRuntime::<TestSpec>::default();
-    let (_shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
     let state = ApiState::build(
         Arc::new(()),
         receiver,
         Arc::new(MockKernel::default()),
         None,
-        shutdown_receiver,
+        sov_rollup_interface::node::PrimaryShutdownController::new(),
     );
 
     let router = runtime.rest_api(state);

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
@@ -12,7 +12,7 @@ use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
 use sov_rollup_apis::endpoints::simulate::SovereignSimulate;
 use sov_rollup_apis::rollup_tx_router;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{PrimaryShutdownController, SyncStatus};
 use sov_stf_runner::{RollupConfig, RunnerConfig};
 
 use super::SequencerCreationReceipt;
@@ -23,7 +23,7 @@ use crate::FullNodeBlueprint;
 pub async fn register_endpoints<B, M>(
     state_update_receiver: StateUpdateReceiver<<B::Spec as Spec>::Storage>,
     sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     ledger_db: &LedgerDb,
     sequencer: &SequencerCreationReceipt<B::Spec>,
     config: &RollupConfig<<B::Spec as Spec>::Address, B::DaService>,
@@ -46,20 +46,19 @@ where
 
     // Ledger endpoint.
     {
-        let ledger_axum_router =
-            LedgerRoutes::<
-                LedgerDb,
-                // Can keep hard-coding:
-                // BatchSequencerReceipt<B::DaSpec>,
-                // or use some associated type.
-                // TODO: But ideally it needs to be addressed properly: https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1268
-                BatchSequencerReceipt<B::Spec>,
-                TxReceiptContents<B::Spec>,
-                <B::Runtime as RuntimeEventProcessor>::RuntimeEvent,
-            >::axum_router(ledger_db.clone(), shutdown_receiver.clone());
+        let ledger_axum_router = LedgerRoutes::<
+            LedgerDb,
+            // Can keep hard-coding:
+            // BatchSequencerReceipt<B::DaSpec>,
+            // or use some associated type.
+            // TODO: But ideally it needs to be addressed properly: https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1268
+            BatchSequencerReceipt<B::Spec>,
+            TxReceiptContents<B::Spec>,
+            <B::Runtime as RuntimeEventProcessor>::RuntimeEvent,
+        >::axum_router(ledger_db.clone(), primary_shutdown.clone());
         let ledger_state = LedgerState {
             ledger: ledger_db.clone(),
-            shutdown_receiver,
+            primary_shutdown,
         };
         endpoints.axum_router = endpoints
             .axum_router

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -27,7 +27,9 @@ use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::{DaService, SlotData};
-use sov_rollup_interface::node::{SecondaryShutdownController, SyncStatus};
+use sov_rollup_interface::node::{
+    PrimaryShutdownController, SecondaryShutdownController, SyncStatus,
+};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::ProvableHeightTracker;
 use sov_sequencer::preferred::PreferredSequencer;
@@ -116,7 +118,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         da_service: &Self::DaService,
@@ -233,7 +235,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         &self,
         _sequencer: Seq,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: watch::Receiver<()>,
+        _primary_shutdown: PrimaryShutdownController,
         _sequencer_da_address: <<Self::Spec as Spec>::Da as DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -254,8 +256,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         ledger_db: &LedgerDb,
         api_ledger_db: &LedgerDb,
         da_service: &Self::DaService,
-        shutdown_receiver: watch::Receiver<()>,
-        shutdown_sender: tokio::sync::watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
         stop_at_rollup_height: Option<RollupHeight>,
         bind_addr: SocketAddr,
     ) -> anyhow::Result<SequencerCreationReceipt<Self::Spec>> {
@@ -277,7 +278,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         max_concurrent_proof_blobs,
                         ledger_db.clone(),
                         api_ledger_db.clone(),
-                        shutdown_sender,
+                        primary_shutdown.clone(),
                     )
                     .await?;
 
@@ -288,12 +289,12 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     .sequencer_additional_apis(
                         sequencer.clone(),
                         rollup_config,
-                        shutdown_receiver.clone(),
+                        primary_shutdown.clone(),
                         da_address,
                     )
                     .await?;
                 endpoints.axum_router = endpoints.axum_router.merge(
-                    SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver),
+                    SequencerApis::rest_api_server(sequencer.clone(), primary_shutdown),
                 );
 
                 Ok(SequencerCreationReceipt {
@@ -319,7 +320,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         max_concurrent_proof_blobs,
                         ledger_db.clone(),
                         api_ledger_db.clone(),
-                        shutdown_sender.clone(),
+                        primary_shutdown.clone(),
                         stop_at_rollup_height,
                         bind_addr,
                     )
@@ -333,12 +334,12 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     .sequencer_additional_apis(
                         sequencer.clone(),
                         rollup_config,
-                        shutdown_receiver.clone(),
+                        primary_shutdown.clone(),
                         da_address,
                     )
                     .await?;
                 endpoints.axum_router = endpoints.axum_router.merge(
-                    SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver),
+                    SequencerApis::rest_api_server(sequencer.clone(), primary_shutdown),
                 );
 
                 Ok(SequencerCreationReceipt {
@@ -378,8 +379,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             <<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::configure(exec_config).map_err(|e|anyhow::anyhow!(e))?;
         }
 
-        let (main_shutdown_sender, mut main_shutdown_receiver) = tokio::sync::watch::channel(());
-        main_shutdown_receiver.mark_unchanged();
+        let primary_shutdown = PrimaryShutdownController::new();
         let secondary_shutdown_controller = SecondaryShutdownController::new();
         let mut background_handles = vec![];
 
@@ -413,7 +413,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     Ok(value) => value,
                     Err(error) => {
                         cleanup_failed_startup_before_sequencer(
-                            &main_shutdown_sender,
+                            &primary_shutdown,
                             &secondary_shutdown_controller,
                             &mut background_handles,
                         )
@@ -620,8 +620,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 &ledger_db,
                 &api_ledger_db,
                 &da_service,
-                main_shutdown_receiver.clone(),
-                main_shutdown_sender.clone(),
+                primary_shutdown.clone(),
                 stop_at_rollup_height,
                 axum_socket_addr,
             )
@@ -649,7 +648,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 Ok((svc, slot)) => (Some(svc), slot),
                 Err(error) => {
                     cleanup_failed_startup(
-                        &main_shutdown_sender,
+                        &primary_shutdown,
                         &secondary_shutdown_controller,
                         &mut background_handles,
                         &mut sequencer,
@@ -677,7 +676,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             state_channel,
             prev_state_root,
             visible_state_height_tracker,
-            main_shutdown_receiver.clone(),
+            primary_shutdown.clone(),
             start_at_rollup_height,
             stop_at_rollup_height,
             da_sync_state.clone(),
@@ -690,7 +689,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             Ok(runner) => runner,
             Err(error) => {
                 cleanup_failed_startup(
-                    &main_shutdown_sender,
+                    &primary_shutdown,
                     &secondary_shutdown_controller,
                     &mut background_handles,
                     &mut sequencer,
@@ -709,7 +708,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     Err(error) => {
                         let _ = runner.shutdown_before_run().await;
                         cleanup_failed_startup(
-                            &main_shutdown_sender,
+                            &primary_shutdown,
                             &secondary_shutdown_controller,
                             &mut background_handles,
                             &mut sequencer,
@@ -750,7 +749,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         stf_info_receiver,
                         runner.da_sync_state(),
                         &secondary_shutdown_controller,
-                        main_shutdown_sender.clone(),
+                        primary_shutdown.clone(),
                         start_fresh_outer_proof_on_resync,
                     )
                     .await
@@ -764,7 +763,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 Err(error) => {
                     let _ = runner.shutdown_before_run().await;
                     cleanup_failed_startup(
-                        &main_shutdown_sender,
+                        &primary_shutdown,
                         &secondary_shutdown_controller,
                         &mut background_handles,
                         &mut sequencer,
@@ -781,7 +780,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             .create_endpoints(
                 state_update_receiver,
                 sync_status_receiver,
-                main_shutdown_receiver.clone(),
+                primary_shutdown.clone(),
                 &api_ledger_db,
                 &sequencer,
                 &da_service,
@@ -793,7 +792,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             Err(error) => {
                 let _ = runner.shutdown_before_run().await;
                 cleanup_failed_startup(
-                    &main_shutdown_sender,
+                    &primary_shutdown,
                     &secondary_shutdown_controller,
                     &mut background_handles,
                     &mut sequencer,
@@ -810,12 +809,12 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
         background_handles.extend(sequencer.background_handles);
 
-        spawn_os_signal_handler(main_shutdown_sender.clone());
+        spawn_os_signal_handler(primary_shutdown.clone());
 
         Ok(Rollup {
             runner,
             endpoints,
-            shutdown_sender: main_shutdown_sender,
+            primary_shutdown,
             secondary_shutdown_controller,
             background_handles,
             genesis_slot_number: genesis_da_height,
@@ -845,12 +844,12 @@ fn validate_operating_mode_config(
 }
 
 async fn cleanup_failed_startup<S: Spec>(
-    main_shutdown_sender: &watch::Sender<()>,
+    primary_shutdown: &PrimaryShutdownController,
     secondary_shutdown_controller: &SecondaryShutdownController,
     background_handles: &mut Vec<JoinHandle<()>>,
     sequencer: &mut SequencerCreationReceipt<S>,
 ) {
-    let _ = main_shutdown_sender.send(());
+    primary_shutdown.shutdown();
     secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
@@ -866,11 +865,11 @@ async fn cleanup_failed_startup<S: Spec>(
 }
 
 async fn cleanup_failed_startup_before_sequencer(
-    main_shutdown_sender: &watch::Sender<()>,
+    primary_shutdown: &PrimaryShutdownController,
     secondary_shutdown_controller: &SecondaryShutdownController,
     background_handles: &mut Vec<JoinHandle<()>>,
 ) {
-    let _ = main_shutdown_sender.send(());
+    primary_shutdown.shutdown();
     secondary_shutdown_controller.shutdown();
 
     let background_handles_to_join = std::mem::take(background_handles);
@@ -950,7 +949,7 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
     pub endpoints: NodeEndpointsContainer,
 
     /// A way to gracefully shut down background tasks.
-    pub shutdown_sender: tokio::sync::watch::Sender<()>,
+    pub primary_shutdown: PrimaryShutdownController,
 
     /// The genesis slot number.
     pub genesis_slot_number: u64,
@@ -982,16 +981,12 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
             .context("Failed to start Axum Server")?;
 
         let monitoring_task =
-            spawn_task_monitor(self.shutdown_sender.clone(), self.background_handles);
+            spawn_task_monitor(self.primary_shutdown.clone(), self.background_handles);
 
         runner.run_in_process().await?;
         tracing::info!("STF Runner has completed execution");
 
-        if self.shutdown_sender.send(()).is_err() {
-            tracing::info!(
-                "Failed to send primary shutdown signal because all receivers have been dropped"
-            );
-        }
+        self.primary_shutdown.shutdown();
 
         self.secondary_shutdown_controller.shutdown();
 
@@ -1016,28 +1011,27 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
 }
 
 fn spawn_task_monitor(
-    shutdown_sender: tokio::sync::watch::Sender<()>,
+    primary_shutdown: PrimaryShutdownController,
     handles: Vec<tokio::task::JoinHandle<()>>,
 ) -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
     tokio::spawn(async move {
-        let shutdown_recv = shutdown_sender.subscribe();
         tracing::trace!("blocking until a background task joins or rollup shutdown");
         let (result, _, handles) = futures::future::select_all(handles).await;
 
         let mut was_graceful = if let Err(error) = result {
             tracing::error!(error = %error, "background task joined with error");
-            _ = shutdown_sender.send(());
+            primary_shutdown.shutdown();
             false
         } else {
-            // If shutdown receiver hasn't changed then it's implied that one of the handles
+            // If no shutdown has been triggered then it's implied that one of the handles
             // joined early before a shutdown signal was sent. This likely indicates
             // incorrect behaviour and so we send the signal ourselves to begin the shutdown process.
-            if let Ok(true) = shutdown_recv.has_changed() {
+            if primary_shutdown.is_triggered() {
                 true
             } else {
                 tracing::error!("background task joined with success status but no shutdown signal had been sent at the time. This is a bug! Please report it.");
                 // Start graceful shutdown
-                _ = shutdown_sender.send(());
+                primary_shutdown.shutdown();
                 false
             }
         };
@@ -1047,7 +1041,7 @@ fn spawn_task_monitor(
         for handle in handles {
             if let Err(error) = handle.await {
                 tracing::error!(error = %error, "Additional background task joined with error");
-                _ = shutdown_sender.send(());
+                primary_shutdown.shutdown();
                 was_graceful = false;
             }
         }
@@ -1061,9 +1055,8 @@ fn spawn_task_monitor(
     })
 }
 
-fn spawn_os_signal_handler(shutdown_sender: tokio::sync::watch::Sender<()>) {
+fn spawn_os_signal_handler(primary_shutdown: PrimaryShutdownController) {
     tokio::spawn(async move {
-        let mut api_shutdown = shutdown_sender.subscribe();
         let mut terminate = tokio::signal::unix::signal(SignalKind::terminate())
             .expect("Failed to set up SIGTERM handler");
         let mut quit = tokio::signal::unix::signal(SignalKind::quit())
@@ -1073,14 +1066,12 @@ fn spawn_os_signal_handler(shutdown_sender: tokio::sync::watch::Sender<()>) {
             _ = tokio::signal::ctrl_c() => tracing::info!("Received Ctrl+C"),
             _ = terminate.recv() => tracing::info!("Received SIGTERM"),
             _ = quit.recv() => tracing::info!("Received SIGQUIT"),
-            _ = api_shutdown.changed() => {
+            _ = primary_shutdown.wait_for_shutdown() => {
                 tracing::debug!("Stopping OS signal handling task, as rollup has been stopped programmatically");
                 return;
             }
         }
-        shutdown_sender
-            .send(())
-            .expect("Failed to send shutdown signal");
+        primary_shutdown.shutdown();
     });
 }
 

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -78,7 +78,7 @@ where
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         da_service: &Self::DaService,
@@ -88,7 +88,7 @@ where
             .create_endpoints(
                 state_update_receiver,
                 sync_status_receiver,
-                shutdown_receiver,
+                primary_shutdown,
                 ledger_db,
                 sequencer,
                 da_service,
@@ -101,7 +101,7 @@ where
         &self,
         sequencer: Seq,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        _primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         _sequencer_da_address: <<Self::Spec as Spec>::Da as DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -7,12 +7,12 @@
 pub mod da;
 mod da_sync_state;
 pub mod ledger_api;
-mod secondary_shutdown;
+mod shutdown_controller;
 
 use std::future::Future;
 
 pub use da_sync_state::SyncStatus;
-pub use secondary_shutdown::SecondaryShutdownController;
+pub use shutdown_controller::{PrimaryShutdownController, SecondaryShutdownController};
 use tokio::select;
 use tokio::sync::watch;
 
@@ -47,7 +47,7 @@ pub enum FutureOrShutdownOutput<O> {
 /// # Args
 /// * `$name` – task name (for structured logs, e.g. `"writer"` or `format!("task-{id}")`)
 /// * `$recv` – async expression like `rx.recv()` or `stream.next()`
-/// * `$shutdown` – `watch::Receiver<()>` for graceful stop
+/// * `$shutdown` – `&PrimaryShutdownController` for graceful stop
 /// * `$var => $body` – code run for each received item
 ///
 /// Logs:
@@ -60,7 +60,7 @@ pub enum FutureOrShutdownOutput<O> {
 /// sov_rollup_interface::consume_until_shutdown!(
 ///     "WebSocket reader",
 ///     ws_reader.next(),
-///     shutdown_rx,
+///     primary_shutdown,
 ///     msg => {
 ///         handle(m).await,
 ///     }
@@ -77,7 +77,7 @@ macro_rules! consume_until_shutdown {
         let name = $name;
         loop {
             tokio::select! {
-                _ = $shutdown.changed() => {
+                _ = $shutdown.wait_for_shutdown() => {
                     tracing::debug!(%name, "Shutdown signal received, stopping task");
                     break;
                 }

--- a/crates/rollup-interface/src/node/secondary_shutdown.rs
+++ b/crates/rollup-interface/src/node/secondary_shutdown.rs
@@ -4,25 +4,50 @@ use tokio::sync::watch;
 
 use super::{future_or_shutdown, FutureOrShutdownOutput};
 
-/// Controls the secondary shutdown channel used after the main runner exits.
 #[derive(Clone)]
-pub struct SecondaryShutdownController {
+struct InnerShutdownController {
     sender: watch::Sender<()>,
     receiver: watch::Receiver<()>,
 }
 
-impl SecondaryShutdownController {
-    /// Creates a new secondary shutdown controller.
-    pub fn new() -> Self {
+impl InnerShutdownController {
+    fn new() -> Self {
         let (sender, mut receiver) = watch::channel(());
         receiver.mark_unchanged();
         Self { sender, receiver }
     }
 
-    /// Waits until a secondary shutdown notification is sent.
-    pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
+    async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
         let mut shutdown_receiver = self.receiver.clone();
         shutdown_receiver.changed().await
+    }
+
+    fn shutdown(&self) {
+        // The controller keeps its own receiver alive for as long as it exists,
+        // so there is always at least one receiver and `send` cannot fail here.
+        self.sender
+            .send(())
+            .expect("secondary shutdown channel always has a live receiver");
+    }
+}
+
+/// Controls the secondary shutdown channel used after the main runner exits.
+#[derive(Clone)]
+pub struct SecondaryShutdownController {
+    inner: InnerShutdownController,
+}
+
+impl SecondaryShutdownController {
+    /// Creates a new secondary shutdown controller.
+    pub fn new() -> Self {
+        Self {
+            inner: InnerShutdownController::new(),
+        }
+    }
+
+    /// Waits until a secondary shutdown notification is sent.
+    pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
+        self.inner.wait_for_shutdown().await
     }
 
     /// Runs a future until it completes or the secondary shutdown signal fires.
@@ -30,16 +55,12 @@ impl SecondaryShutdownController {
     where
         T: Future,
     {
-        future_or_shutdown(inner, &self.receiver).await
+        future_or_shutdown(inner, &self.inner.receiver).await
     }
 
     /// Sends a secondary shutdown notification.
     pub fn shutdown(&self) {
-        // The controller keeps its own receiver alive for as long as it exists,
-        // so there is always at least one receiver and `send` cannot fail here.
-        self.sender
-            .send(())
-            .expect("secondary shutdown channel always has a live receiver");
+        self.inner.shutdown();
     }
 }
 

--- a/crates/rollup-interface/src/node/shutdown_controller.rs
+++ b/crates/rollup-interface/src/node/shutdown_controller.rs
@@ -27,7 +27,59 @@ impl InnerShutdownController {
         // so there is always at least one receiver and `send` cannot fail here.
         self.sender
             .send(())
-            .expect("secondary shutdown channel always has a live receiver");
+            .expect("shutdown channel always has a live receiver");
+    }
+
+    fn is_triggered(&self) -> bool {
+        // The controller keeps its own sender alive for as long as it exists,
+        // so `has_changed` cannot fail here.
+        self.receiver
+            .has_changed()
+            .expect("shutdown channel always has a live sender")
+    }
+}
+
+/// Controls the primary shutdown channel used to stop the main runner.
+#[derive(Clone)]
+pub struct PrimaryShutdownController {
+    inner: InnerShutdownController,
+}
+
+impl PrimaryShutdownController {
+    /// Creates a new primary shutdown controller.
+    pub fn new() -> Self {
+        Self {
+            inner: InnerShutdownController::new(),
+        }
+    }
+
+    /// Waits until a primary shutdown notification is sent.
+    pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
+        self.inner.wait_for_shutdown().await
+    }
+
+    /// Runs a future until it completes or the primary shutdown signal fires.
+    pub async fn future_or_shutdown<T>(&self, inner: T) -> FutureOrShutdownOutput<T::Output>
+    where
+        T: Future,
+    {
+        future_or_shutdown(inner, &self.inner.receiver).await
+    }
+
+    /// Sends a primary shutdown notification.
+    pub fn shutdown(&self) {
+        self.inner.shutdown();
+    }
+
+    /// Returns `true` if a primary shutdown notification has already been sent.
+    pub fn is_triggered(&self) -> bool {
+        self.inner.is_triggered()
+    }
+}
+
+impl Default for PrimaryShutdownController {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/utils/sov-rest-utils/Cargo.toml
+++ b/crates/utils/sov-rest-utils/Cargo.toml
@@ -24,6 +24,7 @@ proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = "0.7"
+sov-rollup-interface = { workspace = true, features = ["native"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true, features = ["util"] }

--- a/crates/utils/sov-rest-utils/Cargo.toml
+++ b/crates/utils/sov-rest-utils/Cargo.toml
@@ -43,4 +43,9 @@ axum = { workspace = true, features = ["query", "ws", "json", "original-uri", "t
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 
 [features]
-arbitrary = ["proptest", "proptest-derive", "sov-rest-utils/arbitrary"]
+arbitrary = [
+	"proptest",
+	"proptest-derive",
+	"sov-rest-utils/arbitrary",
+	"sov-rollup-interface/arbitrary",
+]

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -48,6 +48,7 @@ pub use get_ip::*;
 pub use pagination::{PageSelection, PaginatedResponse, Pagination};
 use serde::Serialize;
 pub use sorting::{Sorting, SortingOrder};
+use sov_rollup_interface::node::PrimaryShutdownController;
 use std::fmt::Debug;
 use tower_http::cors::CorsLayer;
 use tower_http::propagate_header::PropagateHeaderLayer;
@@ -204,7 +205,7 @@ const PONG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 pub async fn serve_generic_ws_subscription<S, M, E>(
     socket: WebSocket,
     subscription: S,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
 ) where
     S: futures::Stream<Item = Result<M, E>> + Unpin,
     E: ReportableWsError,
@@ -213,7 +214,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
     serve_generic_ws_subscription_with_config(
         socket,
         subscription,
-        shutdown_receiver,
+        primary_shutdown,
         WsSubscriptionConfig::default(),
     )
     .await
@@ -236,7 +237,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
 pub async fn serve_generic_ws_subscription_with_config<S, M, E>(
     mut socket: WebSocket,
     subscription: S,
-    mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    primary_shutdown: PrimaryShutdownController,
     config: WsSubscriptionConfig,
 ) where
     S: futures::Stream<Item = Result<M, E>> + Unpin,
@@ -418,7 +419,7 @@ pub async fn serve_generic_ws_subscription_with_config<S, M, E>(
                 awaiting_pong = Some(ping_data);
                 trace!("Sent ping to client");
             },
-            _ = shutdown_receiver.changed() => break,
+            _ = primary_shutdown.wait_for_shutdown() => break,
         }
     }
 

--- a/crates/utils/sov-rest-utils/src/ws_tests.rs
+++ b/crates/utils/sov-rest-utils/src/ws_tests.rs
@@ -20,8 +20,9 @@ mod tests {
     use axum::routing::get;
     use axum::Router;
     use futures::StreamExt;
+    use sov_rollup_interface::node::PrimaryShutdownController;
     use tokio::net::TcpListener;
-    use tokio::sync::{broadcast, watch};
+    use tokio::sync::broadcast;
     use tokio::time::timeout;
     use tokio_stream::wrappers::BroadcastStream;
 
@@ -81,8 +82,7 @@ mod tests {
     /// State shared between test handlers.
     #[derive(Clone)]
     struct TestState {
-        shutdown_tx: watch::Sender<()>,
-        shutdown_rx: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
         /// Tracks how many messages were sent to the broadcast channel.
         messages_produced: Arc<AtomicUsize>,
         /// Tracks how many messages the stream attempted to yield.
@@ -91,10 +91,9 @@ mod tests {
 
     impl TestState {
         fn new() -> Self {
-            let (shutdown_tx, shutdown_rx) = watch::channel(());
+            let primary_shutdown = PrimaryShutdownController::new();
             Self {
-                shutdown_tx,
-                shutdown_rx,
+                primary_shutdown,
                 messages_produced: Arc::new(AtomicUsize::new(0)),
                 messages_yielded: Arc::new(AtomicUsize::new(0)),
             }
@@ -164,7 +163,7 @@ mod tests {
                 }
             });
 
-            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
             producer.abort();
         })
     }
@@ -188,7 +187,7 @@ mod tests {
                 }
             });
 
-            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
             producer.abort();
         })
     }
@@ -201,7 +200,7 @@ mod tests {
         ws.on_upgrade(move |socket| async move {
             // Create a stream that never yields any items (just stays pending)
             let stream = futures::stream::pending::<Result<String, TestSubscriptionError>>();
-            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+            serve_generic_ws_subscription(socket, stream, state.primary_shutdown.clone()).await;
         })
     }
 
@@ -227,7 +226,7 @@ mod tests {
             serve_generic_ws_subscription_with_config(
                 socket,
                 stream,
-                state.shutdown_rx.clone(),
+                state.primary_shutdown.clone(),
                 WsSubscriptionConfig { compress: true },
             )
             .await;
@@ -347,7 +346,7 @@ mod tests {
             );
         }
 
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     // =========================================================================
@@ -426,7 +425,7 @@ mod tests {
             );
         }
 
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     // =========================================================================
@@ -466,7 +465,7 @@ mod tests {
             "Server should send ping frames for keepalive"
         );
 
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     /// Test: Server should disconnect if pong is not received within timeout.
@@ -531,7 +530,7 @@ mod tests {
             "Server should disconnect after pong timeout"
         );
 
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     // =========================================================================
@@ -597,7 +596,7 @@ mod tests {
             assert_eq!(msg, &format!("message-{i}"), "Messages should be in order");
         }
 
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     /// Test: Default config (no compression) should produce text frames.
@@ -641,7 +640,7 @@ mod tests {
         assert!(text_count >= 5, "Should have received text frames");
 
         ws.close(None).await.ok();
-        state.shutdown_tx.send(()).ok();
+        state.primary_shutdown.shutdown();
     }
 
     /// Test: Gzip roundtrip preserves data correctly.

--- a/crates/utils/sov-test-utils/src/ledger_db.rs
+++ b/crates/utils/sov-test-utils/src/ledger_db.rs
@@ -12,11 +12,11 @@ use sov_ledger_apis::{LedgerRoutes, LedgerState};
 use sov_mock_da::{MockBlock, MockBlockHeader, MockHash};
 use sov_modules_api::da::Time;
 use sov_modules_api::{ModuleId, StoredEvent};
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::{BatchReceipt, FullyBakedTx, TransactionReceipt, TxEffect};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::TxHash;
 use tempfile::{tempdir, TempDir};
-use tokio::sync::watch;
 
 use crate::storage::SimpleLedgerStorageManager;
 use crate::{TestSpec, TestTxReceiptContents};
@@ -261,8 +261,8 @@ pub struct LedgerTestService {
     pub axum_handle: axum_server::Handle<std::net::SocketAddr>,
     /// An Axum client.
     pub axum_client: sov_api_spec::Client,
-    /// Shutdown signal receiver to allow for clean shutdowns of the API.
-    pub shutdown_receiver: watch::Receiver<()>,
+    /// Shutdown signal controller to allow for clean shutdowns of the API.
+    pub primary_shutdown: PrimaryShutdownController,
 }
 
 impl LedgerTestService {
@@ -285,24 +285,24 @@ impl LedgerTestService {
             }
         };
 
-        let (_, shutdown_receiver) = watch::channel(());
+        let primary_shutdown = PrimaryShutdownController::new();
 
         let axum_handle = axum_server::Handle::new();
         let axum_handle1 = axum_handle.clone();
         let ledger_db1 = ledger_db.clone();
-        let shutdown = shutdown_receiver.clone();
+        let shutdown = primary_shutdown.clone();
         tokio::spawn(async move {
             let addr = SocketAddr::from_str("127.0.0.1:0").unwrap();
             let state = LedgerState {
                 ledger: ledger_db1.clone(),
-                shutdown_receiver: shutdown_receiver.clone(),
+                primary_shutdown: primary_shutdown.clone(),
             };
             axum_server::Server::bind(addr)
                 .handle(axum_handle1)
                 .serve(
                     LedgerRoutes::<LedgerDb, u32, TestTxReceiptContents, TestEvent>::axum_router(
                         ledger_db1.clone(),
-                        shutdown_receiver,
+                        primary_shutdown,
                     )
                     .with_state::<()>(state)
                     .into_make_service(),
@@ -321,7 +321,7 @@ impl LedgerTestService {
             _dir: dir,
             axum_handle,
             axum_client,
-            shutdown_receiver: shutdown,
+            primary_shutdown: shutdown,
         })
     }
 }

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -191,7 +191,7 @@ where
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -201,7 +201,7 @@ where
             sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
                 state_update_receiver,
                 sync_status_receiver,
-                shutdown_receiver,
+                primary_shutdown,
                 ledger_db,
                 sequencer,
                 rollup_config,
@@ -261,7 +261,7 @@ where
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <<Self::Spec as Spec>::Da as sov_rollup_interface::da::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -270,7 +270,7 @@ where
         A::create(
             sequencer,
             rollup_config,
-            shutdown_receiver,
+            primary_shutdown,
             sequencer_da_address,
         )
     }
@@ -312,7 +312,7 @@ pub trait AdditionalSequencerApis<S: Spec<Da = MockDaSpec>, R: RuntimeTrait<S>>:
     fn create<Seq>(
         sequencer: Seq,
         rollup_config: &RollupConfig<S::Address, StorableMockDaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_rollup_interface::da::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -331,7 +331,7 @@ where
     fn create<Seq>(
         _sequencer: Seq,
         _rollup_config: &RollupConfig<S::Address, StorableMockDaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        _primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         _sequencer_da_address: <MockDaSpec as sov_rollup_interface::da::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where

--- a/crates/utils/sov-test-utils/src/runtime/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/mod.rs
@@ -36,6 +36,7 @@ pub use sov_paymaster::Paymaster;
 pub use sov_prover_incentives::{ProverIncentives, ProverIncentivesConfig};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::RelevantBlobs;
+use sov_rollup_interface::node::PrimaryShutdownController;
 use sov_rollup_interface::stf::DiscardedBlob;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 pub use sov_sequencer_registry::{self, SequencerRegistry, SequencerRegistryConfig};
@@ -179,8 +180,8 @@ pub struct TestRunner<
     /// The corresponding receiving end of the channel.
     checkpoint_receiver: watch::Receiver<Arc<ConcurrentStateCheckpoint<S>>>,
     /// Held for the runner's lifetime so REST API handlers only observe shutdown
-    /// when the runner is dropped.
-    shutdown_sender: watch::Sender<()>,
+    /// when the runner is dropped, at which point `Drop` triggers it explicitly.
+    primary_shutdown: PrimaryShutdownController,
     axum_server: axum_server::Handle<std::net::SocketAddr>,
     /// Test runner configuration.
     pub config: RunnerConfig<S::Da>,
@@ -188,6 +189,7 @@ pub struct TestRunner<
 
 impl<RT: Runtime<S>, S: Spec, Sm: ForklessStorageManager> Drop for TestRunner<RT, S, Sm> {
     fn drop(&mut self) {
+        self.primary_shutdown.shutdown();
         self.axum_server.shutdown();
     }
 }
@@ -515,7 +517,7 @@ where
             axum_server: Default::default(),
             checkpoint_sender: sender,
             checkpoint_receiver: receiver,
-            shutdown_sender: watch::channel(()).0,
+            primary_shutdown: PrimaryShutdownController::new(),
             config,
         };
 
@@ -903,7 +905,7 @@ where
             self.checkpoint_receiver.clone(),
             self.runtime().kernel_with_slot_mapping(),
             None,
-            self.shutdown_sender.subscribe(),
+            self.primary_shutdown.clone(),
         );
 
         let router = self.runtime().rest_api(state);

--- a/crates/utils/sov-test-utils/src/sequencer.rs
+++ b/crates/utils/sov-test-utils/src/sequencer.rs
@@ -21,7 +21,7 @@ use sov_modules_stf_blueprint::GenesisParams;
 use sov_paymaster::{PaymasterConfig, SafeVec};
 use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_full_node_interface::StateUpdateInfo;
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{PrimaryShutdownController, SyncStatus};
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_sequencer::standard::{StdSequencer, StdSequencerConfig};
@@ -57,13 +57,13 @@ pub struct TestSequencerSetup<Rt: Runtime<TestSpec>> {
     /// The Axum server address.
     pub axum_addr: SocketAddr,
     /// Handler for shutdown of sequencer
-    pub shutdown_sender: watch::Sender<()>,
+    pub primary_shutdown: PrimaryShutdownController,
 }
 
 impl<Rt: Runtime<TestSpec>> Drop for TestSequencerSetup<Rt> {
     fn drop(&mut self) {
         // Error means that senders are already shut down.
-        let _ = self.shutdown_sender.send(());
+        self.primary_shutdown.shutdown();
         self.axum_server_handle.shutdown();
     }
 }
@@ -142,8 +142,7 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             query_state_update_info(&ledger_db, stf_state, da_sync_state.as_ref()).await?;
 
         let (state_update_sender, state_update_receiver) = watch::channel(state_update_info);
-        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let primary_shutdown = PrimaryShutdownController::new();
 
         let config = SequencerConfig {
             rollup_address: sequencer_rollup_address,
@@ -167,12 +166,13 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             TEST_MAX_CONCURRENT_PROOF_BLOBS,
             ledger_db,
             api_ledger_db,
-            shutdown_sender.clone(),
+            primary_shutdown.clone(),
         )
         .await?;
 
         let (axum_addr, sequencer_axum_server) = {
-            let router = SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver);
+            let router =
+                SequencerApis::rest_api_server(sequencer.clone(), primary_shutdown.clone());
             let handle = axum_server::Handle::new();
 
             let handle1 = handle.clone();
@@ -197,7 +197,7 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             admin_private_key: admin.private_key,
             axum_server_handle: sequencer_axum_server,
             axum_addr,
-            shutdown_sender,
+            primary_shutdown,
         })
     }
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -43,7 +43,7 @@ use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_full_node_interface::StateUpdateInfo;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::node::{PrimaryShutdownController, SyncStatus};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_sequencer::preferred::{ConfiguredNodeRole, PostgresConfig, PreferredSequencerConfig};
 use sov_sequencer::test_stateless::TestStatelessSequencer;
@@ -273,7 +273,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             )
             .await?;
 
-        let shutdown_sender = rollup.shutdown_sender.clone();
+        let primary_shutdown = rollup.primary_shutdown.clone();
 
         let mut other_handles = Vec::new();
         let da_service = rollup.runner.da_service();
@@ -316,7 +316,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             node_id,
             client,
             da_service,
-            shutdown_sender,
+            primary_shutdown,
             secondary_test_sequencer_client: None,
             _secondary_sequencer_state_sender: None,
             other_handles,
@@ -558,7 +558,7 @@ where
         let da_service = test_rollup.da_service.clone();
 
         let rollup_config = test_rollup.rollup_config.clone();
-        let shutdown_sender = test_rollup.shutdown_sender.clone();
+        let primary_shutdown = test_rollup.primary_shutdown.clone();
         let (secondary_test_sequencer_client, secondary_sequencer_state_sender) =
             match with_secondary_sequencer {
                 Some(addr) => {
@@ -572,7 +572,7 @@ where
                     let (client, sender) = Self::start_secondary_sequencer(
                         da_service.another_on_the_same_layer(addr).await,
                         rollup_config.clone(),
-                        shutdown_sender.clone(),
+                        primary_shutdown.clone(),
                     )
                     .await?;
                     (Some(client), Some(sender))
@@ -589,12 +589,11 @@ where
     async fn start_secondary_sequencer(
         secondary_da_service: StorableMockDaService,
         rollup_config: RollupConfig<<R::Spec as Spec>::Address, R::DaService>,
-        shutdown_sender: tokio::sync::watch::Sender<()>,
+        primary_shutdown: PrimaryShutdownController,
     ) -> anyhow::Result<(
         sov_api_spec::client::Client,
         watch::Sender<StateUpdateInfo<<R::Spec as Spec>::Storage>>,
     )> {
-        let mut shutdown_receiver = shutdown_sender.subscribe();
         let blueprint: R = Default::default();
 
         let mut storage_manager = blueprint.create_storage_manager(&rollup_config, false)?;
@@ -631,11 +630,11 @@ where
                 &rollup_config.storage.path,
                 &rollup_config.sequencer.with_seq_config(()),
                 ledger_db,
-                shutdown_sender,
+                primary_shutdown.clone(),
             )
             .await?;
 
-        let router = SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver.clone());
+        let router = SequencerApis::rest_api_server(sequencer.clone(), primary_shutdown.clone());
 
         let addr = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0));
         let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -648,7 +647,7 @@ where
                 ServiceExt::<Request>::into_make_service_with_connect_info::<SocketAddr>(router),
             )
             .with_graceful_shutdown(async move {
-                shutdown_receiver.changed().await.ok();
+                let _ = primary_shutdown.wait_for_shutdown().await;
             })
             .await
         });
@@ -691,7 +690,7 @@ pub struct TestRollup<R: FullNodeBlueprint<Native>> {
         Arc<<R as FullNodeBlueprint<sov_modules_api::execution_mode::Native>>::DaService>,
     /// Allows programmatically initialize shutdown of the test-rollup.
     /// Used for checking graceful shutdown and restart.
-    pub shutdown_sender: watch::Sender<()>,
+    pub primary_shutdown: PrimaryShutdownController,
     /// Used for cleanup/shutdown logic.
     pub rollup_task: JoinHandle<anyhow::Result<()>>,
     /// For optional handles to background tasks.
@@ -822,9 +821,7 @@ where
 
     /// Shuts down the rollup and waits for all background tasks to finish.
     pub async fn shutdown(self) -> anyhow::Result<RollupBuilder<R>> {
-        if let Err(error) = self.shutdown_sender.send(()) {
-            tracing::info!(%error, "shutdown triggered elsewhere, this is probably OK");
-        }
+        self.primary_shutdown.shutdown();
         self.rollup_task.await.expect("Can't join rollup task")?;
 
         for handle in self.other_handles {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -6208,7 +6208,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -6242,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bech32",
  "borsh",
@@ -6233,7 +6233,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",

--- a/examples/demo-rollup/sov-benchmarks/src/bench_runner/mod.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/bench_runner/mod.rs
@@ -307,10 +307,7 @@ async fn runner(
         "Shutting down rollup..."
     );
 
-    rollup
-        .shutdown_sender
-        .send(())
-        .expect("Failed to send shutdown signal");
+    rollup.primary_shutdown.shutdown();
     let _x = rollup
         .rollup_task
         .await

--- a/examples/demo-rollup/sov-soak-testing/src/bin/main.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/bin/main.rs
@@ -74,7 +74,7 @@ where
     R::Spec: sov_modules_api::Spec<Da = sov_mock_da::MockDaSpec>,
 {
     let rollup = builder.start().await.expect("Impossible to start rollup");
-    let mut shutdown_recv = rollup.shutdown_sender.subscribe();
+    let primary_shutdown = rollup.primary_shutdown.clone();
 
     let mut terminate = tokio::signal::unix::signal(SignalKind::terminate())
         .expect("Failed to set up SIGTERM handler");
@@ -84,7 +84,7 @@ where
         _ = tokio::signal::ctrl_c() => tracing::info!("Received Ctrl+C"),
         _ = terminate.recv() => tracing::info!("Received SIGTERM"),
         _ = quit.recv() => tracing::info!("Received SIGQUIT"),
-        _ = shutdown_recv.changed() => tracing::warn!("Rollup execution finished, this might not be desired!!"),
+        _ = primary_shutdown.wait_for_shutdown() => tracing::warn!("Rollup execution finished, this might not be desired!!"),
     }
 
     rollup.shutdown().await?;

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -93,7 +93,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -102,7 +102,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, _>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -130,7 +130,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <CelestiaSpec as sov_modules_api::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -143,7 +143,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: crate::sequencer_type(&rollup_config.sequencer),
-            shutdown_receiver,
+            primary_shutdown,
         };
         let axum_router = solana_offchain_router(sequencer.clone());
 

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -85,7 +85,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -94,7 +94,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -106,7 +106,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_modules_api::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -119,7 +119,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: crate::sequencer_type(&rollup_config.sequencer),
-            shutdown_receiver,
+            primary_shutdown,
         };
         let axum_router = solana_offchain_router(sequencer.clone());
 

--- a/examples/demo-rollup/src/external_mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_sp1_rollup.rs
@@ -79,7 +79,7 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -88,7 +88,7 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -100,7 +100,7 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_modules_api::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -113,7 +113,7 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: crate::sequencer_type(&rollup_config.sequencer),
-            shutdown_receiver,
+            primary_shutdown,
         };
         let axum_router = solana_offchain_router(sequencer.clone());
 

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -86,7 +86,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -95,7 +95,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -107,7 +107,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_modules_api::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -120,7 +120,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: crate::sequencer_type(&rollup_config.sequencer),
-            shutdown_receiver,
+            primary_shutdown,
         };
         let axum_router = solana_offchain_router(sequencer.clone());
 

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -79,7 +79,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: tokio::sync::watch::Receiver<SyncStatus>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -88,7 +88,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, Native>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -100,7 +100,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController,
         sequencer_da_address: <MockDaSpec as sov_modules_api::DaSpec>::Address,
     ) -> anyhow::Result<NodeEndpoints>
     where
@@ -113,7 +113,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: crate::sequencer_type(&rollup_config.sequencer),
-            shutdown_receiver,
+            primary_shutdown,
         };
         let axum_router = solana_offchain_router(sequencer.clone());
 

--- a/examples/demo-rollup/tests/restart/graceful.rs
+++ b/examples/demo-rollup/tests/restart/graceful.rs
@@ -531,7 +531,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         let mut slot_subscription = test_rollup.client.client.subscribe_slots().await?;
 
         let TestRollup {
-            shutdown_sender,
+            primary_shutdown,
             rollup_task,
             ..
         } = test_rollup;
@@ -551,7 +551,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         }
         drop(slot_subscription);
 
-        shutdown_sender.send(())?;
+        primary_shutdown.shutdown();
         let _ = rollup_task.await?;
     }
 
@@ -573,7 +573,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         let mut slot_subscription = test_rollup.client.client.subscribe_slots().await?;
 
         let TestRollup {
-            shutdown_sender,
+            primary_shutdown,
             rollup_task,
             ..
         } = test_rollup;
@@ -609,7 +609,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         //     "Prover hasn't posted proof"
         // );
 
-        shutdown_sender.send(())?;
+        primary_shutdown.shutdown();
         let _ = rollup_task.await?;
     }
 
@@ -680,7 +680,7 @@ async fn check_with_increasing_stf_infos(
                 .with_context(|| format!("start n={idx} of the rollup failed"))??;
 
         let TestRollup {
-            shutdown_sender,
+            primary_shutdown,
             rollup_task,
             da_service,
             client: sov_cli::NodeClient {
@@ -712,7 +712,7 @@ async fn check_with_increasing_stf_infos(
 
         drop(slot_subscription);
         drop(da_service);
-        shutdown_sender.send(())?;
+        primary_shutdown.shutdown();
         tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, rollup_task)
             .await
             .context("Joining rollup task failed")???;

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -451,7 +451,7 @@ async fn sync_rollup_with_path(
     check_value(&demo_client, CHECK_TRANSACTION_VALUE).await;
 
     let TestRollup {
-        shutdown_sender,
+        primary_shutdown,
         rollup_task,
         da_service,
         ..
@@ -459,7 +459,7 @@ async fn sync_rollup_with_path(
 
     drop(da_service);
     tracing::info!("Triggering shutdown....");
-    shutdown_sender.send(())?;
+    primary_shutdown.shutdown();
     tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, rollup_task)
         .await
         .context("Joining rollup task failed")???;


### PR DESCRIPTION
# Description

This PR:
  - Introduces PrimaryShutdownController alongside the existing secondary shutdown controller.
  - Replaces raw primary watch::Sender/Receiver<()> plumbing across runner, sequencer, blob sender, REST/WebSocket APIs, Ethereum RPC, and test utilities.
  - Adds shared helpers for triggering, awaiting, and checking primary shutdown state.
  - Updates tests and example rollup wiring to use the new controller API.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

