### PR TITLE
Fix demo-rollup README OpenAPI link

### DIFF
--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -395,7 +395,7 @@ By default, this implementation prints the state root and the number of blobs pr
 other data, you'll
 want to use our REST API server. You can configure its host and port in `rollup_config.toml`.
 
-You can get an overview of all available endpoints by reading the OpenAPI specification [here](../../crates/full-node/sov-ledger-apis/openapi-v3.yaml). Here's just a few example queries:
+You can get an overview of all available endpoints by reading the OpenAPI specification [here](../../crates/full-node/sov-api-spec/openapi-v3.yaml). Here's just a few example queries:
 
 - `http://localhost:12346/ledger/events/17`
 - `http://localhost:12346/ledger/txs/50/events/0`


### PR DESCRIPTION
# Description

Fixes the broken OpenAPI specification link in `examples/demo-rollup/README.md`.

The README points to `crates/full-node/sov-ledger-apis/openapi-v3.yaml`, which no longer exists. The current generated specification lives at `crates/full-node/sov-api-spec/openapi-v3.yaml`. This updates the relative link so readers can open the API specification referenced by the REST API section.

- [x] No changelog entry is required because this is a documentation-only correction with no behavior change.
- [x] No `Cargo.toml` files were changed.

## Linked Issues

None — no existing issue or pull request was found for this link.

## Testing

- Verified that the old relative target does not exist.
- Verified that the replacement resolves to the current OpenAPI specification.
- Verified that the specification contains the documented `/ledger/events` endpoint.
- Ran `git diff --check`.

## Docs

Documentation-only fix.