### PR TITLE
feat(ledger-apis): add GET /ledger/events/by-key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11896,6 +11896,7 @@ dependencies = [
  "borsh",
  "derive_more 2.0.1",
  "futures",
+ "hex",
  "insta",
  "reqwest 0.13.3",
  "serde",

--- a/crates/full-node/sov-ledger-apis/Cargo.toml
+++ b/crates/full-node/sov-ledger-apis/Cargo.toml
@@ -18,6 +18,7 @@ axum = { workspace = true, features = ["http1", "http2", "ws", "json"] }
 borsh = { workspace = true }
 derive_more = { workspace = true, features = ["display"] }
 futures = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -32,7 +32,7 @@ use sov_rollup_interface::node::ledger_api::{
     FinalityStatus, IncludeChildren, ItemOrHash, LedgerStateProvider, QueryMode, SlotIdAndOffset,
     SlotIdentifier, SlotResponse, TxIdAndOffset, TxIdentifier, TxResponse,
 };
-use sov_rollup_interface::stf::TxReceiptContents;
+use sov_rollup_interface::stf::{EventKey, TxReceiptContents};
 use sov_shutdown::PrimaryShutdownController;
 
 type PathMap = Path<HashMap<String, NumberOrHash>>;
@@ -166,6 +166,7 @@ where
                 )),
             )
             .route("/events", get(Self::list_events))
+            .route("/events/by-key", get(Self::list_events_by_key))
             .route("/events/counts", get(Self::get_event_key_counts))
             .route("/events/latest", get(Self::get_latest_event))
             .nest(
@@ -348,6 +349,103 @@ where
             Ok(None) => Err(errors::not_found_404("Event", event_number)),
             Err(err) => Err(errors::database_error_response_500(err)),
         }
+    }
+
+    /// Events for one exact event key, oldest first.
+    ///
+    /// `EventByKey` is stored as `(EventKey, TxNumber, EventNumber)`, so an
+    /// exact key is a contiguous range: this seeks once and reads only the page
+    /// it returns. The `prefix` filter on `list_events` cannot do that — a
+    /// string prefix is not a contiguous range, because the encoded key starts
+    /// with its length — which is why that path needs a cursor bound and this
+    /// one does not.
+    ///
+    /// `page[cursor]` is an event number, exclusive: pass the `number` of the
+    /// last event you saw. Event numbers are unique and, for a fixed key, order
+    /// identically to `(TxNumber, EventNumber)`, so the cursor resolves to an
+    /// exact scan position — no rows are re-read and no transaction is split.
+    async fn list_events_by_key(
+        State(state): State<LedgerState<T>>,
+        pagination_opt: Option<Query<Pagination<String>>>,
+        Query(filter): Query<EventKeyFilter>,
+    ) -> ApiResult<EventPage<RuntimeEventResponse<E>>> {
+        let pagination = match pagination_opt {
+            Some(Query(pagination)) => pagination,
+            None => Default::default(),
+        };
+        let limit = pagination.size as usize;
+        if filter.key.is_empty() {
+            return Err(errors::bad_request_400(
+                "key must not be empty",
+                "pass the exact event key, e.g. key=Mailbox/DispatchId",
+            ));
+        }
+
+        let after =
+            match &pagination.selection {
+                PageSelection::First => None,
+                PageSelection::Last => return Err(errors::not_implemented_501()),
+                PageSelection::Next { cursor } => Some(cursor.parse::<u64>().map_err(|e| {
+                    errors::bad_request_400("page[cursor] must be an event number", e)
+                })?),
+            };
+
+        // The scan starts at a transaction boundary, so resuming needs the
+        // transaction that produced the cursor event.
+        let from_tx = match after {
+            None => 0,
+            Some(event_number) => {
+                let event = state
+                    .ledger
+                    .get_event_by_number::<RuntimeEventResponse<E>>(event_number)
+                    .await
+                    .map_err(errors::database_error_response_500)?
+                    .ok_or_else(|| errors::not_found_404("Event", event_number))?;
+                state
+                    .ledger
+                    .resolve_tx_identifier(&TxIdentifier::Hash(event.tx_hash.into()))
+                    .await
+                    .map_err(errors::database_error_response_500)?
+                    .ok_or_else(|| {
+                        errors::database_error_response_500(format!(
+                            "event {event_number} has no transaction"
+                        ))
+                    })?
+            }
+        };
+
+        // The scan can start at an exact `(key, tx, event)`, so the cursor
+        // resumes precisely rather than re-reading the transaction.
+        let resume_at = after
+            .map(|event_number| {
+                borsh::to_vec(&(
+                    EventKey::new(filter.key.as_bytes()),
+                    TxNumber(from_tx),
+                    EventNumber(event_number.saturating_add(1)),
+                ))
+                .map(hex::encode)
+            })
+            .transpose()
+            .map_err(errors::internal_server_error_response_500)?;
+
+        let page = state
+            .ledger
+            .get_events_by_key::<RuntimeEventResponse<E>>(
+                &filter.key,
+                None,
+                limit,
+                resume_at.as_deref(),
+            )
+            .await
+            .map_err(errors::database_error_response_500)?;
+
+        let events = page.events_response;
+        let next = page
+            .next
+            .and(events.last())
+            .map(|event| event.number.to_string());
+
+        Ok(EventPage { events, next }.into())
     }
 
     // TODO: we're going to want to start using range/iters
@@ -930,6 +1028,18 @@ impl ReportableWsError for WsLedgerError {
 #[derive(Deserialize)]
 struct EventFilter {
     prefix: String,
+}
+
+#[derive(Deserialize)]
+struct EventKeyFilter {
+    key: String,
+}
+
+/// A page of events plus the cursor for the following page (`None` at the end).
+#[derive(Debug, Clone, Serialize)]
+struct EventPage<E> {
+    events: Vec<E>,
+    next: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/full-node/sov-ledger-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-ledger-apis/tests/integration/main.rs
@@ -528,3 +528,79 @@ mod utils {
             .expect("Failed test; the API response can't be serialized as JSON... this is a bug")
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_by_key_paginates_by_event_number() {
+    use sov_test_utils::ledger_db::{REPEATED_EVENT_COUNT, REPEATED_EVENT_KEY};
+
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::RepeatedEventKey)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let mut seen = Vec::new();
+    let mut url = format!(
+        "http://{addr}/ledger/events/by-key?key={REPEATED_EVENT_KEY}&page=first&page[size]=10"
+    );
+    loop {
+        let page: serde_json::Value = reqwest::get(&url).await.unwrap().json().await.unwrap();
+        for event in page["events"].as_array().unwrap() {
+            assert_eq!(event["key"].as_str(), Some(REPEATED_EVENT_KEY));
+            seen.push(event["number"].as_u64().unwrap());
+        }
+        match page["next"].as_str() {
+            Some(cursor) => {
+                url = format!(
+                    "http://{addr}/ledger/events/by-key?key={REPEATED_EVENT_KEY}\
+                     &page=next&page[cursor]={cursor}&page[size]=10"
+                );
+            }
+            None => break,
+        }
+    }
+
+    // Every event exactly once, in order, with no duplicates across pages.
+    assert_eq!(seen.len() as u64, REPEATED_EVENT_COUNT);
+    let mut sorted = seen.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted, seen);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_by_key_rejects_empty_key_and_bad_cursor() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::RepeatedEventKey)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let empty = reqwest::get(format!("http://{addr}/ledger/events/by-key?key="))
+        .await
+        .unwrap();
+    assert_eq!(empty.status(), 400);
+
+    let bad_cursor = reqwest::get(format!(
+        "http://{addr}/ledger/events/by-key?key=Repeated/Event&page=next&page[cursor]=abc"
+    ))
+    .await
+    .unwrap();
+    assert_eq!(bad_cursor.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_by_key_unknown_key_is_empty() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::RepeatedEventKey)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let page: serde_json::Value =
+        reqwest::get(format!("http://{addr}/ledger/events/by-key?key=Nope/Nope"))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert!(page["events"].as_array().unwrap().is_empty());
+    assert!(page["next"].is_null());
+}

--- a/crates/utils/sov-test-utils/src/ledger_db.rs
+++ b/crates/utils/sov-test-utils/src/ledger_db.rs
@@ -245,12 +245,70 @@ fn batch3_tx_receipts() -> Vec<TransactionReceipt<TestTxReceiptContents>> {
         .collect()
 }
 
+/// Number of events stored under the same key by
+/// [`LedgerTestServiceData::RepeatedEventKey`].
+pub const REPEATED_EVENT_COUNT: u64 = 25;
+/// The key those events share.
+pub const REPEATED_EVENT_KEY: &str = "Repeated/Event";
+
 /// The different types of data that can be used to test the [`LedgerDb`].
 pub enum LedgerTestServiceData {
     /// The data used to test the [`LedgerDb`] is simple.
     Simple,
     /// The data used to test the [`LedgerDb`] is complex.
     Complex,
+    /// Many events sharing a single key, spread over several transactions, for
+    /// exercising per-key cursor pagination.
+    RepeatedEventKey,
+}
+
+/// Persist [`REPEATED_EVENT_COUNT`] events that all share
+/// [`REPEATED_EVENT_KEY`], one per transaction.
+pub fn materialize_repeated_event_key_data(ledger_db: &LedgerDb) -> anyhow::Result<SchemaBatch> {
+    let mut block = MockBlock::default();
+    block.header.time = Time::from_secs(100);
+    let mut slot: SlotCommit<MockBlock, i32, TestTxReceiptContents> =
+        SlotCommit::new(block, Vec::default());
+
+    let tx_receipts = (0..REPEATED_EVENT_COUNT)
+        .map(|i| TransactionReceipt {
+            tx_hash: TxHash::new([i as u8; 32]),
+            body_to_save: Some(FullyBakedTx::new(format!("tx{i}").into_bytes())),
+            events: vec![StoredEvent::new(
+                REPEATED_EVENT_KEY.as_bytes(),
+                &borsh::to_vec(&repeated_event(i)).unwrap(),
+                [0; 32],
+            )],
+            receipt: TxEffect::Successful(0),
+        })
+        .collect();
+
+    slot.add_batch(BatchReceipt {
+        batch_hash: [11; 32],
+        tx_receipts,
+        ignored_tx_receipts: vec![],
+        inner: 0,
+    });
+
+    ledger_db.materialize_slot(slot, b"state-root")
+}
+
+fn repeated_event(number: u64) -> TestEvent {
+    let holder = TokenHolder::Module(ModuleId::from([0; 32]));
+    let token_id =
+        TokenId::from_str("token_1rwrh8gn2py0dl4vv65twgctmlwck6esm2as9dftumcw89kqqn3nqrduss6")
+            .unwrap();
+    TestEvent::Bank(sov_bank::event::Event::TokenCreated {
+        token_name: format!("token{number}"),
+        coins: Coins {
+            amount: Amount::ZERO,
+            token_id,
+        },
+        minter: holder.clone(),
+        mint_to_address: holder.clone(),
+        admins: vec![],
+        supply_cap: Amount::MAX,
+    })
 }
 
 /// Everything that one needs to run tests against the ledger APIs.
@@ -282,6 +340,11 @@ impl LedgerTestService {
             }
             LedgerTestServiceData::Complex => {
                 materialize_and_commit_complex_ledger_db_data(&ledger_db, &mut storage_manager)?;
+            }
+            LedgerTestServiceData::RepeatedEventKey => {
+                let ledger_data = materialize_repeated_event_key_data(&ledger_db)?;
+                ledger_db.send_notifications();
+                storage_manager.commit(&ledger_data);
             }
         };
 


### PR DESCRIPTION
## Add `GET /ledger/events/by-key`

Iterating **one** event key is the query the storage layout actually supports.
`EventByKey` is stored as `(EventKey, TxNumber, EventNumber)`, so an exact key
is a contiguous range: a page costs one seek plus the rows it returns.

### Why `prefix` can't do this

Keys are encoded with their **length first**, so a string prefix is not a
contiguous range — `Mailbox/Dispatch` and `Mailbox/DispatchId` differ in the
first byte of the encoded key. `list_events?prefix=` therefore has to enumerate
every matching key and re-read from event 0 on each page, which is why it
carries `PREFIX_MAX_START` and simply cannot paginate a chain whose event
numbers exceed 10,000.

Prefixes stay as they are on purpose: all event key strings are publicly known,
so a client that wants a prefix can query each exact key and merge.

### Cursor

`page[cursor]` is an **event number**, exclusive — pass the `number` of the last
event you saw. Event numbers are unique and, for a fixed key, order identically
to `(TxNumber, EventNumber)`, so the cursor resolves to an exact scan position:

1. `get_event_by_number(cursor)` → `tx_hash` → `resolve_tx_identifier` → tx number
2. resume the scan at exactly `(key, tx, event + 1)`

Nothing is re-read and no transaction is split across pages, so a full page is
always a full page. No cursor cap and no `PAGE_SIZE_MAX` change are needed.

### Tests

`get_events_by_key`'s per-key cursor had **no** test coverage. Adds a
`RepeatedEventKey` fixture (25 events sharing one key) and three tests; the
pagination test walks every page and asserts no duplicates and no gaps — it
caught a real off-by-page bug in an earlier revision of this handler.