### PR TITLE
Fix performance in list_events, preventing a tokio hang and allocation explosion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-07-21
+- #3042 The `sequencer/unstable/events` REST endpoint changes behaviour when a negative event range is supplied (i.e. `end` < `start`): this previously silently returned an empty response, now it returns an explicit error since this can never be a valid range.
+
 # 2026-06-25
 - #3018 demo-rollup: split the example into two DA-layer Cargo features — `mock_da` (default; mock + SP1 zkVMs) and `celestia_da` (Risc0) — to cut compile time. The DA layer is selected at compile time while the zkVM stays a runtime `--zk-vm` choice within `mock_da`, so a build only compiles the selected DA's zkVM guests: a default `mock_da` build no longer pulls the Celestia/Risc0 adapters, and a `celestia_da` build skips the SP1 guests. When both DA features are enabled (`--all-features`), mock DA is selected by default. Also drops the unused SP1 Celestia guest build. Example crate only (`publish = false`) — no SDK API, state, or protocol change.
 # 2026-06-30

--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -395,6 +395,8 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/PaginatedLedgerEvents"
+        "400":
+          $ref: "#/components/responses/ApiErrorResponse"
         "404":
           $ref: "#/components/responses/ApiErrorResponse"
   /rollup/base-fee-per-gas/latest:

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -97,6 +97,23 @@ use crate::{
 
 type VisibleSlotNumberIncrease = NonZero<u8>;
 
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid event range {start}..{end}: range start must not be greater than range end")]
+pub(crate) struct InvalidEventRange {
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+}
+
+fn event_range_len(event_numbers: &std::ops::Range<u64>) -> Result<u64, InvalidEventRange> {
+    event_numbers
+        .end
+        .checked_sub(event_numbers.start)
+        .ok_or(InvalidEventRange {
+            start: event_numbers.start,
+            end: event_numbers.end,
+        })
+}
+
 // Big info dump for the user that would make the code hard to read if it were inline.
 const RECOVERY_ERROR_MESSAGE_ON_NONE_STRATEGY: &str = "The preferred sequencer is too far behind, and the visible slot number has lagged more than the allowed deferred slots count. This means some non-preferred batches may have been included by the node, if there were any. If this happened, already provided soft confirmations may now no longer be valid. Because the recovery_strategy config was set to None, we are not attempting recovery at this point. You should either: a) delete everything from the preferred_sequencer database (thus annulling all currently pending soft confirmations), which will allow you to restart the sequencer fresh; or b) set the recovery_strategy config value to TryToSave, in which case all pending batches will be flushed to be executed on a best-effort basis. The latter may save some soft-confirmations if they have not been invalidated yet. However, IF a non-preferred batch has been included, AND some soft-confirmations have been invalidated by it, this will cause the sequencer to be penalised for every invalid batch; ensure your sequencer bond is sufficient to cover any penalties to be able to continue operating uninterrupted.";
 
@@ -773,7 +790,7 @@ where
         Vec<RuntimeEventResponse<<Self::Rt as RuntimeEventProcessor>::RuntimeEvent>>,
         anyhow::Error,
     > {
-        let num_events = event_nums.end - event_nums.start;
+        let num_events = event_range_len(&event_nums)?;
         trace!(events_len = num_events, "listing events");
 
         let events = self.transaction_cache.list_events(event_nums).await?;

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -166,25 +166,29 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         &self,
         event_numbers: std::ops::Range<u64>,
     ) -> anyhow::Result<Vec<RuntimeEventResponse<Rt::RuntimeEvent>>> {
-        let transaction_cache = self.inner.read().await;
-        let Some(last_needed_event) = event_numbers.end.checked_sub(1) else {
+        if event_numbers.start >= event_numbers.end {
             return Ok(vec![]);
+        }
+        let cached_events = {
+            let transaction_cache = self.inner.read().await;
+            let mut relevant_txs = transaction_cache
+                .event_numbers_index
+                .range(event_numbers.clone())
+                .map(|(_, tx_number)| *tx_number);
+            match relevant_txs.next() {
+                Some(first_needed_tx) => {
+                    let last_needed_tx = relevant_txs.next_back().unwrap_or(first_needed_tx);
+                    transaction_cache
+                        .cache
+                        .range(first_needed_tx..=last_needed_tx)
+                        .flat_map(|(_, tx)| tx.confirmation.events.iter())
+                        .filter(|event| event_numbers.contains(&event.number))
+                        .cloned()
+                        .collect::<Vec<_>>()
+                }
+                None => Vec::new(),
+            }
         };
-        let first_needed_tx = transaction_cache
-            .event_numbers_index
-            .get_key_value(&event_numbers.start)
-            .map(|(_, tx_number)| *tx_number)
-            .unwrap_or(0);
-        let last_needed_tx = transaction_cache
-            .event_numbers_index
-            .get_key_value(&last_needed_event)
-            .map(|(_, tx_number)| *tx_number)
-            .unwrap_or(u64::MAX);
-        let cached_events = transaction_cache
-            .cache
-            .range(first_needed_tx..=last_needed_tx)
-            .flat_map(|(_, tx)| tx.confirmation.events.iter().cloned())
-            .collect::<Vec<_>>();
 
         // If we found any events in cache, we don't need to fetch those ones from the DB - adjust the range accordingly
         let db_range_end = if let Some(first_event_from_cache) = cached_events.first() {
@@ -604,15 +608,43 @@ mod tests {
     use sov_db::ledger_db::SlotCommit;
     use sov_mock_da::{MockAddress, MockBlob, MockBlock};
     use sov_modules_api::{
-        ApiTxEffect, BatchReceipt, FullyBakedTx, Gas, SuccessfulTxContents, TransactionReceipt,
-        TxEffect, TxReceiptContents,
+        ApiTxEffect, BatchReceipt, FullyBakedTx, Gas, RuntimeEventProcessor, SuccessfulTxContents,
+        TransactionReceipt, TxEffect, TxReceiptContents,
     };
+    use sov_rollup_interface::stf::StoredEvent;
     use sov_test_utils::storage::SimpleLedgerStorageManager;
     use sov_test_utils::{generate_optimistic_runtime, TestSpec as S};
 
     use super::*;
 
-    generate_optimistic_runtime!(TestRuntime <=);
+    generate_optimistic_runtime!(TestRuntime <= value_setter: sov_value_setter::ValueSetter<S>);
+
+    type TestEvent = RuntimeEventResponse<<TestRuntime<S> as RuntimeEventProcessor>::RuntimeEvent>;
+
+    fn build_event(event_number: u64) -> TestEvent {
+        RuntimeEventResponse {
+            number: event_number,
+            key: "ValueSetter/NewValue".to_owned(),
+            value: TestRuntimeEvent::ValueSetter(sov_value_setter::Event::NewValue(
+                event_number as u32,
+            )),
+            module: sov_modules_api::ModuleRef {
+                name: "ValueSetter".to_owned(),
+            },
+            tx_hash: HexString([event_number as u8; 32]),
+        }
+    }
+
+    fn build_stored_event(event_number: u64, tx_hash: TxHash) -> StoredEvent {
+        let event = TestRuntimeEvent::<S>::ValueSetter(sov_value_setter::Event::NewValue(
+            event_number as u32,
+        ));
+        StoredEvent::new(
+            b"ValueSetter/NewValue",
+            &borsh::to_vec(&event).unwrap(),
+            tx_hash.0,
+        )
+    }
 
     fn build_mock_confirmation(tx_number: u64) -> AcceptedTx<Confirmation<S, TestRuntime<S>>> {
         AcceptedTx {
@@ -629,6 +661,131 @@ mod tests {
                 timestamp_nanos: None,
             },
         }
+    }
+
+    fn build_mock_confirmation_with_events(
+        tx_number: u64,
+        event_numbers: std::ops::Range<u64>,
+    ) -> AcceptedTx<Confirmation<S, TestRuntime<S>>> {
+        let mut tx = build_mock_confirmation(tx_number);
+        tx.confirmation.events = event_numbers.map(build_event).collect();
+        tx
+    }
+
+    fn build_cache_with_db_events(
+        event_numbers: std::ops::Range<u64>,
+    ) -> (tempfile::TempDir, TransactionCache<S, TestRuntime<S>>) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+        let ledger_db = LedgerDb::with_reader(storage_manager.create_ledger_storage()).unwrap();
+        let tx_hash = HexString([0; 32]);
+        let mut slot = SlotCommit::<_, MockBlob, TxReceiptContents<S>>::new(
+            MockBlock::default(),
+            Default::default(),
+        );
+        let batch = BatchReceipt::<MockBlob, TxReceiptContents<S>> {
+            batch_hash: [0; 32],
+            tx_receipts: vec![TransactionReceipt {
+                tx_hash,
+                body_to_save: None,
+                events: event_numbers
+                    .map(|event_number| build_stored_event(event_number, tx_hash))
+                    .collect(),
+                receipt: TxEffect::Successful(SuccessfulTxContents {
+                    gas_used: <<S as Spec>::Gas as Gas>::zero(),
+                }),
+            }],
+            ignored_tx_receipts: vec![],
+            inner: MockBlob::new(vec![], MockAddress::new([0; 32]), [0; 32]),
+        };
+        slot.add_batch(batch);
+        let commit_data = ledger_db.materialize_slot(slot, b"state-root").unwrap();
+        storage_manager.commit(&commit_data);
+        ledger_db.replace_reader(storage_manager.create_ledger_storage());
+
+        (temp_dir, TransactionCache::new(ledger_db, 1, 100))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_events_db_page_ignores_newer_cached_events() {
+        let (_temp_dir, cache) = build_cache_with_db_events(0..3);
+        cache
+            .write_handle()
+            .insert(build_mock_confirmation_with_events(1, 1_000..1_002))
+            .await;
+
+        let events = cache.list_events(0..2).await.unwrap();
+        assert_eq!(
+            events.iter().map(|event| event.number).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_events_merges_db_and_cache_with_exact_bounds() {
+        let (_temp_dir, cache) = build_cache_with_db_events(0..3);
+        cache
+            .write_handle()
+            .insert(build_mock_confirmation_with_events(1, 3..6))
+            .await;
+
+        let events = cache.list_events(1..5).await.unwrap();
+        assert_eq!(
+            events.iter().map(|event| event.number).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+
+        let events = cache.list_events(4..5).await.unwrap();
+        assert_eq!(
+            events.iter().map(|event| event.number).collect::<Vec<_>>(),
+            vec![4]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_events_entirely_in_future() {
+        let (_temp_dir, cache) = build_cache_with_db_events(0..3);
+        cache
+            .write_handle()
+            .insert(build_mock_confirmation_with_events(1, 3..6))
+            .await;
+
+        assert!(cache.list_events(1_000..1_025).await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_list_events_releases_cache_lock_before_db_await() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+        let ledger_db = LedgerDb::with_reader(storage_manager.create_ledger_storage()).unwrap();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let cache = TransactionCache::<S, TestRuntime<S>>::new(ledger_db, 0, 100);
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            });
+            started_rx.await.unwrap();
+
+            let mut events = Box::pin(cache.list_events(0..1));
+            assert!(futures::poll!(&mut events).is_pending());
+            assert!(
+                cache.inner.try_write().is_ok(),
+                "cache read lock was held across the DB await"
+            );
+
+            release_tx.send(()).unwrap();
+            assert!(events.await.unwrap().is_empty());
+            blocker.await.unwrap();
+        });
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -18,6 +18,10 @@ use crate::common::{SequencerTxStream, SubscriptionStreamError};
 use crate::preferred::{AcceptedTx, Confirmation};
 use crate::rest_api::ApiAcceptedTx;
 
+use super::event_range_len;
+#[cfg(test)]
+use super::InvalidEventRange;
+
 type TxStreamItem<S, Rt> = Result<ApiAcceptedTx<Confirmation<S, Rt>>, SubscriptionStreamError>;
 type GetNextChunkFuture<S, Rt> = Pin<
     Box<
@@ -166,7 +170,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         &self,
         event_numbers: std::ops::Range<u64>,
     ) -> anyhow::Result<Vec<RuntimeEventResponse<Rt::RuntimeEvent>>> {
-        if event_numbers.start >= event_numbers.end {
+        if event_range_len(&event_numbers)? == 0 {
             return Ok(vec![]);
         }
         let cached_events = {
@@ -751,6 +755,16 @@ mod tests {
             .await;
 
         assert!(cache.list_events(1_000..1_025).await.unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[allow(clippy::reversed_empty_ranges)]
+    async fn test_list_events_rejects_inverted_range() {
+        let (_temp_dir, cache) = build_cache_with_db_events(0..3);
+
+        let error = cache.list_events(2..1).await.unwrap_err();
+        assert!(error.is::<InvalidEventRange>());
+        assert!(cache.list_events(1..1).await.unwrap().is_empty());
     }
 
     #[test]

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -34,6 +34,7 @@ use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::common::{error_not_fully_synced, AcceptedTx, Sequencer, SubscriptionStreamError};
+use crate::preferred::InvalidEventRange;
 use crate::TxStatus;
 
 /// Interval between ping frames sent to the client for keepalive.
@@ -41,6 +42,14 @@ const PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Maximum time to wait for a pong response before considering the connection dead.
 const PONG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn list_events_error_response(error: anyhow::Error) -> axum::response::Response {
+    if error.is::<InvalidEventRange>() {
+        errors::bad_request_400("Invalid event range", error)
+    } else {
+        errors::database_error_500("Unable to retrieve events").into_response()
+    }
+}
 
 /// Emits HTTP metrics for a WebSocket message.
 fn emit_ws_metrics(
@@ -709,10 +718,11 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         // This is now fixed.
         let end = start.saturating_add(pagination.size as u64);
 
-        let events =
-            state.sequencer.list_events(start..end).await.map_err(|_| {
-                errors::database_error_500("Unable to retrieve events").into_response()
-            })?;
+        let events = state
+            .sequencer
+            .list_events(start..end)
+            .await
+            .map_err(list_events_error_response)?;
         let next_cursor = start + events.len() as u64;
         let response = PaginatedResponse {
             items: events,
@@ -780,5 +790,26 @@ impl<C> ApiAcceptedTx<C> {
             tx: tx_json,
             confirmation: tx.confirmation,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_event_range_maps_to_bad_request() {
+        let response = list_events_error_response(InvalidEventRange { start: 2, end: 1 }.into());
+
+        assert_eq!(response.status(), http::StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["message"], "Invalid event range");
+        assert_eq!(
+            body["details"]["error"],
+            "Invalid event range 2..1: range start must not be greater than range end"
+        );
     }
 }


### PR DESCRIPTION
# Description

* Fix bug that would attempt to query unbounded events if they were not in the cache - bound all reads by the actual range param provided
* Filter events from the transaction cache by the range before cloning, not after
* Drop the cache lock after it's been read, instead of continuing to hold the lock across the DB queries
* Handle missing ranges gracefully, including future/nonexistent ranges

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
