### PR TITLE
Disable gas charging when trying multiple chain hashes during grace period

### DIFF
--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -378,19 +378,22 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     chain_hash: &[u8; 32],
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
+    charge_signature_gas: bool,
 ) -> Result<Vec<u8>, AuthenticationError> {
     let serialized_tx = tx.to_signing_bytes(chain_hash);
 
-    tx.charge_gas_for_signature(serialized_tx.len(), meter)
-        .map_err(|e| match e {
-            TransactionVerificationError::GasError(_) => {
-                AuthenticationError::OutOfGas(e.to_string())
-            }
-            _ => AuthenticationError::FatalError(
-                FatalError::SigVerificationFailed(e.to_string()),
-                raw_tx_hash,
-            ),
-        })?;
+    if charge_signature_gas {
+        tx.charge_gas_for_signature(serialized_tx.len(), meter)
+            .map_err(|e| match e {
+                TransactionVerificationError::GasError(_) => {
+                    AuthenticationError::OutOfGas(e.to_string())
+                }
+                _ => AuthenticationError::FatalError(
+                    FatalError::SigVerificationFailed(e.to_string()),
+                    raw_tx_hash,
+                ),
+            })?;
+    }
 
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&(raw_tx_hash, *chain_hash)) {
@@ -523,8 +526,11 @@ fn verify_and_decode_tx_multi_hash<S: Spec, D: DispatchCall<Spec = S>>(
 
     // Try signature verification with each valid chain hash
     let mut last_error = None;
-    for chain_hash in resolved_hashes.iter() {
-        match verify_signature(&tx, chain_hash, raw_tx_hash, meter) {
+    for (index, chain_hash) in resolved_hashes.iter().enumerate() {
+        // Every candidate replaces the same 32-byte chain-hash suffix, so the signed message
+        // length is identical. Charge once to preserve the gas cost paid by transactions before
+        // multi-hash grace periods were introduced, then try all valid hashes unmetered.
+        match verify_signature(&tx, chain_hash, raw_tx_hash, meter, index == 0) {
             Ok(serialized_tx) => {
                 let non_malleable_hash = calculate_non_malleable_hash_metered::<_, S>(
                     match &tx {

--- a/crates/module-system/sov-modules-api/tests/integration/transaction.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/transaction.rs
@@ -1,14 +1,112 @@
 use sov_mock_zkvm::MockZkvmCryptoSpec;
-use sov_modules_api::capabilities::UniquenessData;
-use sov_modules_api::transaction::{Transaction, TransactionSigningPayload, TxDetails, Version0};
-use sov_modules_api::CryptoSpec;
+use sov_modules_api::capabilities::{authenticate, mocks::MockKernel, UniquenessData};
+use sov_modules_api::transaction::{
+    Transaction, TransactionSigningPayload, TxDetails, UnsignedTransaction, Version0,
+};
+use sov_modules_api::{
+    Amount, BasicGasMeter, CryptoSpec, PrivateKey, Runtime as RuntimeTrait, Spec, StateCheckpoint,
+    StateProvider,
+};
 use sov_test_utils::runtime::{sov_value_setter, TestOptimisticRuntime, TestOptimisticRuntimeCall};
-use sov_test_utils::TestSpec;
+use sov_test_utils::storage::SimpleStorageManager;
+use sov_test_utils::{
+    default_test_signed_transaction, default_test_tx_details, TestPrivateKey, TestSpec,
+};
 use sov_universal_wallet::schema::Schema;
 
 type Runtime = TestOptimisticRuntime<TestSpec>;
 
 const ASSERT_MSG: &str = "JSON representation changed, this is a breaking change for web3 SDK, please ensure it is also updated";
+
+fn gas_used_to_authenticate(tx: &Transaction<Runtime, TestSpec>) -> <TestSpec as Spec>::Gas {
+    let storage_manager = SimpleStorageManager::new();
+    let storage = storage_manager.create_storage();
+    let kernel = MockKernel::<TestSpec>::new(10, 10);
+    let checkpoint = StateCheckpoint::<TestSpec>::new(storage, &kernel);
+    let gas_meter = BasicGasMeter::<TestSpec>::new_with_gas(
+        [u64::MAX, u64::MAX].into(),
+        [Amount::ZERO, Amount::ZERO].into(),
+    );
+    let mut state = checkpoint
+        .to_tx_scratchpad()
+        .to_pre_exec_working_set(gas_meter);
+
+    authenticate::<_, TestSpec, Runtime>(
+        &borsh::to_vec(tx).unwrap(),
+        &Runtime::CHAIN_HASH,
+        &mut state,
+    )
+    .unwrap();
+
+    let (_, meter) = state.to_scratchpad_and_gas_meter();
+    meter.gas_info().gas_used
+}
+
+#[test]
+fn v0_fallback_chain_hash_does_not_change_authentication_gas() {
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_CHAIN_HASH_OVERRIDES",
+        "[{start_height = 0, end_height = 10, chain_hash = \"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\", grace_period = 5}]",
+    );
+
+    let key = TestPrivateKey::generate();
+    let call: TestOptimisticRuntimeCall<TestSpec> =
+        TestOptimisticRuntimeCall::ValueSetter(sov_value_setter::CallMessage::SetValue {
+            value: 42,
+            gas: None,
+        });
+    let fallback_hash = [0xFF; 32];
+    let primary_tx =
+        default_test_signed_transaction::<Runtime, TestSpec>(&key, &call, 0, &Runtime::CHAIN_HASH);
+    let fallback_tx =
+        default_test_signed_transaction::<Runtime, TestSpec>(&key, &call, 0, &fallback_hash);
+
+    assert_eq!(
+        gas_used_to_authenticate(&primary_tx),
+        gas_used_to_authenticate(&fallback_tx),
+        "a grace-period signature retry must not change transaction gas"
+    );
+}
+
+#[test]
+fn v1_fallback_chain_hash_does_not_change_authentication_gas() {
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_CHAIN_HASH_OVERRIDES",
+        "[{start_height = 0, end_height = 10, chain_hash = \"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\", grace_period = 5}]",
+    );
+
+    let keys = [TestPrivateKey::generate(), TestPrivateKey::generate()];
+    let multisig =
+        sov_modules_api::Multisig::new(2, keys.iter().map(PrivateKey::pub_key).collect());
+    let call: TestOptimisticRuntimeCall<TestSpec> =
+        TestOptimisticRuntimeCall::ValueSetter(sov_value_setter::CallMessage::SetValue {
+            value: 42,
+            gas: None,
+        });
+    let build_tx = |chain_hash: &[u8; 32]| -> Transaction<Runtime, TestSpec> {
+        let mut tx = UnsignedTransaction::<Runtime, TestSpec>::new_with_details(
+            call.clone(),
+            UniquenessData::Generation(0),
+            default_test_tx_details::<TestSpec>(),
+            None,
+        )
+        .to_multisig_tx(multisig.clone());
+        for key in &keys {
+            tx.sign(key, chain_hash).unwrap();
+        }
+        tx.into()
+    };
+
+    let fallback_hash = [0xFF; 32];
+    let primary_tx = build_tx(&Runtime::CHAIN_HASH);
+    let fallback_tx = build_tx(&fallback_hash);
+
+    assert_eq!(
+        gas_used_to_authenticate(&primary_tx),
+        gas_used_to_authenticate(&fallback_tx),
+        "a grace-period V1 signature retry must not change transaction gas"
+    );
+}
 
 // ensure custom serde serialized fields are serialized as expected
 // i.e Transaction pub_key and signature fields as hex strings


### PR DESCRIPTION
# Description

Slightly simplifies gas tracking at upgrade boundaries. The amount of "free" signature verifications remains bound since the grace periods are controlled by rollup devs, and should be a rare and short occurrence in most cases.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
