### PR TITLE
Avoid restarting the stf-info channel from genesis in optimistic rollups

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -260,6 +260,10 @@ pub struct LedgerDb {
 
 // Db key for the latest height of the written STF info.
 const WRITE_ROLLUP_HEIGHT_ID: StfInfoUniqueId = StfInfoUniqueId(0);
+// ID 1 was previously used for the next STF-info cursor. Do not reuse it because
+// existing databases can retain that value.
+// Db key for the latest optimistic attestation recorded in durable local metadata.
+const LATEST_OPTIMISTIC_ATTESTATION_ID: StfInfoUniqueId = StfInfoUniqueId(3);
 // Db key for the oldest saved STF info.
 const LAST_SLOT_NUMBER_ID: StfInfoUniqueId = StfInfoUniqueId(2);
 
@@ -651,6 +655,23 @@ impl LedgerDb {
     pub async fn get_stf_info_write_slot_number(&self) -> anyhow::Result<Option<SlotNumber>> {
         let db = self.db.read().expect(DB_LOCK_POISONED).clone();
         db.get_async::<StfInfoMetadata>(&WRITE_ROLLUP_HEIGHT_ID)
+            .await
+    }
+
+    /// Materializes the latest optimistic attestation in durable local metadata.
+    pub fn materialize_latest_optimistic_attestation(
+        &self,
+        slot_number: SlotNumber,
+    ) -> anyhow::Result<SchemaBatch> {
+        let mut schema_batch = SchemaBatch::new();
+        schema_batch.put::<StfInfoMetadata>(&LATEST_OPTIMISTIC_ATTESTATION_ID, &slot_number)?;
+        Ok(schema_batch)
+    }
+
+    /// Gets the latest optimistic attestation recorded in durable local metadata.
+    pub async fn get_latest_optimistic_attestation(&self) -> anyhow::Result<Option<SlotNumber>> {
+        let db = self.db.read().expect(DB_LOCK_POISONED).clone();
+        db.get_async::<StfInfoMetadata>(&LATEST_OPTIMISTIC_ATTESTATION_ID)
             .await
     }
 

--- a/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
@@ -103,7 +103,8 @@ where
 
         tracing::debug!(%slot_number, %attestation_height, "Submitting attestation to DA");
 
-        self.stf_info_receiver.inc_next_height_to_receive();
+        self.stf_info_receiver
+            .record_successful_optimistic_attestation();
         Ok(())
     }
 }

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -18,6 +18,15 @@ use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_rollup_interface::ProvableHeightTracker;
 use tokio::sync::mpsc;
 
+/// The durable event from which STF-info processing should resume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StfInfoResumeSource {
+    /// The latest aggregated proof accepted and persisted by a ZK rollup.
+    LatestAggregatedProof(Option<SlotNumber>),
+    /// The latest optimistic attestation recorded in durable local metadata.
+    LatestOptimisticAttestation(Option<SlotNumber>),
+}
+
 /// Holds all the necessary data for the creation of a block zk-proof.
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "StateRoot: Serialize + DeserializeOwned, Witness: Serialize + DeserializeOwned")]
@@ -66,6 +75,9 @@ pub struct Sender<StateRoot, Witness, Da: DaSpec> {
 
     // Max number of entries we will keep in the Db, older data will be pruned.
     max_nb_of_infos_in_db: NonZero<u64>,
+
+    // Latest optimistic attestation successfully submitted by the consumer.
+    latest_optimistic_attestation: Option<Arc<AtomicU64>>,
 
     /// The notification channel does not contain the actual STF info data,
     /// only the indexes in the Db where the data is stored.
@@ -150,6 +162,10 @@ impl<
 
     /// Increment next height to receive by one, returning the previous value.
     pub fn inc_next_height_to_receive(&self) -> SlotNumber {
+        assert!(
+            self.latest_optimistic_attestation.is_none(),
+            "Optimistic STF-info progress must be recorded by the attestation consumer"
+        );
         SlotNumber::new(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
     }
 }
@@ -158,6 +174,8 @@ impl<
 pub struct Receiver<StateRoot, Witness, Da: DaSpec> {
     /// Height of the next `StateTransitionInfo` that is expected to be processed by the `Receiver`
     next_height_to_receive: Arc<AtomicU64>,
+    // Latest optimistic attestation successfully submitted by the consumer.
+    latest_optimistic_attestation: Option<Arc<AtomicU64>>,
     ledger_db: LedgerDb,
     receiver: mpsc::Receiver<SlotNumber>,
     _phantom: PhantomData<(StateRoot, Witness, Da)>,
@@ -176,7 +194,7 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
     ledger_db: LedgerDb,
     max_channel_size: NonZero<u64>,
     max_nb_of_infos_in_db: NonZero<u64>,
-    latest_proof_final_slot: Option<SlotNumber>,
+    resume_source: StfInfoResumeSource,
 ) -> anyhow::Result<(
     Sender<StateRoot, Witness, Da>,
     Receiver<StateRoot, Witness, Da>,
@@ -189,25 +207,34 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
     // Internally, the Db keeps the following entries:
     // 1. The STF info data.
     // 2. The latest height of the written STF info (increased on every `materialize_stf_info`` operation)
-    // 3. The next height of the retrieved STF info (increased on every `read_next`` operation).
+    // 3. In optimistic mode, the latest successfully submitted attestation.
 
     // On startup, we need to fill the notification channel with the pending STF info from the db.
     let (notifier, receiver) =
         tokio::sync::mpsc::channel::<SlotNumber>(max_channel_size.get().try_into()?);
 
-    // Resume STF-info processing from the last aggregated proof that was
-    // verified on-chain and persisted in the DB: that proof's `final_slot` is
-    // the last slot we know is committed, so the prover picks up at
-    // `final_slot + 1`. If no such proof exists yet (fresh node), start from
-    // genesis.
-    let next_height_to_receive = latest_proof_final_slot
-        .map(|final_slot| final_slot.saturating_add(1))
+    let (latest_processed_slot, latest_optimistic_attestation) = match resume_source {
+        StfInfoResumeSource::LatestAggregatedProof(latest_aggregated_proof) => {
+            (latest_aggregated_proof, None)
+        }
+        StfInfoResumeSource::LatestOptimisticAttestation(latest_optimistic_attestation) => (
+            latest_optimistic_attestation,
+            Some(Arc::new(AtomicU64::new(
+                latest_optimistic_attestation
+                    .unwrap_or(SlotNumber::GENESIS)
+                    .get(),
+            ))),
+        ),
+    };
+    let next_height_to_receive = latest_processed_slot
+        .map(|slot_number| slot_number.saturating_add(1))
         .unwrap_or(SlotNumber::ONE);
 
     let next_height_to_receive_ref = Arc::new(AtomicU64::new(next_height_to_receive.get()));
 
     let sender = Sender {
         max_nb_of_infos_in_db,
+        latest_optimistic_attestation: latest_optimistic_attestation.clone(),
         next_height_to_receive: next_height_to_receive_ref.clone(),
         next_height_to_send: next_height_to_receive,
         notifier,
@@ -217,6 +244,7 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
 
     let receiver = Receiver {
         next_height_to_receive: next_height_to_receive_ref,
+        latest_optimistic_attestation,
         ledger_db,
         receiver,
         _phantom: PhantomData,
@@ -335,6 +363,20 @@ where
         schema.merge(ledger_db.materialize_stf_info_write_slot_number(write_rollup_height)?);
 
         let next_rollup_height_to_receive = self.next_height_to_receive();
+        if let Some(latest_optimistic_attestation) = &self.latest_optimistic_attestation {
+            // This checkpoint deliberately lags successful submission until the
+            // next STF-info commit. A restart can therefore replay recent
+            // attestations, preserving at-least-once rather than at-most-once
+            // submission semantics.
+            let latest_optimistic_attestation =
+                SlotNumber::new(latest_optimistic_attestation.load(Ordering::SeqCst));
+            if latest_optimistic_attestation > SlotNumber::GENESIS {
+                schema
+                    .merge(ledger_db.materialize_latest_optimistic_attestation(
+                        latest_optimistic_attestation,
+                    )?);
+            }
+        }
 
         // Prune the oldest entries if needed
         schema.merge(
@@ -395,6 +437,9 @@ where
                          This usually means the node previously ran without the proof pipeline (e.g. as a replica)."
                     );
                     self.next_height_to_send = height;
+                    // Realignment is not evidence that an optimistic
+                    // attestation was submitted, so it must not update the
+                    // optimistic attestation checkpoint.
                     self.next_height_to_receive
                         .fetch_max(height.get(), Ordering::SeqCst);
                 }
@@ -463,13 +508,33 @@ where
         SlotNumber::new(self.next_height_to_receive.load(Ordering::SeqCst))
     }
 
-    /// Increment next height to receive by one, returning the previous value.
-    pub fn inc_next_height_to_receive(&self) -> SlotNumber {
-        SlotNumber::new(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst))
+    /// Records a successfully submitted optimistic attestation and advances the cursor.
+    pub(crate) fn record_successful_optimistic_attestation(&self) -> SlotNumber {
+        let latest_optimistic_attestation = self
+            .latest_optimistic_attestation
+            .as_ref()
+            .expect("An optimistic attestation can only be recorded in optimistic mode");
+        let processed_slot = self.next_height_to_receive();
+
+        // Store the attestation first so a concurrent materialization can never
+        // prune the processed STF info while checkpointing the previous
+        // attestation.
+        latest_optimistic_attestation.store(processed_slot.get(), Ordering::SeqCst);
+        let previous_slot =
+            SlotNumber::new(self.next_height_to_receive.fetch_add(1, Ordering::SeqCst));
+        assert_eq!(
+            previous_slot, processed_slot,
+            "The optimistic STF-info cursor changed concurrently"
+        );
+        processed_slot
     }
 
-    /// Increment next height to receive by the requested amount, returning the previous value.
+    /// Increment the ZK STF-info cursor by the requested amount, returning the previous value.
     pub fn inc_next_height_to_receive_by(&self, amount: u64) -> SlotNumber {
+        assert!(
+            self.latest_optimistic_attestation.is_none(),
+            "Optimistic STF-info progress must advance one successfully submitted attestation at a time"
+        );
         SlotNumber::new(
             self.next_height_to_receive
                 .fetch_add(amount, Ordering::SeqCst),
@@ -482,6 +547,10 @@ where
     /// cursor advance co-located with the actual proof publication, while
     /// the channel-draining `read_next` still happens on the intake task.
     pub fn cursor_handle(&self) -> CursorHandle {
+        assert!(
+            self.latest_optimistic_attestation.is_none(),
+            "CursorHandle is only valid for the ZK proof pipeline"
+        );
         CursorHandle {
             next_height_to_receive: self.next_height_to_receive.clone(),
         }
@@ -539,14 +608,20 @@ mod tests {
         Sender<StateRoot, Witness, MockDaSpec>,
         Receiver<StateRoot, Witness, MockDaSpec>,
     )> {
-        setup_with_resume(path, max_channel_size, max_nb_of_infos_in_db, None).await
+        setup_with_resume_source(
+            path,
+            max_channel_size,
+            max_nb_of_infos_in_db,
+            StfInfoResumeSource::LatestAggregatedProof(None),
+        )
+        .await
     }
 
-    async fn setup_with_resume(
+    async fn setup_with_resume_source(
         path: &Path,
         max_channel_size: u64,
         max_nb_of_infos_in_db: u64,
-        latest_proof_final_slot: Option<SlotNumber>,
+        resume_source: StfInfoResumeSource,
     ) -> anyhow::Result<(
         LedgerDb,
         SimpleLedgerStorageManager,
@@ -560,7 +635,7 @@ mod tests {
             ledger_db.clone(),
             NonZero::new(max_channel_size).unwrap(),
             NonZero::new(max_nb_of_infos_in_db).unwrap(),
-            latest_proof_final_slot,
+            resume_source,
         )
         .await?;
 
@@ -617,9 +692,7 @@ mod tests {
             assert_eq!(sender.get_oldest_slot_number(&ledger_db).await?.get(), 1);
 
             // Commit new data.
-            receiver
-                .next_height_to_receive
-                .fetch_add(2, Ordering::SeqCst);
+            receiver.inc_next_height_to_receive_by(2);
 
             let stf_info = make_stf_info(channel_size + 1);
             let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
@@ -639,11 +712,11 @@ mod tests {
             // The previous block advanced `next_height_to_receive` to 3 in
             // memory and persisted writes through slot 12. Resume the channel
             // at slot 3 by anchoring to a "previous proof" with `final_slot=2`.
-            let (ledger_db, _, sender, mut receiver) = setup_with_resume(
+            let (ledger_db, _, sender, mut receiver) = setup_with_resume_source(
                 temp_dir.path(),
                 channel_size,
                 max_nb_of_infos_in_db,
-                Some(SlotNumber::new(2)),
+                StfInfoResumeSource::LatestAggregatedProof(Some(SlotNumber::new(2))),
             )
             .await?;
 
@@ -656,6 +729,98 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_optimistic_attestation_resume_is_persisted() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let channel_size = 10;
+        let max_nb_of_infos_in_db = 10;
+
+        {
+            let (ledger_db, mut storage_manager, mut sender, mut receiver) =
+                setup_with_resume_source(
+                    temp_dir.path(),
+                    channel_size,
+                    max_nb_of_infos_in_db,
+                    StfInfoResumeSource::LatestOptimisticAttestation(None),
+                )
+                .await?;
+
+            let first_stf_info = make_stf_info(1);
+            let schema_batch = sender
+                .materialize_stf_info(&first_stf_info, &ledger_db)
+                .await?;
+            storage_manager.commit(&schema_batch);
+            sender
+                .notify(first_stf_info.slot_number(), &ledger_db)
+                .await?;
+
+            let stf_info = receiver.read_next().await?.unwrap();
+            assert_eq!(stf_info.slot_number(), SlotNumber::ONE);
+            receiver.record_successful_optimistic_attestation();
+
+            let second_stf_info = make_stf_info(2);
+            let schema_batch = sender
+                .materialize_stf_info(&second_stf_info, &ledger_db)
+                .await?;
+            storage_manager.commit(&schema_batch);
+            sender
+                .notify(second_stf_info.slot_number(), &ledger_db)
+                .await?;
+
+            assert_eq!(
+                ledger_db.get_latest_optimistic_attestation().await?,
+                Some(SlotNumber::ONE)
+            );
+        }
+
+        {
+            let latest_optimistic_attestation = {
+                let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+                let ledger_db = LedgerDb::with_reader(storage_manager.create_ledger_storage())?;
+                ledger_db.get_latest_optimistic_attestation().await?
+            };
+            let (_, _, _, mut receiver) = setup_with_resume_source(
+                temp_dir.path(),
+                channel_size,
+                max_nb_of_infos_in_db,
+                StfInfoResumeSource::LatestOptimisticAttestation(latest_optimistic_attestation),
+            )
+            .await?;
+
+            let stf_info = receiver.read_next().await?.unwrap();
+            assert_eq!(stf_info.slot_number(), SlotNumber::new(2));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_aggregated_proof_resume_does_not_persist_optimistic_attestation(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let (ledger_db, mut storage_manager, sender, receiver) = setup_with_resume_source(
+            temp_dir.path(),
+            10,
+            10,
+            StfInfoResumeSource::LatestAggregatedProof(None),
+        )
+        .await?;
+
+        let schema_batch = sender
+            .materialize_stf_info(&make_stf_info(1), &ledger_db)
+            .await?;
+        storage_manager.commit(&schema_batch);
+
+        receiver.inc_next_height_to_receive_by(1);
+        let schema_batch = sender
+            .materialize_stf_info(&make_stf_info(2), &ledger_db)
+            .await?;
+        storage_manager.commit(&schema_batch);
+
+        assert_eq!(ledger_db.get_latest_optimistic_attestation().await?, None);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_stf_info_restart_realigns_missing_local_prefix() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let channel_size = 10;
@@ -664,11 +829,11 @@ mod tests {
         // Simulate a former replica that restarts as a prover: the resume cursor
         // points at slot 3, but the local node only has STF infos starting at 5.
         {
-            let (ledger_db, mut storage_manager, sender, _receiver) = setup_with_resume(
+            let (ledger_db, mut storage_manager, sender, _receiver) = setup_with_resume_source(
                 temp_dir.path(),
                 channel_size,
                 max_nb_of_infos_in_db,
-                Some(SlotNumber::new(2)),
+                StfInfoResumeSource::LatestAggregatedProof(Some(SlotNumber::new(2))),
             )
             .await?;
 
@@ -680,11 +845,11 @@ mod tests {
         }
 
         {
-            let (_, _, _, mut receiver) = setup_with_resume(
+            let (_, _, _, mut receiver) = setup_with_resume_source(
                 temp_dir.path(),
                 channel_size,
                 max_nb_of_infos_in_db,
-                Some(SlotNumber::new(2)),
+                StfInfoResumeSource::LatestAggregatedProof(Some(SlotNumber::new(2))),
             )
             .await?;
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -31,7 +31,7 @@ use tracing::{debug, info, trace};
 
 use crate::da::{DaServiceWithCachedFinalizedHeaders, FinalizedBlocksBulkFetcher};
 use crate::http::HttpServerStart;
-use crate::processes::{new_stf_info_channel, Receiver};
+use crate::processes::{new_stf_info_channel, Receiver, StfInfoResumeSource};
 use crate::state_manager::{AggregatedProofs, BlockCandidateResolution, StateManager};
 use tokio::net::TcpListener;
 
@@ -190,7 +190,7 @@ where
         sync_state: Arc<DaSyncState>,
         da_service_with_cached_finalized_headers: DaServiceWithCachedFinalizedHeaders<Da>,
         genesis_da_height: u64,
-        latest_proof_final_slot: Option<SlotNumber>,
+        stf_info_resume_source: StfInfoResumeSource,
     ) -> anyhow::Result<Self> {
         error_if_tokio_runtime_is_not_multi_threaded()?;
         tracing::info!(config = ?runner_config, "Initializing StateTransitionRunner");
@@ -226,7 +226,7 @@ where
                 ledger_db.clone(),
                 config.max_number_of_transitions_in_memory,
                 config.max_number_of_transitions_in_db,
-                latest_proof_final_slot,
+                stf_info_resume_source,
             )
             .await?;
 

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -30,6 +30,8 @@ use sov_shutdown::SecondaryShutdownController;
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{ArrayWitness, NativeStorage, SlotKey, SlotValue, StateAccesses, Storage};
 
+use crate::processes::StfInfoResumeSource;
+
 use super::*;
 // We need a proof receipt type whose first and last generics are serializable, and middle two params are daspec and state root.
 // This is never constructed - just used to satisfy the type checker.
@@ -173,7 +175,7 @@ async fn test_instant_finality() -> anyhow::Result<()> {
         state_manager.ledger_db.clone(),
         NonZero::new(40).unwrap(),
         NonZero::new(40).unwrap(),
-        None,
+        StfInfoResumeSource::LatestAggregatedProof(None),
     )
     .await?;
     state_manager.stf_info_sender = Some(sender);
@@ -230,7 +232,7 @@ async fn rejected_aggregated_proofs_are_not_published_as_latest() -> anyhow::Res
         state_manager.ledger_db.clone(),
         NonZero::new(40).unwrap(),
         NonZero::new(40).unwrap(),
-        None,
+        StfInfoResumeSource::LatestAggregatedProof(None),
     )
     .await?;
     state_manager.stf_info_sender = Some(sender);

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -33,7 +33,9 @@ use sov_sequencer::standard::StdSequencerConfig;
 use sov_sequencer::{react_to_state_updates, SequencerConfig, SequencerKindConfig};
 use sov_shutdown::{PrimaryShutdownController, SecondaryShutdownController};
 use sov_state::NativeStorage;
-use sov_stf_runner::processes::{start_zk_workflow_in_background, ParallelProverService};
+use sov_stf_runner::processes::{
+    start_zk_workflow_in_background, ParallelProverService, StfInfoResumeSource,
+};
 use sov_stf_runner::{
     initialize_state, query_state_update_info, HttpServerConfig, ProofManagerConfig, RollupConfig,
     RunnerConfig, StateTransitionRunner,
@@ -305,7 +307,7 @@ pub async fn initialize_runner_with_stop_at(
         da_sync_state,
         da_service_with_cache,
         0,
-        None,
+        StfInfoResumeSource::LatestAggregatedProof(None),
     )
     .await
     .unwrap();

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -25,6 +25,7 @@ use sov_rollup_interface::node::SyncStatus;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_shutdown::{PrimaryShutdownController, SecondaryShutdownController};
 use sov_state::{ArrayWitness, NativeStorage, Storage, StorageRoot};
+use sov_stf_runner::processes::StfInfoResumeSource;
 use sov_stf_runner::StateTransitionRunner;
 use sov_stf_runner::{make_da_sync_state, DaServiceWithCachedFinalizedHeaders};
 use sov_test_utils::storage::SimpleStorageManager;
@@ -122,7 +123,7 @@ async fn test_runner_with_background_da_service(
         da_sync_state,
         da_service_with_cache,
         genesis_da_height,
-        None,
+        StfInfoResumeSource::LatestAggregatedProof(None),
     )
     .await?;
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -38,7 +38,7 @@ use sov_state::storage::NativeStorage;
 use sov_state::Storage;
 use sov_stf_runner::processes::{
     start_op_workflow_in_background, start_operator_workflow_in_background,
-    start_zk_workflow_in_background, ProverService, RollupProverConfig,
+    start_zk_workflow_in_background, ProverService, RollupProverConfig, StfInfoResumeSource,
 };
 use sov_stf_runner::{
     initialize_state, query_state_update_info, CorsConfiguration, RollupConfig,
@@ -567,6 +567,12 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
         info!(?operating_mode, "Instantiating a new rollup");
 
+        let latest_optimistic_attestation = if operating_mode == OperatingMode::Optimistic {
+            startup_step!(ledger_db.get_latest_optimistic_attestation().await)
+        } else {
+            None
+        };
+
         let da_sync_state = startup_step!(
             make_da_sync_state(
                 genesis_da_height,
@@ -630,8 +636,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             should_enable_proof_pipeline(prover_config, sequencer.is_replica);
 
         // The prover service validates the latest aggregated proof persisted in
-        // the ledger DB and returns its `final_slot_number`. We pass this slot
-        // into the runner so the STF-info stream resumes at `final_slot + 1`.
+        // the ledger DB and returns its `final_slot_number`. In ZK mode this
+        // anchors the STF-info stream at `final_slot + 1`; optimistic mode uses
+        // its latest locally-checkpointed attestation instead.
         let (prover_service, latest_proof_final_slot) = if proof_pipeline_enabled {
             let create_prover_service_result = self
                 .create_prover_service(
@@ -659,6 +666,22 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         } else {
             (None, None)
         };
+        let stf_info_resume_source = match operating_mode {
+            OperatingMode::Zk => {
+                StfInfoResumeSource::LatestAggregatedProof(latest_proof_final_slot)
+            }
+            OperatingMode::Optimistic => {
+                StfInfoResumeSource::LatestOptimisticAttestation(latest_optimistic_attestation)
+            }
+            OperatingMode::Operator => {
+                assert!(
+                    !proof_pipeline_enabled,
+                    "Operator mode must not enable the proof pipeline"
+                );
+                // The runner does not create an STF-info channel in operator mode.
+                StfInfoResumeSource::LatestAggregatedProof(None)
+            }
+        };
 
         let runner_result = StateTransitionRunner::new(
             rollup_config.runner.clone(),
@@ -681,7 +704,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             da_sync_state.clone(),
             da_service_with_cache,
             genesis_da_height,
-            latest_proof_final_slot,
+            stf_info_resume_source,
         )
         .await;
         let mut runner = match runner_result {


### PR DESCRIPTION
# Description

The `flaky_test_start_stop_optimistic_non_instant_finality` test was extremely flaky, and codex found that it was due to optimistic rollups restarting the stf_info channel from genesis since they lack aggregate proofs - thus using up the sequencer's entire bond in the test. Fix the channel to revert to the older behaviour for optimistic rollups, saving the cursor in the DB rather than relying on the latest aggregated proof (that would be always `None`).

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
