### PR TITLE
fix(node-client): don't treat HTTP errors as nonce zero

### DIFF
--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -117,9 +117,15 @@ impl NodeClient {
         );
         let response = self.http_client.get(&nonce_url).send().await?;
 
-        let nonce = match response.error_for_status() {
-            Ok(res) => res.json::<NonceResponse>().await?.value,
-            Err(_) => 0,
+        let nonce = match nonce_from_response_status(response.status())? {
+            Some(nonce) => nonce,
+            None => {
+                response
+                    .error_for_status()?
+                    .json::<NonceResponse>()
+                    .await?
+                    .value
+            }
         };
 
         tracing::debug!(url = nonce_url, ?nonce, "Queried nonce");
@@ -372,6 +378,18 @@ impl NodeClient {
     }
 }
 
+fn nonce_from_response_status(status: reqwest::StatusCode) -> anyhow::Result<Option<u64>> {
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(Some(0));
+    }
+
+    if !status.is_success() {
+        anyhow::bail!("Unsuccessful nonce response status {status}");
+    }
+
+    Ok(None)
+}
+
 #[derive(serde::Deserialize)]
 struct ModuleInfo {
     #[allow(dead_code)]
@@ -397,4 +415,26 @@ async fn check_if_rollup_has_standard_modules(
         && module_response.modules.contains_key("accounts")
         && module_response.modules.contains_key("uniqueness")
         && module_response.modules.contains_key("sequencer-registry"))
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn nonce_response_not_found_returns_zero() {
+        assert_eq!(
+            nonce_from_response_status(StatusCode::NOT_FOUND).unwrap(),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn nonce_response_server_error_returns_error() {
+        let err = nonce_from_response_status(StatusCode::INTERNAL_SERVER_ERROR).unwrap_err();
+
+        assert!(err.to_string().contains("500"));
+    }
 }


### PR DESCRIPTION
# Description

Fix `NodeClient::get_nonce_for_public_key` so it only returns nonce `0` when the nonce state item is actually missing.

Previously, the method called `error_for_status()` and converted any HTTP error into `0`. This meant responses such as 429, 500, or 503 were treated the same as a missing nonce. Callers such as the CLI `SubmitBatch` workflow could then sign a batch starting from nonce `0` instead of surfacing the node error.

This changes the status handling to:

- return `0` for `404 Not Found`
- return an error for other non-success HTTP statuses
- continue parsing the nonce response for successful statuses

This matches the existing pattern used by `sequencer_rollup_address`, where `404` is treated as absence and other non-success responses are errors.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing


- `SKIP_GUEST_BUILD=1 cargo test -p sov-node-client`
- `cargo fmt --check`
- `git diff --check`

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
