### PR TITLE
Run TS release on GitHub-hosted runner to fix npm publishing

### DIFF
--- a/.github/workflows/typescript.release.yml
+++ b/.github/workflows/typescript.release.yml
@@ -22,21 +22,26 @@ jobs:
       id-token: write # OpenID Connect token needed for provenance
       pull-requests: write # to create pull request (changesets/action)
     name: Release
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=typescript-release-1-93
+    # Must run on a GitHub-hosted runner: npm trusted publishing (OIDC)
+    # rejects tokens from self-hosted runners.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || '' }}
-      # Cache the pnpm store in a Namespace volume.
-      - uses: namespacelabs/nscloud-cache-action@v1
+      - uses: pnpm/action-setup@v4
         with:
-          cache: pnpm
-      # Node 24, pnpm, and Bun are baked into the base image; setup-node is kept
-      # only to configure the npm registry (.npmrc) for publishing.
+          package_json_file: ./typescript/package.json
       - uses: actions/setup-node@v6
         with:
+          node-version: 24.x
+          cache: "pnpm"
+          cache-dependency-path: "./typescript/pnpm-lock.yaml"
           registry-url: 'https://registry.npmjs.org'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.5
       - name: Install dependencies
         run: pnpm install
         working-directory: ./typescript


### PR DESCRIPTION
# Description

npm trusted publishing rejects OIDC tokens from self-hosted runners, so publishes have failed with E404 since the job moved to Namespace runners in #2937. Restores the pnpm/bun setup steps that the Namespace image provided.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
