### PR TITLE
Move rollup HTTP/RPC shutdown into the STF runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2026-06-26
+- #3020 Rollup shutdown: moves HTTP/RPC server task ownership into `StateTransitionRunner`, so runner-owned background tasks are stopped and joined as part of runner shutdown.
+  * **Breaking Change** `sov_modules_api::NodeEndpoints` no longer has a `background_handles` field. Endpoint constructors should return only `axum_router` and `jsonrpsee_module`; long-lived background tasks need to be owned by the rollup, runner, sequencer, or service lifecycle instead.
+
 # 2026-06-25
 - #3017 Shutdown utilities: extracts the shutdown controllers and graceful-shutdown helpers into a new published `sov-shutdown` crate.
   * **Breaking Change** `PrimaryShutdownController`, `SecondaryShutdownController`, `FutureOrShutdownOutput`, `future_or_shutdown`, and the `consume_until_shutdown!` macro move from `sov_rollup_interface::node` to the `sov_shutdown` crate. Update imports from `sov_rollup_interface::node::…` (or `sov_rollup_interface::consume_until_shutdown!`) to `sov_shutdown::…`.

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -472,6 +472,19 @@ where
             }
         }
 
+        self.stop_runner(status_updater_handle).await
+    }
+
+    /// Signals the runner's background tasks to stop and waits for them to
+    /// finish.
+    ///
+    /// Sends the runner shutdown notification, then joins the sync-status
+    /// updater followed by all other tracked background handles (HTTP server,
+    /// finalized-block fetcher, etc.).
+    async fn stop_runner(
+        &mut self,
+        status_updater_handle: tokio::task::JoinHandle<()>,
+    ) -> anyhow::Result<()> {
         info!("Runner main loop is completed, keep shutting down...");
         self.runner_shutdown.shutdown();
         info!("Runner shutdown sent, waiting for status updater to stop...");

--- a/crates/module-system/sov-eip712-auth/src/stub_evm_rpc.rs
+++ b/crates/module-system/sov-eip712-auth/src/stub_evm_rpc.rs
@@ -7,7 +7,7 @@ use sov_modules_api::macros::config_value;
 /// ```ignore
 /// #[cfg(feature = "native")]
 /// fn endpoints(api_state: sov_modules_api::rest::ApiState<S>) -> sov_modules_api::NodeEndpoints {
-///     // Existing code to set up `axum_router` and `background_handles`...
+///     // Existing code to set up `axum_router`...
 ///
 ///     let mut jsonrpsee_module = stf_declaration_crate::get_rpc_methods::<S>(api_state);
 ///     let stub_rpc = sov_eip712::stub_evm_rpc();
@@ -17,7 +17,6 @@ use sov_modules_api::macros::config_value;
 ///     sov_modules_api::NodeEndpoints {
 ///         axum_router,
 ///         jsonrpsee_module,
-///         background_handles
 ///     }
 /// }
 /// ```

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -237,10 +237,6 @@ pub struct NodeEndpoints {
     pub axum_router: axum::Router<()>,
     /// A [`jsonrpsee::RpcModule`] for the runtime's JSON-RPC server.
     pub jsonrpsee_module: jsonrpsee::RpcModule<()>,
-    /// A list of optional background tasks that have been spawned for the endpoints' purposes.
-    ///
-    /// These will be joined upon node shutdown.
-    pub background_handles: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
 }
 
 #[cfg(feature = "native")]
@@ -249,7 +245,6 @@ impl Default for NodeEndpoints {
         Self {
             axum_router: Default::default(),
             jsonrpsee_module: jsonrpsee::RpcModule::new(()),
-            background_handles: Vec::new(),
         }
     }
 }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -13,7 +13,6 @@ use sov_modules_api::capabilities::{
     ChainState, HasCapabilities, HasKernel, ProofProcessor, RollupHeight,
 };
 use sov_modules_api::execution_mode::ExecutionMode;
-use sov_modules_api::prelude::jsonrpsee::RpcModule;
 use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::ApiState;
 use sov_modules_api::{
@@ -959,29 +958,46 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
 
 impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
     /// Runs the rollup.
-    pub async fn run(mut self) -> anyhow::Result<()> {
-        self.runner
+    pub async fn run(self) -> anyhow::Result<()> {
+        let Self {
+            mut runner,
+            endpoints,
+            primary_shutdown,
+            genesis_slot_number: _,
+            secondary_shutdown_controller,
+            background_handles,
+            rpc_aggregation_config,
+        } = self;
+        let NodeEndpointsContainer {
+            inner,
+            cors_configuration,
+        } = endpoints;
+        let NodeEndpoints {
+            axum_router,
+            jsonrpsee_module,
+        } = inner;
+
+        runner
             .start_http_server(
-                std::mem::take(&mut self.endpoints.inner.axum_router),
-                std::mem::replace(
-                    &mut self.endpoints.inner.jsonrpsee_module,
-                    RpcModule::new(()),
-                ),
-                self.endpoints.cors_configuration,
-                self.rpc_aggregation_config.clone(),
+                axum_router,
+                jsonrpsee_module,
+                cors_configuration,
+                rpc_aggregation_config,
             )
             .await
             .context("Failed to start Axum Server")?;
 
-        let monitoring_task = spawn_task_monitor(
-            self.primary_shutdown.clone(),
-            std::mem::take(&mut self.background_handles),
-        );
+        let monitoring_task = spawn_task_monitor(primary_shutdown.clone(), background_handles);
 
-        self.runner.run_in_process().await?;
+        runner.run_in_process().await?;
         tracing::info!("STF Runner has completed execution");
 
-        self.stop_rollup(monitoring_task).await
+        Self::stop_rollup(
+            primary_shutdown,
+            secondary_shutdown_controller,
+            monitoring_task,
+        )
+        .await
     }
 
     /// Triggers a graceful shutdown of all rollup background tasks and waits for
@@ -992,12 +1008,13 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
     /// infrastructure), then blocks until the monitored background tasks have
     /// joined.
     async fn stop_rollup(
-        &self,
+        primary_shutdown: PrimaryShutdownController,
+        secondary_shutdown_controller: SecondaryShutdownController,
         monitoring_task: JoinHandle<anyhow::Result<()>>,
     ) -> anyhow::Result<()> {
-        self.primary_shutdown.shutdown();
+        primary_shutdown.shutdown();
 
-        self.secondary_shutdown_controller.shutdown();
+        secondary_shutdown_controller.shutdown();
 
         // blocks until background handles have shutdown
         monitoring_task.await??;

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -985,13 +985,35 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
         runner.run_in_process().await?;
         tracing::info!("STF Runner has completed execution");
 
-        self.primary_shutdown.shutdown();
+        Self::stop_rollup(
+            self.primary_shutdown,
+            self.secondary_shutdown_controller,
+            monitoring_task,
+            self.endpoints.inner.background_handles,
+        )
+        .await
+    }
 
-        self.secondary_shutdown_controller.shutdown();
+    /// Triggers a graceful shutdown of all rollup background tasks and waits for
+    /// them to finish.
+    ///
+    /// Signals the primary tier (main loop and node-level background tasks) and
+    /// then the secondary tier (DA service, metrics, and other shared
+    /// infrastructure), then blocks until the monitored background tasks and the
+    /// HTTP/RPC endpoint tasks have joined.
+    async fn stop_rollup(
+        primary_shutdown: PrimaryShutdownController,
+        secondary_shutdown_controller: SecondaryShutdownController,
+        monitoring_task: JoinHandle<anyhow::Result<()>>,
+        endpoint_background_handles: Vec<JoinHandle<anyhow::Result<()>>>,
+    ) -> anyhow::Result<()> {
+        primary_shutdown.shutdown();
+
+        secondary_shutdown_controller.shutdown();
 
         // blocks until background handles have shutdown
         monitoring_task.await??;
-        for handle in self.endpoints.inner.background_handles {
+        for handle in endpoint_background_handles {
             match handle.await {
                 Err(e) => {
                     tracing::error!(error = %e, "Endpoint background task panicked.");

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -13,6 +13,7 @@ use sov_modules_api::capabilities::{
     ChainState, HasCapabilities, HasKernel, ProofProcessor, RollupHeight,
 };
 use sov_modules_api::execution_mode::ExecutionMode;
+use sov_modules_api::prelude::jsonrpsee::RpcModule;
 use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::ApiState;
 use sov_modules_api::{
@@ -853,14 +854,8 @@ async fn cleanup_failed_startup<S: Spec>(
 
     let background_handles_to_join = std::mem::take(background_handles);
     let sequencer_background_handles = std::mem::take(&mut sequencer.background_handles);
-    let endpoint_background_handles = std::mem::take(&mut sequencer.endpoints.background_handles);
 
-    wait_for_failed_startup_tasks(
-        background_handles_to_join,
-        sequencer_background_handles,
-        endpoint_background_handles,
-    )
-    .await;
+    wait_for_failed_startup_tasks(background_handles_to_join, sequencer_background_handles).await;
 }
 
 async fn cleanup_failed_startup_before_sequencer(
@@ -873,20 +868,18 @@ async fn cleanup_failed_startup_before_sequencer(
 
     let background_handles_to_join = std::mem::take(background_handles);
 
-    wait_for_failed_startup_tasks(background_handles_to_join, Vec::new(), Vec::new()).await;
+    wait_for_failed_startup_tasks(background_handles_to_join, Vec::new()).await;
 }
 
 async fn wait_for_failed_startup_tasks(
     background_handles_to_join: Vec<JoinHandle<()>>,
     sequencer_background_handles: Vec<JoinHandle<()>>,
-    endpoint_background_handles: Vec<JoinHandle<anyhow::Result<()>>>,
 ) {
     // Drain handles concurrently rather than serially.
     let drain = async move {
         let _ = tokio::join!(
             future::join_all(background_handles_to_join),
             future::join_all(sequencer_background_handles),
-            future::join_all(endpoint_background_handles),
         );
     };
 
@@ -966,32 +959,29 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
 
 impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
     /// Runs the rollup.
-    pub async fn run(self) -> anyhow::Result<()> {
-        let mut runner = self.runner;
-
-        runner
+    pub async fn run(mut self) -> anyhow::Result<()> {
+        self.runner
             .start_http_server(
-                self.endpoints.inner.axum_router,
-                self.endpoints.inner.jsonrpsee_module,
+                std::mem::take(&mut self.endpoints.inner.axum_router),
+                std::mem::replace(
+                    &mut self.endpoints.inner.jsonrpsee_module,
+                    RpcModule::new(()),
+                ),
                 self.endpoints.cors_configuration,
-                self.rpc_aggregation_config,
+                self.rpc_aggregation_config.clone(),
             )
             .await
             .context("Failed to start Axum Server")?;
 
-        let monitoring_task =
-            spawn_task_monitor(self.primary_shutdown.clone(), self.background_handles);
+        let monitoring_task = spawn_task_monitor(
+            self.primary_shutdown.clone(),
+            std::mem::take(&mut self.background_handles),
+        );
 
-        runner.run_in_process().await?;
+        self.runner.run_in_process().await?;
         tracing::info!("STF Runner has completed execution");
 
-        Self::stop_rollup(
-            self.primary_shutdown,
-            self.secondary_shutdown_controller,
-            monitoring_task,
-            self.endpoints.inner.background_handles,
-        )
-        .await
+        self.stop_rollup(monitoring_task).await
     }
 
     /// Triggers a graceful shutdown of all rollup background tasks and waits for
@@ -999,33 +989,18 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
     ///
     /// Signals the primary tier (main loop and node-level background tasks) and
     /// then the secondary tier (DA service, metrics, and other shared
-    /// infrastructure), then blocks until the monitored background tasks and the
-    /// HTTP/RPC endpoint tasks have joined.
+    /// infrastructure), then blocks until the monitored background tasks have
+    /// joined.
     async fn stop_rollup(
-        primary_shutdown: PrimaryShutdownController,
-        secondary_shutdown_controller: SecondaryShutdownController,
+        &self,
         monitoring_task: JoinHandle<anyhow::Result<()>>,
-        endpoint_background_handles: Vec<JoinHandle<anyhow::Result<()>>>,
     ) -> anyhow::Result<()> {
-        primary_shutdown.shutdown();
+        self.primary_shutdown.shutdown();
 
-        secondary_shutdown_controller.shutdown();
+        self.secondary_shutdown_controller.shutdown();
 
         // blocks until background handles have shutdown
         monitoring_task.await??;
-        for handle in endpoint_background_handles {
-            match handle.await {
-                Err(e) => {
-                    tracing::error!(error = %e, "Endpoint background task panicked.");
-                    return Err(e.into());
-                }
-                Ok(Err(e)) => {
-                    tracing::error!(error = %e, "Endpoint background task joined with error");
-                    return Err(e);
-                }
-                _ => {}
-            }
-        }
         tracing::debug!("Rollup completed run");
         Ok(())
     }

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -117,7 +117,6 @@ where
         Ok(NodeEndpoints {
             axum_router: router,
             jsonrpsee_module: jsonrpsee::RpcModule::new(()),
-            background_handles: Vec::new(),
         })
     }
 

--- a/crates/rollup-interface/Cargo.toml
+++ b/crates/rollup-interface/Cargo.toml
@@ -44,7 +44,7 @@ sov-universal-wallet = { workspace = true, features = ["macros"] }
 sha2 = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["macros", "sync", "rt"], optional = true }
+tokio = { workspace = true, features = ["sync", "rt"], optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/utils/sov-test-utils/src/runtime/macros.rs
+++ b/crates/utils/sov-test-utils/src/runtime/macros.rs
@@ -167,7 +167,6 @@ macro_rules! generate_runtime_without_capabilities {
                 ::sov_modules_api::NodeEndpoints {
                     axum_router,
                     jsonrpsee_module: get_rpc_methods(api_state),
-                    background_handles: Vec::new(),
                 }
             }
 

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -151,7 +151,6 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -127,7 +127,6 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 

--- a/examples/demo-rollup/src/external_mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_sp1_rollup.rs
@@ -121,7 +121,6 @@ impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -128,7 +128,6 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -121,7 +121,6 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -112,7 +112,6 @@ where
         ::sov_modules_api::NodeEndpoints {
             axum_router,
             jsonrpsee_module: demo_stf_declaration::get_rpc_methods::<S>(api_state),
-            background_handles: Vec::new(),
         }
     }
 


### PR DESCRIPTION
# Description
This PR introduces the following changes

  - Remove `NodeEndpoints::background_handles` (it was never used, but adds additional cleanup logic)
  - Keep HTTP/RPC server task ownership inside `StateTransitionRunner`
  - Add explicit rollup and runner shutdown helpers to signal and await background tasks
  - Update endpoint construction sites after the `NodeEndpoints` shape change

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

