### PR TITLE
Fix wait_for_tx_processing timeout on idle transaction-status streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 2026-08-17
+- #3053 `sov-node-client`: fixes `wait_for_tx_processing` potentially waiting indefinitely when the transaction-status WebSocket remains open but idle. The full subscription lifecycle is now covered by a hard timeout. This does not change state, consensus, or protocol behavior.
+
 ## #2892 Multisig and accounts hard fork - major breaking change
 This commit constitutes a hard fork of the SDK. Rollups existing before this commit will need to coordinate an upgrade to a new binary.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12204,6 +12204,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-sequencer-registry",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/utils/sov-node-client/Cargo.toml
+++ b/crates/utils/sov-node-client/Cargo.toml
@@ -15,6 +15,7 @@ futures = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 
 sov-api-spec = { workspace = true }
 sov-bank = { workspace = true, features = ["native"] }
@@ -22,6 +23,9 @@ sov-sequencer-registry = { workspace = true, features = ["native"] }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }
 
 [lints]
 workspace = true

--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -1,12 +1,13 @@
 //! Contains a simple client to interact with sovereign rollup node
 
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::future::Future;
+use std::time::Duration;
 
 use anyhow::Context;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use sov_api_spec::types;
 use sov_api_spec::types::AcceptTxBody;
 use sov_bank::utils::TokenHolder;
@@ -278,27 +279,17 @@ impl NodeClient {
     pub async fn wait_for_tx_processing(&self, tx_hash: &types::TxHash) -> anyhow::Result<()> {
         let max_waiting_time = Duration::from_secs(300);
         tracing::info!(?max_waiting_time, "Going to wait for batch to be processed");
-        let start_wait = Instant::now();
 
-        let mut subscription = self
-            .client
-            .subscribe_to_tx_status_updates(tx_hash.parse()?)
-            .await?;
-
-        while start_wait.elapsed() < max_waiting_time {
-            if let Some(tx_info) = subscription.next().await.transpose()? {
-                if tx_info.status == types::TxStatus::Processed
-                    || tx_info.status == types::TxStatus::Finalized
-                {
-                    tracing::info!("Rollup has processed the submitted batch!");
-                    return Ok(());
-                }
-            }
-        }
-        anyhow::bail!(
-            "Giving up waiting for target batch to be published after {:?}",
-            start_wait.elapsed()
-        );
+        wait_for_tx_processing_with_timeout(
+            async {
+                self.client
+                    .subscribe_to_tx_status_updates(tx_hash.parse()?)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            max_waiting_time,
+        )
+        .await
     }
 
     /// Performs a get request at given URL on the REST API socket.
@@ -369,6 +360,66 @@ impl NodeClient {
             .context("Deserialization of `KnownSequencerResponse`")?;
 
         Ok(Some(response.value))
+    }
+}
+
+async fn wait_for_tx_processing_with_timeout<F, S>(
+    subscription: F,
+    max_waiting_time: Duration,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = anyhow::Result<S>>,
+    S: Stream<Item = anyhow::Result<types::TxInfo>> + Unpin,
+{
+    let result = tokio::time::timeout(max_waiting_time, async {
+        let mut subscription = subscription.await?;
+
+        while let Some(tx_info) = subscription.next().await.transpose()? {
+            if tx_info.status == types::TxStatus::Processed
+                || tx_info.status == types::TxStatus::Finalized
+            {
+                tracing::info!("Rollup has processed the submitted batch!");
+                return Ok(());
+            }
+        }
+
+        anyhow::bail!(
+            "Transaction status subscription ended before the target batch was processed"
+        );
+    })
+    .await;
+
+    match result {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!(
+            "Giving up waiting for target batch to be published after {:?}",
+            max_waiting_time
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_subscription_respects_timeout() {
+        let subscription =
+            std::future::ready(Ok(stream::pending::<anyhow::Result<types::TxInfo>>()));
+
+        let task = tokio::spawn(wait_for_tx_processing_with_timeout(
+            subscription,
+            Duration::from_millis(1),
+        ));
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(1)).await;
+
+        let error = task.await.unwrap().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Giving up waiting for target batch"));
     }
 }
 


### PR DESCRIPTION
# Description

Fixes a timeout bug in `NodeClient::wait_for_tx_processing`.

The function checks the five-minute deadline only around the outer loop:

```rust
while start_wait.elapsed() < max_waiting_time {
    subscription.next().await
}
```

When the transaction-status WebSocket remains connected but produces no new status messages, subscription.next().await can remain pending indefinitely. The deadline is therefore not enforced.

The subscription setup was also outside the timeout guard.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Changes
- Wrap transaction-status subscription setup and stream consumption in tokio::time::timeout.
- Return a timeout error when no terminal transaction status is received within the configured duration.
- Handle stream termination explicitly.
- Add the required direct tokio dependency with the time feature.


## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing

cargo nextest run -p sov-node-client

cargo fmt --check

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
