### PR TITLE
Add RunnerShutdownController and use it in the runner

### DIFF
--- a/crates/full-node/sov-stf-runner/src/da/bulk_finalized_blocks_fetcher.rs
+++ b/crates/full-node/sov-stf-runner/src/da/bulk_finalized_blocks_fetcher.rs
@@ -29,7 +29,7 @@
 //!     start_height,      // First height to fetch
 //!     bulk_size,         // Number of concurrent requests
 //!     channel_capacity,  // Size of the pre-fetch buffer
-//!     shutdown_receiver,
+//!     shutdown,          // RunnerShutdownController
 //! ).await?;
 //!
 //! // Get blocks - returns pre-fetched blocks for the configured range
@@ -46,13 +46,13 @@
 //! # Shutdown Behavior
 //!
 //! The background fetcher task respects shutdown signals and will cleanly terminate
-//! when the `shutdown_receiver` is triggered, ensuring no orphaned tasks remain.
+//! when the `shutdown` controller is triggered, ensuring no orphaned tasks remain.
 use futures::Stream;
 use futures_util::stream::FuturesOrdered;
 use futures_util::StreamExt;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::{DaService, SlotData};
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{FutureOrShutdownOutput, RunnerShutdownController};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
@@ -97,7 +97,7 @@ where
         start_height: u64,
         bulk_size: u8,
         channel_capacity: usize,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        shutdown: RunnerShutdownController,
     ) -> anyhow::Result<(Self, tokio::task::JoinHandle<anyhow::Result<()>>)> {
         if bulk_size as usize > channel_capacity {
             anyhow::bail!("pre_fetched_blocks_capacity={channel_capacity} should be larger than concurrent_sync_tasks={bulk_size}");
@@ -121,7 +121,7 @@ where
 
         let background_handle = tokio::spawn(async {
             // Intentionally swallow error to not produce panic on shutdown.
-            match block_fetcher.run(shutdown_receiver).await {
+            match block_fetcher.run(shutdown).await {
                 Ok(()) => {
                     tracing::debug!("BlockFetcher task has completed");
                 }
@@ -244,10 +244,7 @@ where
         Box::pin(futures)
     }
 
-    pub(crate) async fn run(
-        mut self,
-        mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
-    ) -> anyhow::Result<()> {
+    pub(crate) async fn run(mut self, shutdown: RunnerShutdownController) -> anyhow::Result<()> {
         tracing::trace!(
             start = self.start_height,
             last_finalized_height = self.last_finalized_height,
@@ -277,7 +274,7 @@ where
             let mut permit = match select_with_shutdown(
                 // The range is inclusive.
                 self.blocks.reserve_many(self.bulk_size as usize + 1),
-                &mut shutdown_receiver,
+                &shutdown,
                 "reserve space in channel",
             )
             .await
@@ -293,7 +290,7 @@ where
 
             let block_stream = match select_with_shutdown(
                 self.fetch_blocks_in_range(start_height, end_height),
-                &mut shutdown_receiver,
+                &shutdown,
                 "self.fetch_blocks_in_range()",
             )
             .await
@@ -307,12 +304,9 @@ where
             let mut blocks_fetched = 0;
 
             loop {
-                let next_block = select_with_shutdown(
-                    block_stream.next(),
-                    &mut shutdown_receiver,
-                    "block_stream.next()",
-                )
-                .await;
+                let next_block =
+                    select_with_shutdown(block_stream.next(), &shutdown, "block_stream.next()")
+                        .await;
 
                 match next_block {
                     Some(Some(block_result)) => {
@@ -369,13 +363,13 @@ where
 
 async fn select_with_shutdown<F, T>(
     fut: F,
-    shutdown_receiver: &mut tokio::sync::watch::Receiver<()>,
+    shutdown: &RunnerShutdownController,
     label: &'static str,
 ) -> Option<T>
 where
     F: std::future::Future<Output = T>,
 {
-    match future_or_shutdown(fut, shutdown_receiver).await {
+    match shutdown.future_or_shutdown(fut).await {
         FutureOrShutdownOutput::Output(res) => Some(res),
         FutureOrShutdownOutput::Shutdown => {
             tracing::debug!(%label, "Shutting down block fetcher");
@@ -398,11 +392,11 @@ mod tests {
             da_service.send_transaction(&[i; 32]).await.await??;
         }
 
-        let (sender, mut receiver) = tokio::sync::watch::channel(());
-        receiver.mark_unchanged();
+        let shutdown = RunnerShutdownController::new();
 
         let (mut fetcher, handle) =
-            FinalizedBlocksBulkFetcher::new(Arc::new(da_service), 0, 3, 30, receiver).await?;
+            FinalizedBlocksBulkFetcher::new(Arc::new(da_service), 0, 3, 30, shutdown.clone())
+                .await?;
 
         for i in 0..blocks_number {
             let block = fetcher.get_block_at(i as u64).await?;
@@ -410,7 +404,7 @@ mod tests {
         }
 
         // pre-fetcher might exit by that point.
-        let _ = sender.send(());
+        shutdown.shutdown();
         handle.await??;
         Ok(())
     }

--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -15,10 +15,10 @@ use jsonrpsee::server::{
 use jsonrpsee::types::{ErrorCode, ErrorObject};
 use jsonrpsee::RpcModule;
 use sov_metrics::{track_metrics, HttpMetrics, RpcAggregationConfig, RpcStatsAggregator};
+use sov_rollup_interface::node::RunnerShutdownController;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tower_http::cors::CorsLayer;
@@ -89,7 +89,7 @@ pub(crate) async fn start_http_server(
     axum_listener: TcpListener,
     router: axum::Router<()>,
     methods: RpcModule<()>,
-    mut shutdown_receiver: watch::Receiver<()>,
+    shutdown: RunnerShutdownController,
     cors_configuration: CorsConfiguration,
     rpc_aggregation: RpcAggregationConfig,
 ) -> anyhow::Result<HttpServerStart> {
@@ -127,7 +127,7 @@ pub(crate) async fn start_http_server(
             ),
         )
         .with_graceful_shutdown(async move {
-            shutdown_receiver.changed().await.ok();
+            shutdown.wait_for_shutdown().await.ok();
         })
         .await
         .map_err(|e| anyhow::anyhow!(e));
@@ -355,31 +355,30 @@ mod tests {
         axum::Router::new().route("/", axum::routing::get(|| async { "hi" }))
     }
 
-    // Returns shutdown sender
-    async fn build_and_start_test_server() -> (SocketAddr, watch::Sender<()>) {
+    // Returns the shutdown controller used to stop the server.
+    async fn build_and_start_test_server() -> (SocketAddr, RunnerShutdownController) {
         let methods = build_test_json_rpc();
         let axum_router = build_test_axum_router();
-        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
-        shutdown_receiver.mark_unchanged();
+        let shutdown = RunnerShutdownController::new();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let _ = start_http_server(
             listener,
             axum_router,
             methods,
-            shutdown_receiver,
+            shutdown.clone(),
             CorsConfiguration::Restrictive,
             RpcAggregationConfig::standard(),
         )
         .await
         .unwrap();
 
-        (addr, shutdown_sender)
+        (addr, shutdown)
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_request_response() -> anyhow::Result<()> {
-        let (addr, shutdown_sender) = build_and_start_test_server().await;
+        let (addr, shutdown) = build_and_start_test_server().await;
 
         let ws_client = WsClientBuilder::default()
             .build(&format!("ws://{addr}/rpc"))
@@ -392,13 +391,13 @@ mod tests {
 
             assert_eq!(response, "hi");
         }
-        shutdown_sender.send(())?;
+        shutdown.shutdown();
         Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_subscription() -> anyhow::Result<()> {
-        let (addr, shutdown_sender) = build_and_start_test_server().await;
+        let (addr, shutdown) = build_and_start_test_server().await;
 
         let ws_client = WsClientBuilder::default()
             .build(&format!("ws://{addr}/rpc"))
@@ -420,13 +419,13 @@ mod tests {
         subscription.unsubscribe().await?;
         assert_eq!(numbers, (0..10).collect::<Vec<u64>>());
 
-        shutdown_sender.send(())?;
+        shutdown.shutdown();
         Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_binary_frames() -> anyhow::Result<()> {
-        let (addr, shutdown_sender) = build_and_start_test_server().await;
+        let (addr, shutdown) = build_and_start_test_server().await;
 
         // Connect using raw tungstenite client to send binary frames
         let (ws_stream, _) = connect_async(format!("ws://{addr}/rpc"))
@@ -449,7 +448,7 @@ mod tests {
         };
         assert!(response.contains("\"result\":\"hi\""));
 
-        shutdown_sender.send(())?;
+        shutdown.shutdown();
         Ok(())
     }
 
@@ -459,7 +458,7 @@ mod tests {
     }
 
     async fn test_ws_duplex_inner() -> anyhow::Result<()> {
-        let (addr, shutdown_sender) = build_and_start_test_server().await;
+        let (addr, shutdown) = build_and_start_test_server().await;
 
         let ws_client = WsClientBuilder::default()
             .build(&format!("ws://{addr}/rpc"))
@@ -485,7 +484,7 @@ mod tests {
             .await?;
         assert_eq!(response, "hi");
 
-        shutdown_sender.send(())?;
+        shutdown.shutdown();
 
         Ok(())
     }

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -17,8 +17,7 @@ use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::node::da::{DaService, SlotData};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::{
-    future_or_shutdown, FutureOrShutdownOutput, PrimaryShutdownController, RunnerShutdownController,
-    SyncStatus,
+    FutureOrShutdownOutput, PrimaryShutdownController, RunnerShutdownController, SyncStatus,
 };
 use sov_rollup_interface::stf::{
     ExecutionContext, PartialProofReceipt, ProofOutcome, ProofReceipt, ProofReceiptContents,
@@ -27,7 +26,6 @@ use sov_rollup_interface::stf::{
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_rollup_interface::ProvableHeightTracker;
-use tokio::sync::watch;
 use tracing::{debug, info, trace};
 
 use crate::da::{DaServiceWithCachedFinalizedHeaders, FinalizedBlocksBulkFetcher};
@@ -100,6 +98,19 @@ where
     save_tx_bodies: bool,
     finalized_headers_provider: DaServiceWithCachedFinalizedHeaders<Da>,
     axum_tcp: Option<TcpListener>,
+}
+
+// Guarantees the runner's background tasks are signalled to stop whenever the runner is dropped.
+impl<Stf, Sm, Da> Drop for StateTransitionRunner<Stf, Sm, Da>
+where
+    Da: DaService,
+    Sm: HierarchicalStorageManager<Da::Spec>,
+    Sm::StfState: Clone,
+    Stf: StateTransitionFunction<Da::Spec>,
+{
+    fn drop(&mut self) {
+        self.runner_shutdown.shutdown();
+    }
 }
 
 /// Initializes rollup genesis.
@@ -243,7 +254,7 @@ where
             first_unprocessed_height_at_startup,
             runner_config.concurrent_sync_tasks,
             runner_config.pre_fetched_blocks_capacity.get(),
-            runner_shutdown.subscribe(),
+            runner_shutdown.clone(),
         )
         .await?;
         background_handles.push(fetcher_background_handle);
@@ -313,7 +324,7 @@ where
                 .ok_or_else(|| anyhow::anyhow!("HTTP server already started."))?,
             router,
             methods,
-            self.runner_shutdown.subscribe(),
+            self.runner_shutdown.clone(),
             cors_configuration,
             rpc_aggregation,
         )
@@ -341,7 +352,7 @@ where
     fn spawn_sync_status_updater(
         &self,
         polling_interval: Duration,
-        shutdown_receiver: watch::Receiver<()>,
+        shutdown: RunnerShutdownController,
     ) -> tokio::task::JoinHandle<()> {
         let sync_state = self.sync_state.clone();
         let da_service_with_cache = self.finalized_headers_provider.clone();
@@ -357,11 +368,12 @@ where
             interval.tick().await; // Tick the interval once because it starts at 0ms.
 
             loop {
-                match future_or_shutdown(
-                    get_target_block(&da_service_with_cache, &stop_at_rollup_height),
-                    &shutdown_receiver,
-                )
-                .await
+                match shutdown
+                    .future_or_shutdown(get_target_block(
+                        &da_service_with_cache,
+                        &stop_at_rollup_height,
+                    ))
+                    .await
                 {
                     FutureOrShutdownOutput::Shutdown => break,
                     FutureOrShutdownOutput::Output(Err(error)) => {
@@ -410,7 +422,7 @@ where
                                 }
                             };
                         }
-                        future_or_shutdown(interval.tick(), &shutdown_receiver).await;
+                        shutdown.future_or_shutdown(interval.tick()).await;
                     }
                 }
             }
@@ -423,10 +435,8 @@ where
 
         let mut next_da_height = self.first_unprocessed_height_at_startup;
 
-        let status_updater_handle = self.spawn_sync_status_updater(
-            self.da_polling_interval,
-            self.runner_shutdown.subscribe(),
-        );
+        let status_updater_handle =
+            self.spawn_sync_status_updater(self.da_polling_interval, self.runner_shutdown.clone());
 
         let start_at_rollup_height = self.start_at_rollup_height;
         let stop_at_rollup_height = self.stop_at_rollup_height;

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -17,7 +17,8 @@ use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::node::da::{DaService, SlotData};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::{
-    future_or_shutdown, FutureOrShutdownOutput, PrimaryShutdownController, SyncStatus,
+    future_or_shutdown, FutureOrShutdownOutput, PrimaryShutdownController, RunnerShutdownController,
+    SyncStatus,
 };
 use sov_rollup_interface::stf::{
     ExecutionContext, PartialProofReceipt, ProofOutcome, ProofReceipt, ProofReceiptContents,
@@ -92,7 +93,7 @@ where
     sync_state: Arc<DaSyncState>,
     sync_fetcher: FinalizedBlocksBulkFetcher<Da>,
     primary_shutdown: PrimaryShutdownController,
-    secondary_shutdown_sender: watch::Sender<()>,
+    runner_shutdown: RunnerShutdownController,
     background_handles: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
@@ -183,10 +184,11 @@ where
         tracing::info!(config = ?runner_config, "Initializing StateTransitionRunner");
         let mut background_handles = Vec::new();
 
-        // This sender is not used immediately,
-        // But when REST and RPC handlers start, sender is used to get another subscription.
-        let (secondary_shutdown_sender, mut secondary_shutdown_receiver) = watch::channel(());
-        secondary_shutdown_receiver.mark_unchanged();
+        // Controls shutdown of the runner's own background tasks. It is not
+        // signalled immediately; background tasks subscribe to it as they are
+        // spawned (fetcher here, REST/RPC handlers and the sync-status updater
+        // later) and stop once `shutdown` is sent.
+        let runner_shutdown = RunnerShutdownController::new();
 
         let first_unprocessed_height_at_startup = sync_state
             .synced_da_height
@@ -241,7 +243,7 @@ where
             first_unprocessed_height_at_startup,
             runner_config.concurrent_sync_tasks,
             runner_config.pre_fetched_blocks_capacity.get(),
-            secondary_shutdown_receiver.clone(),
+            runner_shutdown.subscribe(),
         )
         .await?;
         background_handles.push(fetcher_background_handle);
@@ -256,7 +258,7 @@ where
             stf_info_receiver,
             sync_fetcher,
             primary_shutdown,
-            secondary_shutdown_sender,
+            runner_shutdown,
             background_handles,
             start_at_rollup_height,
             stop_at_rollup_height,
@@ -311,7 +313,7 @@ where
                 .ok_or_else(|| anyhow::anyhow!("HTTP server already started."))?,
             router,
             methods,
-            self.secondary_shutdown_sender.subscribe(),
+            self.runner_shutdown.subscribe(),
             cors_configuration,
             rpc_aggregation,
         )
@@ -326,12 +328,7 @@ where
     /// Shuts down any background work spawned during initialization before the
     /// runner enters its main loop.
     pub async fn shutdown_before_run(mut self) -> anyhow::Result<()> {
-        if let Err(e) = self.secondary_shutdown_sender.send(()) {
-            tracing::warn!(
-                error = ?e,
-                "Failed to send secondary shutdown signal while aborting runner startup"
-            );
-        }
+        self.runner_shutdown.shutdown();
 
         // Drain concurrently.
         let background_handles = std::mem::take(&mut self.background_handles);
@@ -428,7 +425,7 @@ where
 
         let status_updater_handle = self.spawn_sync_status_updater(
             self.da_polling_interval,
-            self.secondary_shutdown_sender.subscribe(),
+            self.runner_shutdown.subscribe(),
         );
 
         let start_at_rollup_height = self.start_at_rollup_height;
@@ -467,13 +464,8 @@ where
         }
 
         info!("Runner main loop is completed, keep shutting down...");
-        if let Err(e) = self.secondary_shutdown_sender.send(()) {
-            tracing::warn!(
-                error = ?e,
-                "Failed to send secondary shutdown signal. Happens if no HTTP handlers are running"
-            );
-        }
-        info!("Secondary shutdown sent, waiting for status updater to stop...");
+        self.runner_shutdown.shutdown();
+        info!("Runner shutdown sent, waiting for status updater to stop...");
         status_updater_handle
             .await
             .context("Status update handler")?;

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -12,7 +12,9 @@ mod shutdown_controller;
 use std::future::Future;
 
 pub use da_sync_state::SyncStatus;
-pub use shutdown_controller::{PrimaryShutdownController, SecondaryShutdownController};
+pub use shutdown_controller::{
+    PrimaryShutdownController, RunnerShutdownController, SecondaryShutdownController,
+};
 use tokio::select;
 use tokio::sync::watch;
 

--- a/crates/rollup-interface/src/node/shutdown_controller.rs
+++ b/crates/rollup-interface/src/node/shutdown_controller.rs
@@ -137,16 +137,6 @@ impl RunnerShutdownController {
         }
     }
 
-    /// Returns a new receiver that fires when the runner shutdown signal is sent.
-    ///
-    /// Handed to background tasks spawned by the runner so they can stop
-    /// cooperatively via [`future_or_shutdown`]. The returned receiver starts
-    /// out marked as having seen the current value, so it only resolves once
-    /// [`RunnerShutdownController::shutdown`] is called.
-    pub fn subscribe(&self) -> watch::Receiver<()> {
-        self.inner.sender.subscribe()
-    }
-
     /// Waits until a runner shutdown notification is sent.
     pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
         self.inner.wait_for_shutdown().await
@@ -163,11 +153,6 @@ impl RunnerShutdownController {
     /// Sends a runner shutdown notification.
     pub fn shutdown(&self) {
         self.inner.shutdown();
-    }
-
-    /// Returns `true` if a runner shutdown notification has already been sent.
-    pub fn is_triggered(&self) -> bool {
-        self.inner.is_triggered()
     }
 }
 

--- a/crates/rollup-interface/src/node/shutdown_controller.rs
+++ b/crates/rollup-interface/src/node/shutdown_controller.rs
@@ -121,3 +121,58 @@ impl Default for SecondaryShutdownController {
         Self::new()
     }
 }
+
+/// Controls the shutdown channel for the runner's own background tasks
+/// (HTTP server, sync-status updater, finalized-block fetcher).
+#[derive(Clone)]
+pub struct RunnerShutdownController {
+    inner: InnerShutdownController,
+}
+
+impl RunnerShutdownController {
+    /// Creates a new runner shutdown controller.
+    pub fn new() -> Self {
+        Self {
+            inner: InnerShutdownController::new(),
+        }
+    }
+
+    /// Returns a new receiver that fires when the runner shutdown signal is sent.
+    ///
+    /// Handed to background tasks spawned by the runner so they can stop
+    /// cooperatively via [`future_or_shutdown`]. The returned receiver starts
+    /// out marked as having seen the current value, so it only resolves once
+    /// [`RunnerShutdownController::shutdown`] is called.
+    pub fn subscribe(&self) -> watch::Receiver<()> {
+        self.inner.sender.subscribe()
+    }
+
+    /// Waits until a runner shutdown notification is sent.
+    pub async fn wait_for_shutdown(&self) -> Result<(), watch::error::RecvError> {
+        self.inner.wait_for_shutdown().await
+    }
+
+    /// Runs a future until it completes or the runner shutdown signal fires.
+    pub async fn future_or_shutdown<T>(&self, inner: T) -> FutureOrShutdownOutput<T::Output>
+    where
+        T: Future,
+    {
+        future_or_shutdown(inner, &self.inner.receiver).await
+    }
+
+    /// Sends a runner shutdown notification.
+    pub fn shutdown(&self) {
+        self.inner.shutdown();
+    }
+
+    /// Returns `true` if a runner shutdown notification has already been sent.
+    pub fn is_triggered(&self) -> bool {
+        self.inner.is_triggered()
+    }
+}
+
+impl Default for RunnerShutdownController {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
# Description

In a follow-up PR, we will evaluate whether this controller can be unified with the primary/secondary shutdown controllers and how to reduce duplication across all shutdown controllers.

Changes:

  - Introduces `RunnerShutdownController` for STF runner-owned background tasks.
  - Wires the finalized-block fetcher, HTTP/RPC server, and sync-status updater to the runner shutdown signal.
  - Ensures runner background tasks are signaled when the runner finishes, shuts down before running, or is dropped.
  - Updates affected tests to use the new controller API.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
