### PR TITLE
Add credential_id to recent (cached) transactions in sequencer APIs

### DIFF
--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -956,6 +956,10 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/TxHash"
+        credential_id:
+          allOf:
+            - $ref: "#/components/schemas/Hash"
+          description: Credential identifier captured during sequencer ingress authentication. Omitted when unavailable, including for transactions reconstructed from ledger history.
         tx:
           description: Decoded transaction body as a JSON object. Omitted if the transaction could not be decoded.
         tx_number:

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -259,6 +259,10 @@ pub struct AcceptedTx<C> {
     pub tx: FullyBakedTx,
     /// Hash of the transaction.
     pub tx_hash: TxHash,
+    /// Credential identifier captured during sequencer ingress authentication.
+    /// May be unavailable, including for transactions reconstructed from ledger history.
+    #[serde(skip_serializing)]
+    pub credential_id: Option<CredentialId>,
     #[derivative(Debug(bound = "C: Debug"))]
     /// Confirmation data. Could be empty, a receipt, or other data.
     pub confirmation: C,
@@ -295,6 +299,7 @@ impl<C> AcceptedTx<C> {
         AcceptedTx {
             tx: self.tx,
             tx_hash: self.tx_hash,
+            credential_id: self.credential_id,
             confirmation: f(self.confirmation),
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -677,6 +677,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         AcceptedTx {
             tx,
             tx_hash,
+            credential_id: None,
             confirmation: Confirmation {
                 events,
                 receipt: receipt.into(),

--- a/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
@@ -1383,6 +1383,7 @@ mod tests {
                 let _ = tx.send(AcceptedTx::<Confirmation<TestSpec, TestRuntime>> {
                     tx: baked_tx_clone,
                     tx_hash,
+                    credential_id: None,
                     confirmation: Confirmation {
                         events: vec![],
                         receipt: sov_modules_api::ApiTxEffect::Skipped {

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -402,6 +402,7 @@ mod tests {
             accepted_tx: AcceptedTx {
                 tx,
                 tx_hash,
+                credential_id: None,
                 confirmation,
             },
             tx_changes,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -32,7 +32,7 @@ use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::Gas;
 use sov_modules_api::{
-    FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, VersionReader,
+    CredentialId, FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, VersionReader,
     VisibleSlotNumber,
 };
 use sov_rollup_full_node_interface::StateUpdateInfo;
@@ -753,6 +753,7 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
+        credential_id: Option<CredentialId>,
     ) -> (
         Result<
             (
@@ -806,7 +807,7 @@ where
 
         let (
             AcceptedTxWithBudgetInfo {
-                accepted_tx,
+                mut accepted_tx,
                 remaining_slot_gas,
                 execution_time_micros,
             },
@@ -834,6 +835,7 @@ where
         let gas_used = accepted_tx.confirmation.gas_used();
         let finalized_tx_len = accepted_tx.tx.len();
         let resource_used = ResourceUsed::new(1, tx_len, execution_time_micros, gas_used);
+        accepted_tx.credential_id = credential_id;
 
         batch_size_tracker.add_tx(finalized_tx_len, execution_time_micros);
         let rx = executor_events_sender

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -1211,7 +1211,9 @@ where
         // Important: we read the sequencing data from the baked tx inside apply_tx_to_in_progress_batch (which is called from do_new_tx)
         // so this must not be moved without updating do_new_tx. See the comment in apply_tx_to_in_progress_batch for more details.
         baked_tx.set_sequencing_metadata(&sequencing_data);
-        let (res, resource_used) = inner.do_new_tx(tx_hash, baked_tx).await;
+        let (res, resource_used) = inner
+            .do_new_tx(tx_hash, baked_tx, Some(ip_and_credential.credential_id))
+            .await;
 
         // Do not use `?` or return early here. We must always call `rate_limiter.update`
         // to ensure the limits are updated even for unsuccessful transactions.
@@ -1299,7 +1301,7 @@ where
             inner.next_unassigned_sequence_number,
         )?;
 
-        let (res, _) = inner.do_new_tx(tx_hash, baked_tx).await;
+        let (res, _) = inner.do_new_tx(tx_hash, baked_tx, None).await;
         let _ = res.map_err(ReplicaError::NewTx)?.0.await;
 
         Ok(())

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -270,6 +270,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         Ok(Some(AcceptedTx {
             tx: tx.body.unwrap_or_default(),
             tx_hash,
+            credential_id: None,
             confirmation: Confirmation {
                 events: tx
                     .events
@@ -485,6 +486,7 @@ impl<S: Spec, Rt: Runtime<S>> AcceptedTxStream<S, Rt> {
                 ApiAcceptedTx {
                     tx: tx_body,
                     id: HexString(tx.hash),
+                    credential_id: None,
                     confirmation: Confirmation {
                         events: tx
                             .events
@@ -612,8 +614,8 @@ mod tests {
     use sov_db::ledger_db::SlotCommit;
     use sov_mock_da::{MockAddress, MockBlob, MockBlock};
     use sov_modules_api::{
-        ApiTxEffect, BatchReceipt, FullyBakedTx, Gas, RuntimeEventProcessor, SuccessfulTxContents,
-        TransactionReceipt, TxEffect, TxReceiptContents,
+        ApiTxEffect, BatchReceipt, CredentialId, FullyBakedTx, Gas, RuntimeEventProcessor,
+        SuccessfulTxContents, TransactionReceipt, TxEffect, TxReceiptContents,
     };
     use sov_rollup_interface::stf::StoredEvent;
     use sov_test_utils::storage::SimpleLedgerStorageManager;
@@ -654,6 +656,7 @@ mod tests {
         AcceptedTx {
             tx: FullyBakedTx::new(vec![]),
             tx_hash: HexString([tx_number as u8; 32]),
+            credential_id: Some(CredentialId::from_bytes([tx_number as u8; 32])),
             confirmation: Confirmation {
                 events: vec![],
                 receipt: ApiTxEffect::Successful {
@@ -832,6 +835,10 @@ mod tests {
                         .unwrap()
                         .unwrap();
                 assert_eq!(next_tx.confirmation.tx_number, j);
+                assert_eq!(
+                    next_tx.credential_id,
+                    Some(CredentialId::from_bytes([j as u8; 32]))
+                );
             }
             // Occasionally, insert a new tx to test that the stream continues working after catchup
             if i % 13 == 0 {
@@ -844,6 +851,10 @@ mod tests {
                         .unwrap()
                         .unwrap();
                 assert_eq!(next_tx.confirmation.tx_number, num_txs);
+                assert_eq!(
+                    next_tx.credential_id,
+                    Some(CredentialId::from_bytes([num_txs as u8; 32]))
+                );
                 num_txs += 1;
             } else {
                 // If we're not inserting a new tx, then the stream should be empty. Check that it is.
@@ -886,6 +897,10 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(next_tx.confirmation.tx_number, num_txs);
+        assert_eq!(
+            next_tx.credential_id,
+            Some(CredentialId::from_bytes([num_txs as u8; 32]))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1003,6 +1018,9 @@ mod tests {
                 .unwrap();
             assert_eq!(next_tx.confirmation.tx_number, i);
             assert_eq!(next_tx.id, HexString([i as u8; 32]));
+            let expected_credential_id =
+                (i >= 105).then(|| CredentialId::from_bytes([i as u8; 32]));
+            assert_eq!(next_tx.credential_id, expected_credential_id);
         }
 
         // Push a new tx to the stream and check that it comes through
@@ -1013,5 +1031,9 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(next_tx.confirmation.tx_number, num_txs);
+        assert_eq!(
+            next_tx.credential_id,
+            Some(CredentialId::from_bytes([num_txs as u8; 32]))
+        );
     }
 }

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -18,7 +18,7 @@ use sov_metrics::{track_metrics, HttpMetrics};
 use sov_modules_api::capabilities::TransactionAuthenticator;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::runtime::Runtime;
-use sov_modules_api::{RawTx, RuntimeEventProcessor, RuntimeEventResponse, Spec};
+use sov_modules_api::{CredentialId, RawTx, RuntimeEventProcessor, RuntimeEventResponse, Spec};
 use sov_rest_utils::handle_bad_ws_request;
 use sov_rest_utils::{
     errors, preconfigured_router_layers, serve_generic_ws_subscription,
@@ -771,6 +771,10 @@ pub struct TxInfoWithConfirmation<DaTransactionId, Confirmation> {
 pub struct ApiAcceptedTx<Confirmation> {
     /// The hex encoded transaction hash
     pub id: TxHash,
+    /// Credential identifier captured during sequencer ingress authentication.
+    /// Omitted when unavailable, including for transactions reconstructed from ledger history.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<CredentialId>,
     /// Transaction body
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx: Option<serde_json::Value>,
@@ -787,6 +791,7 @@ impl<C> ApiAcceptedTx<C> {
         });
         Self {
             id: tx.tx_hash,
+            credential_id: tx.credential_id,
             tx: tx_json,
             confirmation: tx.confirmation,
         }

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -620,6 +620,7 @@ where
         Ok(AcceptedTx {
             tx: baked_tx,
             tx_hash,
+            credential_id: None,
             confirmation: EmptyConfirmation {},
         })
     }

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -141,6 +141,7 @@ where
         AcceptedTx {
             tx,
             tx_hash,
+            credential_id: None,
             confirmation: EmptyConfirmation {},
         }
     }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -24,7 +24,9 @@ use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::BlockProducingConfig;
 use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::prelude::*;
-use sov_modules_api::{Amount, DispatchCall, Gas, GasArray, GasPrice, GasUnit, RawTx, Runtime};
+use sov_modules_api::{
+    Amount, DispatchCall, Gas, GasArray, GasPrice, GasUnit, PrivateKey, PublicKey, RawTx, Runtime,
+};
 use sov_modules_stf_blueprint::GenesisParams;
 use sov_node_client::NodeClient;
 use sov_paymaster::{Paymaster, PaymasterConfig};
@@ -1728,6 +1730,67 @@ async fn test_sequencer_getters() {
     let mut slot_subscription = test_rollup.api_client().subscribe_slots().await.unwrap();
     let mut responses: Vec<TxInfoWithConfirmation> = Vec::new();
     let mut tx_number = 0;
+
+    // The credential is available on the live stream, cache-backed historical stream, and
+    // cache-backed REST response for a newly authenticated transaction.
+    let expected_credential_id = admin
+        .private_key
+        .pub_key()
+        .credential_id()
+        .to_string()
+        .parse::<types::Hash>()
+        .unwrap();
+    let mut live_tx_ws = test_rollup
+        .api_client()
+        .subscribe_to_txs(None)
+        .await
+        .unwrap();
+    let tx = tx_set_value(&admin.private_key, tx_number, tx_number);
+    let response = test_rollup
+        .api_client()
+        .send_raw_tx_to_sequencer_with_retry(&tx)
+        .await
+        .unwrap()
+        .into_inner();
+    let live_response = tokio::time::timeout(Duration::from_millis(500), live_tx_ws.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        live_response.credential_id.as_ref(),
+        Some(&expected_credential_id)
+    );
+
+    let cached_response = test_rollup
+        .api_client()
+        .sequencer_get_tx(&response.id)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        cached_response.credential_id.as_ref(),
+        Some(&expected_credential_id)
+    );
+
+    let mut cached_tx_ws = test_rollup
+        .api_client()
+        .subscribe_to_txs(Some(tx_number))
+        .await
+        .unwrap();
+    let cached_stream_response =
+        tokio::time::timeout(Duration::from_millis(500), cached_tx_ws.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    assert_eq!(
+        cached_stream_response.credential_id.as_ref(),
+        Some(&expected_credential_id)
+    );
+    responses.push(response);
+    tx_number += 1;
+
     // Create a helper function to check that the tx endpoint responds with the expected txs.
     let check_responses = |starting_from: usize,
                            responses: Vec<TxInfoWithConfirmation>,


### PR DESCRIPTION
# Description

Wires `credential_id` through the sequencer's transaction cache. This is then returned for new transactions in the websocket subscription, and as a side-effect also for recent transactions in the REST API.

The credential_id is not available in the ledger, so transactions that fall out of the sequencer's cache (once the node processes the DA block and stores its data to the ledger DB) will no longer get this field. Since the primary usecase is websocket subscriptions at the tip, that's been left out of the scope of the PR. (Ledger transactions can also be fetched from the ledger API, and manually decoded to get the pubkey/signing material.) The main consequence is that websocket subscriptions support a starting parameter with backfill, so it is possible to query historical transactions that are missing credential_id through a websocket subscription if the starting index is set far enough into the past.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
