### PR TITLE
The README only uses ghcr.io, so dockerhub is unneeded.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -443,12 +443,6 @@ jobs:
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
-      - name: Login to Docker Hub
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -434,6 +434,9 @@ jobs:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=demo-rollup-1-93
     needs:
       - check
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: 60
     env:
       SKIP_GUEST_BUILD: "risc0"
@@ -443,6 +446,12 @@ jobs:
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust


### PR DESCRIPTION
# Description

This fixes CI breakage due to an expire dockerhub PAT

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
