### PR TITLE
Celestia config: unify casing and deny unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2026-06-24
+- #PR_NUMBER Celestia config: aligns the `compression` and `tx_priority` config enums to lowercase/snake_case so they match `verify_on_fetch_mode` (e.g. `compression = "lz4"`, `tx_priority = "high"`). Previously these required PascalCase (`"Lz4"`, `"High"`) and a natural lowercase value was rejected, crashing the node at startup. `tx_priority` keeps PascalCase aliases (`"Low"`/`"Medium"`/`"High"`) for back-compat; `compression` (unreleased) switches from `"Off"`/`"Lz4"` to `"off"`/`"lz4"` without an alias.
+  * **Breaking Change** `CelestiaConfig` and `GrpcEndpointConfig` now set `#[serde(deny_unknown_fields)]`: unknown or misspelled keys in the `[da]` config table fail at startup instead of being silently ignored. Existing field aliases (e.g. `celestia_rpc_address`) are unaffected.
+
 # 2026-04-20
 - #2764 Celestia adapter: re-adds block integrity verification on fetch. Replaces the previously-reverted boolean toggle (PR #2489 / reverted in PR #2520) with a
   `verify_on_fetch_mode` enum accepting `"off"` (default), `"log_error"`, or `"return_error"`. `log_error` runs verification and logs via `tracing::error!` on failure while still returning the block, enabling staged rollouts without breaking the node.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-06-24
-- #PR_NUMBER Celestia config: aligns the `compression` and `tx_priority` config enums to lowercase/snake_case so they match `verify_on_fetch_mode` (e.g. `compression = "lz4"`, `tx_priority = "high"`). Previously these required PascalCase (`"Lz4"`, `"High"`) and a natural lowercase value was rejected, crashing the node at startup. `tx_priority` keeps PascalCase aliases (`"Low"`/`"Medium"`/`"High"`) for back-compat; `compression` (unreleased) switches from `"Off"`/`"Lz4"` to `"off"`/`"lz4"` without an alias.
+- #3014 Celestia config: aligns the `compression` and `tx_priority` config enums to lowercase/snake_case so they match `verify_on_fetch_mode` (e.g. `compression = "lz4"`, `tx_priority = "high"`). Previously these required PascalCase (`"Lz4"`, `"High"`) and a natural lowercase value was rejected, crashing the node at startup. `tx_priority` keeps PascalCase aliases (`"Low"`/`"Medium"`/`"High"`) for back-compat; `compression` (unreleased) switches from `"Off"`/`"Lz4"` to `"off"`/`"lz4"` without an alias.
   * **Breaking Change** `CelestiaConfig` and `GrpcEndpointConfig` now set `#[serde(deny_unknown_fields)]`: unknown or misspelled keys in the `[da]` config table fail at startup instead of being silently ignored. Existing field aliases (e.g. `celestia_rpc_address`) are unaffected.
 
 # 2026-04-20

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 /// Configuration for a single gRPC fallback endpoint.
 #[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GrpcEndpointConfig {
     /// The URL of the gRPC endpoint, for example `http://fallback1:9090`.
     pub url: String,
@@ -24,6 +25,7 @@ impl fmt::Debug for GrpcEndpointConfig {
 
 /// Runtime configuration for the [`sov_rollup_interface::node::da::DaService`] implementation.
 #[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct CelestiaConfig {
     /// The address of the Celestia RPC server
     /// For example: ws://localhost:26658
@@ -171,9 +173,13 @@ impl fmt::Debug for CelestiaConfig {
 
 /// Custom type matching [`celestia_rpc::TxPriority`] but with `JsonSchema` support.
 #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum TxPriority {
+    #[serde(alias = "Low")]
     Low,
+    #[serde(alias = "Medium")]
     Medium,
+    #[serde(alias = "High")]
     High,
 }
 
@@ -215,6 +221,7 @@ pub enum VerifyOnFetchMode {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize, JsonSchema,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum CompressOnSubmit {
     /// Post batch blobs verbatim (today's behavior).
     #[default]
@@ -440,7 +447,7 @@ pub(crate) fn default_background_stat_polling_interval_secs() -> u64 {
 mod tests {
     use super::{
         default_compression_chunk_size, validate_compression_chunk_size, validate_rpc_url,
-        CelestiaConfig, GrpcEndpointConfig, VerifyOnFetchMode,
+        CelestiaConfig, CompressOnSubmit, GrpcEndpointConfig, TxPriority, VerifyOnFetchMode,
     };
 
     const RPC_ENV_VAR: &str = "SOV_CELESTIA_RPC_URL";
@@ -660,6 +667,70 @@ mod tests {
             let config = deserialize_config(json).expect(json);
             assert_eq!(config.verify_on_fetch_mode, expected);
         }
+    }
+
+    #[test]
+    fn compression_accepts_lowercase_variants() {
+        let cases = [
+            (r#"{"compression":"off"}"#, CompressOnSubmit::Off),
+            (r#"{"compression":"lz4"}"#, CompressOnSubmit::Lz4),
+        ];
+        for (json, expected) in cases {
+            let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+            let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+            let config = deserialize_config(json).expect(json);
+            assert_eq!(config.compression, expected);
+        }
+    }
+
+    #[test]
+    fn tx_priority_accepts_snake_case() {
+        let cases = [
+            (r#"{"tx_priority":"low"}"#, TxPriority::Low),
+            (r#"{"tx_priority":"medium"}"#, TxPriority::Medium),
+            (r#"{"tx_priority":"high"}"#, TxPriority::High),
+        ];
+        for (json, expected) in cases {
+            let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+            let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+            let config = deserialize_config(json).expect(json);
+            assert_eq!(config.tx_priority, expected);
+        }
+    }
+
+    #[test]
+    fn tx_priority_accepts_pascal_case_alias() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config(r#"{"tx_priority":"High"}"#).unwrap();
+        assert_eq!(config.tx_priority, TxPriority::High);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let error = deserialize_config(r#"{"unknown_field": true}"#).unwrap_err();
+        assert!(
+            error.to_string().contains("unknown field"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn legacy_field_alias_survives_deny_unknown_fields() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, None);
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        // `celestia_rpc_address` is a back-compat alias for `rpc_url`; `deny_unknown_fields`
+        // must still recognize it rather than reject it as unknown.
+        let config =
+            deserialize_config(r#"{"celestia_rpc_address":"ws://config-rpc:26658"}"#).unwrap();
+        assert_eq!(config.rpc_url, "ws://config-rpc:26658");
     }
 
     #[test]

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -66,15 +66,15 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 #   "return_error" - run verification; on failure fail the fetch and propagate the error
 #verify_on_fetch_mode = "off"
 
-# Options are "Low", "Medium" and "High"
-# Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.
-# Default: High for better blob inclusion.
-#tx_priority = "High"
+# Options are "low", "medium" and "high"
+# Defines a priority of rollup blob transactions. Set it to "high" for faster inclusion.
+# Default: high for better blob inclusion.
+#tx_priority = "high"
 
 # Whether to compress batch blobs before submission. Emission only — it never affects
-# how blobs are read or verified. Keep "Off" until every node/prover on the network can
-# read compression envelopes. Options: "Off", "Lz4". Default: "Off".
-#compression = "Off"
+# how blobs are read or verified. Keep "off" until every node/prover on the network can
+# read compression envelopes. Options: "off", "lz4". Default: "off".
+#compression = "off"
 # Target chunk size (uncompressed bytes) for the chunked compression envelope. Must be in
 # 1..=16384 (MAX_ROLLUP_CHUNK_LEN, the verifier's per-chunk rollup cap); an out-of-range value
 # is rejected at startup rather than silently clamped.


### PR DESCRIPTION
# Description

Recently added compression config had no `snake_case` option, so whole config became inconsistent.

Also CelestiaConfig hasn't been denying unknown fields, which can lead to non-applied settings with typoes

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Added unit tests


## Docs
No updates
