### PR TITLE
Fix HexString JSON schema for empty byte strings

### DIFF
--- a/crates/rollup-interface/src/common/hex_string.rs
+++ b/crates/rollup-interface/src/common/hex_string.rs
@@ -33,8 +33,8 @@ impl schemars::JsonSchema for HexString {
     fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
         schemars::json_schema!({
             "type": "string",
-            "pattern": "^0x(?:[a-fA-F0-9]{2})+$",
-            "description": "A `0x`-prefixed hexadecimal string (uppercase or lowercase) of variable length, with an even number of hex digits.",
+            "pattern": "^0x(?:[a-fA-F0-9]{2})*$",
+            "description": "A `0x`-prefixed hexadecimal string (uppercase or lowercase) of variable length, including zero bytes, with an even number of hex digits.",
         })
     }
 }
@@ -272,5 +272,22 @@ mod tests {
     #[test_strategy::proptest]
     fn hex_string_str_roundtrip(item: HexString) {
         test_str_roundtrip(item);
+    }
+
+    #[test]
+    fn variable_length_hex_string_json_schema_allows_empty_string() {
+        let empty_hex = HexString(Vec::<u8>::new());
+
+        assert_eq!(serde_json::to_string(&empty_hex).unwrap(), "\"0x\"");
+        assert_eq!(
+            HexString::<Vec<u8>>::from_str("0x").unwrap(),
+            HexString(Vec::new())
+        );
+
+        let mut schema_generator = schemars::SchemaGenerator::default();
+        let schema = <HexString as schemars::JsonSchema>::json_schema(&mut schema_generator);
+        let schema = serde_json::to_value(schema).unwrap();
+
+        assert_eq!(schema["pattern"], "^0x(?:[a-fA-F0-9]{2})*$");
     }
 }


### PR DESCRIPTION
# Description

*Summary of the changes...*

Fix the variable-length `HexString` JSON Schema pattern so it accepts empty byte strings.

`HexString<Vec<u8>>` can already serialize an empty byte vector as `"0x"` and parse `"0x"` back into an empty vector. However, its JSON Schema pattern required at least one byte, which made the schema reject a value that the type itself accepts.

This changes the variable-length pattern from `+` to `*` and updates the description to explicitly mention zero bytes.



- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing

- `SKIP_GUEST_BUILD=1 cargo test -p sov-rollup-interface variable_length_hex_string_json_schema_allows_empty_string`
- `SKIP_GUEST_BUILD=1 cargo test -p sov-rollup-interface`
- `cargo fmt --check`

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
