### PR TITLE
Fix demo STF README rollup interface links

### DIFF
--- a/examples/demo-rollup/stf/README.md
+++ b/examples/demo-rollup/stf/README.md
@@ -23,13 +23,13 @@ no matter which ones you pick.
 ## Overview
 
 To get a fully functional rollup, we recommend implementing the [State Transition Function
-interface](../../rollup-interface/specs/interfaces/stf.md) ("STF") trait, which specifies your rollup's abstract logic. Second, there's
+interface](../../../crates/rollup-interface/specs/interfaces/stf.md) ("STF") trait, which specifies your rollup's abstract logic. Second, there's
 a related struct called `State Transition Runner` ("STR") which tells a full node how to run your abstract STF on a concrete machine.
 
 ## Implementing State Transition _Function_
 
 As you recall, the Module System is primarily designed to help you implement the [State Transition Function
-interface](../../rollup-interface/specs/interfaces/stf.md).
+interface](../../../crates/rollup-interface/specs/interfaces/stf.md).
 
 That interface is quite high-level - the only notion
 that it surfaces is that of a `blob` of rollup data. In the Module System, we work at a much lower level - with


### PR DESCRIPTION
# Description

This fixes two broken relative links in `examples/demo-rollup/stf/README.md`.

Both links point to the State Transition Function interface spec, but the previous path resolved under `examples/rollup-interface/...`, which does not exist. The updated path correctly points to `crates/rollup-interface/specs/interfaces/stf.md`.



## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing

- `git diff --check`
- Verified that local Markdown links in `examples/demo-rollup/stf/README.md` resolve

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
