### PR TITLE
Log shutdown trigger call sites 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-06-27
-- #3024 Shutdown diagnostics: shutdown controllers now log the source location that triggered the shutdown. `PrimaryShutdownController`, `SecondaryShutdownController`, and `RunnerShutdownController` `shutdown()` are now `#[track_caller]` and emit a `"Shutdown triggered"` info log with the caller's `file`/`line`/`column`. Adds a `shutdown_with_location` method for cases where the triggering call site was captured earlier (e.g. across an async boundary), used by the preferred sequencer's `exit_rollup`. Not state- or API-breaking.
+- #3024 Shutdown diagnostics: shutdown controllers now log the source location that triggered the shutdown. `PrimaryShutdownController`, `SecondaryShutdownController`, and `RunnerShutdownController` `shutdown()` are now `#[track_caller]` and emit a `"Shutdown triggered"` info log with the triggered `controller` name (`primary`/`secondary`/`runner`) and the caller's `file`/`line`/`column`. Adds a `shutdown_with_location` method for cases where the triggering call site was captured earlier (e.g. across an async boundary), used by the preferred sequencer's `exit_rollup`. Not state- or API-breaking.
 
 # 2026-06-26
 - #3020 Rollup shutdown: moves HTTP/RPC server task ownership into `StateTransitionRunner`, so runner-owned background tasks are stopped and joined as part of runner shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-06-27
+- #3024 Shutdown diagnostics: shutdown controllers now log the source location that triggered the shutdown. `PrimaryShutdownController`, `SecondaryShutdownController`, and `RunnerShutdownController` `shutdown()` are now `#[track_caller]` and emit a `"Shutdown triggered"` info log with the caller's `file`/`line`/`column`. Adds a `shutdown_with_location` method for cases where the triggering call site was captured earlier (e.g. across an async boundary), used by the preferred sequencer's `exit_rollup`. Not state- or API-breaking.
+
 # 2026-06-26
 - #3020 Rollup shutdown: moves HTTP/RPC server task ownership into `StateTransitionRunner`, so runner-owned background tasks are stopped and joined as part of runner shutdown.
   * **Breaking Change** `sov_modules_api::NodeEndpoints` no longer has a `background_handles` field. Endpoint constructors should return only `axum_router` and `jsonrpsee_module`; long-lived background tasks need to be owned by the rollup, runner, sequencer, or service lifecycle instead.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12465,6 +12465,7 @@ version = "0.3.0"
 dependencies = [
  "tokio",
  "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1132,7 +1132,7 @@ async fn exit_rollup_inner(
     // In the Kubernetes environment, logs are sometimes lost during shutdown.
     // This delay ensures logs have time to be flushed before the application exits.
     tracing::info!("Shutting down the rollup");
-    primary_shutdown.shutdown();
+    primary_shutdown.shutdown_with_location(location);
     let sleep_time = Duration::from_secs(5);
     tracing::error!(%location, after = ?sleep_time, "Calling std::process::exit(1)");
     println!("Calling std::process::exit(1): {location}");

--- a/crates/utils/sov-shutdown/Cargo.toml
+++ b/crates/utils/sov-shutdown/Cargo.toml
@@ -18,3 +18,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
+tracing-test = { workspace = true }

--- a/crates/utils/sov-shutdown/src/shutdown_controller.rs
+++ b/crates/utils/sov-shutdown/src/shutdown_controller.rs
@@ -30,6 +30,16 @@ impl InnerShutdownController {
             .expect("shutdown channel always has a live receiver");
     }
 
+    fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
+        tracing::info!(
+            file = location.file(),
+            line = location.line(),
+            column = location.column(),
+            "Shutdown triggered",
+        );
+        self.shutdown();
+    }
+
     fn is_triggered(&self) -> bool {
         // The controller keeps its own sender alive for as long as it exists,
         // so `has_changed` cannot fail here.
@@ -69,6 +79,12 @@ impl PrimaryShutdownController {
     /// Sends a primary shutdown notification.
     pub fn shutdown(&self) {
         self.inner.shutdown();
+    }
+
+    /// Sends a primary shutdown notification, logging the call site that
+    /// triggered it.
+    pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
+        self.inner.shutdown_with_location(location);
     }
 
     /// Returns `true` if a primary shutdown notification has already been sent.
@@ -114,6 +130,12 @@ impl SecondaryShutdownController {
     pub fn shutdown(&self) {
         self.inner.shutdown();
     }
+
+    /// Sends a secondary shutdown notification, logging the call site that
+    /// triggered it.
+    pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
+        self.inner.shutdown_with_location(location);
+    }
 }
 
 impl Default for SecondaryShutdownController {
@@ -153,6 +175,12 @@ impl RunnerShutdownController {
     /// Sends a runner shutdown notification.
     pub fn shutdown(&self) {
         self.inner.shutdown();
+    }
+
+    /// Sends a runner shutdown notification, logging the call site that
+    /// triggered it.
+    pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
+        self.inner.shutdown_with_location(location);
     }
 }
 

--- a/crates/utils/sov-shutdown/src/shutdown_controller.rs
+++ b/crates/utils/sov-shutdown/src/shutdown_controller.rs
@@ -84,8 +84,9 @@ impl PrimaryShutdownController {
             .shutdown_with_location(std::panic::Location::caller());
     }
 
-    /// Sends a primary shutdown notification, logging the call site that
-    /// triggered it.
+    /// Sends a primary shutdown notification, logging the supplied `location`.
+    /// Use this when the triggering call site was captured earlier (e.g. across
+    /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
         self.inner.shutdown_with_location(location);
     }
@@ -137,8 +138,9 @@ impl SecondaryShutdownController {
             .shutdown_with_location(std::panic::Location::caller());
     }
 
-    /// Sends a secondary shutdown notification, logging the call site that
-    /// triggered it.
+    /// Sends a secondary shutdown notification, logging the supplied `location`.
+    /// Use this when the triggering call site was captured earlier (e.g. across
+    /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
         self.inner.shutdown_with_location(location);
     }
@@ -186,8 +188,9 @@ impl RunnerShutdownController {
             .shutdown_with_location(std::panic::Location::caller());
     }
 
-    /// Sends a runner shutdown notification, logging the call site that
-    /// triggered it.
+    /// Sends a runner shutdown notification, logging the supplied `location`.
+    /// Use this when the triggering call site was captured earlier (e.g. across
+    /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
         self.inner.shutdown_with_location(location);
     }

--- a/crates/utils/sov-shutdown/src/shutdown_controller.rs
+++ b/crates/utils/sov-shutdown/src/shutdown_controller.rs
@@ -30,8 +30,13 @@ impl InnerShutdownController {
             .expect("shutdown channel always has a live receiver");
     }
 
-    fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
+    fn shutdown_with_location(
+        &self,
+        name: &'static str,
+        location: &'static std::panic::Location<'static>,
+    ) {
         tracing::info!(
+            controller = name,
             file = location.file(),
             line = location.line(),
             column = location.column(),
@@ -56,6 +61,8 @@ pub struct PrimaryShutdownController {
 }
 
 impl PrimaryShutdownController {
+    const NAME: &'static str = "primary";
+
     /// Creates a new primary shutdown controller.
     pub fn new() -> Self {
         Self {
@@ -81,14 +88,14 @@ impl PrimaryShutdownController {
     #[track_caller]
     pub fn shutdown(&self) {
         self.inner
-            .shutdown_with_location(std::panic::Location::caller());
+            .shutdown_with_location(Self::NAME, std::panic::Location::caller());
     }
 
     /// Sends a primary shutdown notification, logging the supplied `location`.
     /// Use this when the triggering call site was captured earlier (e.g. across
     /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
-        self.inner.shutdown_with_location(location);
+        self.inner.shutdown_with_location(Self::NAME, location);
     }
 
     /// Returns `true` if a primary shutdown notification has already been sent.
@@ -110,6 +117,8 @@ pub struct SecondaryShutdownController {
 }
 
 impl SecondaryShutdownController {
+    const NAME: &'static str = "secondary";
+
     /// Creates a new secondary shutdown controller.
     pub fn new() -> Self {
         Self {
@@ -135,14 +144,14 @@ impl SecondaryShutdownController {
     #[track_caller]
     pub fn shutdown(&self) {
         self.inner
-            .shutdown_with_location(std::panic::Location::caller());
+            .shutdown_with_location(Self::NAME, std::panic::Location::caller());
     }
 
     /// Sends a secondary shutdown notification, logging the supplied `location`.
     /// Use this when the triggering call site was captured earlier (e.g. across
     /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
-        self.inner.shutdown_with_location(location);
+        self.inner.shutdown_with_location(Self::NAME, location);
     }
 }
 
@@ -160,6 +169,8 @@ pub struct RunnerShutdownController {
 }
 
 impl RunnerShutdownController {
+    const NAME: &'static str = "runner";
+
     /// Creates a new runner shutdown controller.
     pub fn new() -> Self {
         Self {
@@ -185,14 +196,14 @@ impl RunnerShutdownController {
     #[track_caller]
     pub fn shutdown(&self) {
         self.inner
-            .shutdown_with_location(std::panic::Location::caller());
+            .shutdown_with_location(Self::NAME, std::panic::Location::caller());
     }
 
     /// Sends a runner shutdown notification, logging the supplied `location`.
     /// Use this when the triggering call site was captured earlier (e.g. across
     /// an async boundary); otherwise prefer [`Self::shutdown`].
     pub fn shutdown_with_location(&self, location: &'static std::panic::Location<'static>) {
-        self.inner.shutdown_with_location(location);
+        self.inner.shutdown_with_location(Self::NAME, location);
     }
 }
 
@@ -214,8 +225,11 @@ mod tests {
         let (file, line) = test_shutdown();
 
         assert!(
-            logs_contain(&format!("Shutdown triggered file=\"{file}\" line={line}")),
-            "shutdown should log the triggered message with the caller's location",
+            logs_contain(&format!(
+                "Shutdown triggered controller=\"{name}\" file=\"{file}\" line={line}",
+                name = PrimaryShutdownController::NAME,
+            )),
+            "shutdown should log the triggered message with the controller name and caller's location",
         );
     }
 

--- a/crates/utils/sov-shutdown/src/shutdown_controller.rs
+++ b/crates/utils/sov-shutdown/src/shutdown_controller.rs
@@ -76,9 +76,12 @@ impl PrimaryShutdownController {
         future_or_shutdown(inner, &self.inner.receiver).await
     }
 
-    /// Sends a primary shutdown notification.
+    /// Sends a primary shutdown notification, logging the call site that
+    /// triggered it.
+    #[track_caller]
     pub fn shutdown(&self) {
-        self.inner.shutdown();
+        self.inner
+            .shutdown_with_location(std::panic::Location::caller());
     }
 
     /// Sends a primary shutdown notification, logging the call site that
@@ -126,9 +129,12 @@ impl SecondaryShutdownController {
         future_or_shutdown(inner, &self.inner.receiver).await
     }
 
-    /// Sends a secondary shutdown notification.
+    /// Sends a secondary shutdown notification, logging the call site that
+    /// triggered it.
+    #[track_caller]
     pub fn shutdown(&self) {
-        self.inner.shutdown();
+        self.inner
+            .shutdown_with_location(std::panic::Location::caller());
     }
 
     /// Sends a secondary shutdown notification, logging the call site that
@@ -172,9 +178,12 @@ impl RunnerShutdownController {
         future_or_shutdown(inner, &self.inner.receiver).await
     }
 
-    /// Sends a runner shutdown notification.
+    /// Sends a runner shutdown notification, logging the call site that
+    /// triggered it.
+    #[track_caller]
     pub fn shutdown(&self) {
-        self.inner.shutdown();
+        self.inner
+            .shutdown_with_location(std::panic::Location::caller());
     }
 
     /// Sends a runner shutdown notification, logging the call site that
@@ -187,5 +196,32 @@ impl RunnerShutdownController {
 impl Default for RunnerShutdownController {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing_test::traced_test;
+
+    use super::*;
+
+    #[traced_test]
+    #[test]
+    fn shutdown_logs_the_caller_location() {
+        let (file, line) = test_shutdown();
+
+        assert!(
+            logs_contain(&format!("Shutdown triggered file=\"{file}\" line={line}")),
+            "shutdown should log the triggered message with the caller's location",
+        );
+    }
+
+    /// Triggers a shutdown and returns the file and line of the `shutdown()`
+    /// call site that the log should be attributed to.
+    fn test_shutdown() -> (&'static str, u32) {
+        // `shutdown` is `#[track_caller]`, so the logged location should point
+        // at this call site (i.e. this source file and line).
+        PrimaryShutdownController::new().shutdown();
+        (file!(), line!() - 1)
     }
 }


### PR DESCRIPTION
# Description

This PR introduces the following changes:
  - Add shutdown call-site logging to primary, secondary, and runner shutdown controllers.
  - Add `shutdown_with_location` for callers that already capture a caller location.
  - Use the captured `exit_rollup` location when triggering sequencer shutdown.
  - Add a unit test covering caller-location logging.

Example of the shutdown log:
```
 Shutdown triggered controller="runner" file="/home/blazej/workspace/sovereign/sovereign-sdk/crates/full-node/sov-stf-runner/src/runner.rs" line=111 column=30
 ```

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
